### PR TITLE
Disable vagrant for sub-processes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 option(THORIN_PROFILE "profile complexity in thorin::HashTable - only works in Debug build" ON)
 
 find_program(MEMORYCHECK_COMMAND valgrind)
-set(VALGRIND_COMMAND_OPTIONS "--leak-check=full --trace-children=yes --error-exitcode=1")
+set(VALGRIND_COMMAND_OPTIONS "--leak-check=full --trace-children=no --error-exitcode=1")
 include(CTest)
 
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")

--- a/gtest/test.cpp
+++ b/gtest/test.cpp
@@ -49,9 +49,7 @@ TEST(Main, ll) {
     // TODO make sure that proper clang is in path on Windows
     std::system("clang test.ll -o test");
     // I don't know why but for some reason the output doesn't appear on the test server.
-#if 0
     EXPECT_EQ(4, WEXITSTATUS(std::system("./test a b c")));
     EXPECT_EQ(7, WEXITSTATUS(std::system("./test a b c d e f")));
-#endif
 #endif
 }


### PR DESCRIPTION
With this the tests can can call std::system to compile the LLVM IR files using clang and execute them.