### PR TITLE
Add affine for-loop axiom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *.s
 build*
 html
+.cache

--- a/gtest/CMakeLists.txt
+++ b/gtest/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_executable(thorin-gtest
     lexer.cpp
     test.cpp
+    for_ax.cpp
 )
 
 target_link_libraries(thorin-gtest gtest_main libthorin)

--- a/gtest/for_ax.cpp
+++ b/gtest/for_ax.cpp
@@ -1,0 +1,93 @@
+#include <gtest/gtest-param-test.h>
+#include <gtest/gtest.h>
+
+#include "thorin/error.h"
+#include "thorin/world.h"
+
+#include "thorin/be/ll/ll.h"
+#include "thorin/pass/fp/beta_red.h"
+#include "thorin/pass/fp/copy_prop.h"
+#include "thorin/pass/fp/eta_red.h"
+#include "thorin/pass/fp/eta_exp.h"
+#include "thorin/pass/pass.h"
+#include "thorin/pass/rw/lower_for.h"
+
+using namespace thorin;
+
+class ForAxiomTest :
+    public testing::TestWithParam<std::tuple<int, int, int>> {
+
+};
+
+TEST_P(ForAxiomTest, for) {
+    World w;
+    auto mem_t  = w.type_mem();
+    auto i32_t  = w.type_int_width(32);
+    auto i64_t  = w.type_int_width(64);
+    auto argv_t = w.type_ptr(w.type_ptr(i32_t));
+    const auto [cstart, cstop, cstep] = GetParam();
+    auto lit_start = w.lit_int_width(32, cstart);
+    auto lit_stop = w.lit_int_width(32, cstop);
+    auto lit_step = w.lit_int_width(32, cstep);
+
+    // Cn [mem, i32, ptr(ptr(i32, 0), 0) Cn [mem, i32]]
+    auto main_t = w.cn({mem_t, i32_t, argv_t, w.cn({mem_t, i32_t})});
+    auto main   = w.nom_lam(main_t, w.dbg("main"));
+
+    {
+        auto loop = w.fn_loop({i32_t, i64_t});
+        auto accumulator_type = w.sigma({i32_t, i64_t});
+        auto cont_type        = w.cn({mem_t, accumulator_type});
+        auto body_type        = w.cn({mem_t, i32_t, accumulator_type, cont_type});
+
+        auto body = w.nom_lam(body_type, w.dbg("body"));
+        {
+            auto [mem, i, acctpl, cont] = body->vars<4>({w.dbg("mem"), w.dbg("i"), w.dbg("acctpl"), w.dbg("cont")});
+            auto add = w.op(Wrap::add, w.lit_nat(0), w.extract(acctpl, 0_s), i);
+            auto mul = w.op(Wrap::mul, w.lit_nat(0), w.extract(acctpl, 1_s), w.op(Conv::u2u, i64_t, i));
+            body->app(false, cont, {mem, w.tuple({add, mul})});
+        }
+
+        auto brk = w.nom_lam(w.cn({mem_t, accumulator_type}), w.dbg("break"));
+        {
+            auto [main_mem, argc, argv, ret] =
+                main->vars<4>({w.dbg("mem"), w.dbg("argc"), w.dbg("argv"), w.dbg("exit")});
+            auto [mem, acctpl] = brk->vars<2>();
+            brk->app(false, ret, {mem, w.extract(acctpl, 0_s)});
+            main->app(false, loop, {main_mem, lit_start, lit_stop, lit_step, w.tuple({w.lit_int(0), w.lit_int(i64_t, 5)}), body, brk});
+        }
+    }
+
+    main->make_external();
+
+    PassMan man{w};
+    man.add<LowerFor>();
+    man.run();
+
+    PassMan opt{w};
+    auto br = opt.add<BetaRed>();
+    auto er = opt.add<EtaRed>();
+    auto ee = opt.add<EtaExp>(er);
+    opt.add<CopyProp>(br, ee);
+    opt.run();
+
+    std::ofstream file("test.ll");
+    Stream s(file);
+    ll::emit(w, s);
+    file.close();
+    
+    // TODO make sure that proper clang is in path on Windows
+#ifndef _MSC_VER
+    unsigned gt = 0;
+    for(int i = cstart; i < cstop; i += cstep) {
+        gt += i;
+    }
+
+    EXPECT_EQ(0, WEXITSTATUS(std::system("clang test.ll -o `pwd`/test")));
+    EXPECT_EQ(gt % 255, WEXITSTATUS(std::system("./test")));
+#endif
+}
+
+// test with these start, stop, step combinations:
+INSTANTIATE_TEST_SUITE_P(ForSteps, ForAxiomTest, testing::Combine(testing::Values(0, 2), testing::Values(0, 4, 8), testing::Values(1, 2, 5)));
+

--- a/gtest/for_ax.cpp
+++ b/gtest/for_ax.cpp
@@ -7,8 +7,8 @@
 #include "thorin/be/ll/ll.h"
 #include "thorin/pass/fp/beta_red.h"
 #include "thorin/pass/fp/copy_prop.h"
-#include "thorin/pass/fp/eta_red.h"
 #include "thorin/pass/fp/eta_exp.h"
+#include "thorin/pass/fp/eta_red.h"
 #include "thorin/pass/pass.h"
 #include "thorin/pass/rw/lower_for.h"
 
@@ -22,10 +22,12 @@ TEST_P(ForAxiomTest, for) {
     auto i32_t  = w.type_int_width(32);
     auto i64_t  = w.type_int_width(64);
     auto argv_t = w.type_ptr(w.type_ptr(i32_t));
-    const auto [cstart, cstop, cstep] = GetParam();
-    auto lit_start = w.lit_int_width(32, cstart);
-    auto lit_stop = w.lit_int_width(32, cstop);
-    auto lit_step = w.lit_int_width(32, cstep);
+
+    const auto [cbegin, cend, cstep] = GetParam();
+
+    auto lit_begin = w.lit_int_width(32, cbegin);
+    auto lit_end   = w.lit_int_width(32, cend);
+    auto lit_step  = w.lit_int_width(32, cstep);
 
     // Cn [mem, i32, ptr(ptr(i32, 0), 0) Cn [mem, i32]]
     auto main_t = w.cn({mem_t, i32_t, argv_t, w.cn({mem_t, i32_t})});
@@ -33,15 +35,15 @@ TEST_P(ForAxiomTest, for) {
 
     {
         auto accumulator_type = w.sigma({i32_t, i64_t});
-        auto cont_type        = w.cn({mem_t, accumulator_type});
-        auto body_type        = w.cn({mem_t, i32_t, accumulator_type, cont_type});
+        auto yield_type       = w.cn({mem_t, accumulator_type});
+        auto body_type        = w.cn({mem_t, i32_t, accumulator_type, yield_type});
 
         auto body = w.nom_lam(body_type, w.dbg("body"));
         {
-            auto [mem, i, acctpl, cont] = body->vars<4>({w.dbg("mem"), w.dbg("i"), w.dbg("acctpl"), w.dbg("cont")});
-            auto add = w.op(Wrap::add, w.lit_nat(0), w.extract(acctpl, 0_s), i);
+            auto [mem, i, acctpl, yield] = body->vars<4>({w.dbg("mem"), w.dbg("i"), w.dbg("acctpl"), w.dbg("yield")});
+            auto add                     = w.op(Wrap::add, w.lit_nat(0), w.extract(acctpl, 0_s), i);
             auto mul = w.op(Wrap::mul, w.lit_nat(0), w.extract(acctpl, 1_s), w.op(Conv::u2u, i64_t, i));
-            body->app(false, cont, {mem, w.tuple({add, mul})});
+            body->app(false, yield, {mem, w.tuple({add, mul})});
         }
 
         auto brk = w.nom_lam(w.cn({mem_t, accumulator_type}), w.dbg("break"));
@@ -51,7 +53,8 @@ TEST_P(ForAxiomTest, for) {
             auto [mem, acctpl] = brk->vars<2>();
             brk->app(false, ret, {mem, w.extract(acctpl, 0_s)});
             main->set_filter(false);
-            main->set_body(w.op_for({i32_t, i64_t}, main_mem, lit_start, lit_stop, lit_step, {w.lit_int(0), w.lit_int(i64_t, 5)}, body, brk));
+            main->set_body(w.op_for({i32_t, i64_t}, main_mem, lit_begin, lit_end, lit_step,
+                                    {w.lit_int(0), w.lit_int(i64_t, 5)}, body, brk));
         }
     }
 
@@ -76,15 +79,14 @@ TEST_P(ForAxiomTest, for) {
     // TODO make sure that proper clang is in path on Windows
 #ifndef _MSC_VER
     unsigned gt = 0;
-    for(int i = cstart; i < cstop; i += cstep) {
-        gt += i;
-    }
+    for (int i = cbegin; i < cend; i += cstep) { gt += i; }
 
     EXPECT_EQ(0, WEXITSTATUS(std::system("clang test.ll -o `pwd`/test")));
     EXPECT_EQ(gt % 255, WEXITSTATUS(std::system("./test")));
 #endif
 }
 
-// test with these start, stop, step combinations:
-INSTANTIATE_TEST_SUITE_P(ForSteps, ForAxiomTest, testing::Combine(testing::Values(0, 2), testing::Values(0, 4, 8), testing::Values(1, 2, 5)));
-
+// test with these begin, end, step combinations:
+INSTANTIATE_TEST_SUITE_P(ForSteps,
+                         ForAxiomTest,
+                         testing::Combine(testing::Values(0, 2), testing::Values(0, 4, 8), testing::Values(1, 2, 5)));

--- a/gtest/for_ax.cpp
+++ b/gtest/for_ax.cpp
@@ -35,7 +35,6 @@ TEST_P(ForAxiomTest, for) {
     auto main   = w.nom_lam(main_t, w.dbg("main"));
 
     {
-        auto loop = w.fn_loop({i32_t, i64_t});
         auto accumulator_type = w.sigma({i32_t, i64_t});
         auto cont_type        = w.cn({mem_t, accumulator_type});
         auto body_type        = w.cn({mem_t, i32_t, accumulator_type, cont_type});
@@ -54,7 +53,8 @@ TEST_P(ForAxiomTest, for) {
                 main->vars<4>({w.dbg("mem"), w.dbg("argc"), w.dbg("argv"), w.dbg("exit")});
             auto [mem, acctpl] = brk->vars<2>();
             brk->app(false, ret, {mem, w.extract(acctpl, 0_s)});
-            main->app(false, loop, {main_mem, lit_start, lit_stop, lit_step, w.tuple({w.lit_int(0), w.lit_int(i64_t, 5)}), body, brk});
+            main->set_filter(false);
+            main->set_body(w.op_for({i32_t, i64_t}, main_mem, lit_start, lit_stop, lit_step, {w.lit_int(0), w.lit_int(i64_t, 5)}, body, brk));
         }
     }
 

--- a/gtest/for_ax.cpp
+++ b/gtest/for_ax.cpp
@@ -14,10 +14,7 @@
 
 using namespace thorin;
 
-class ForAxiomTest :
-    public testing::TestWithParam<std::tuple<int, int, int>> {
-
-};
+class ForAxiomTest : public testing::TestWithParam<std::tuple<int, int, int>> {};
 
 TEST_P(ForAxiomTest, for) {
     World w;
@@ -75,7 +72,7 @@ TEST_P(ForAxiomTest, for) {
     Stream s(file);
     ll::emit(w, s);
     file.close();
-    
+
     // TODO make sure that proper clang is in path on Windows
 #ifndef _MSC_VER
     unsigned gt = 0;

--- a/gtest/test.cpp
+++ b/gtest/test.cpp
@@ -78,3 +78,101 @@ TEST(Axiom, mangle) {
     EXPECT_EQ(Axiom::demangle(*Axiom::mangle("test") | 0xFF_u64), "test");
     EXPECT_EQ(Axiom::demangle(*Axiom::mangle("01234567") | 0xFF_u64), "01234567");
 }
+
+TEST(Main, sec) {
+    World w;
+    auto mem_t  = w.type_mem();
+    auto i32_t  = w.type_int_width(32);
+    auto argv_t = w.type_ptr(w.type_ptr(i32_t));
+    auto i32_w  = w.lit_nat(width2mod(32));
+    auto l32    = w.lit_int(32);
+
+    // Cn [mem, i32, i32**, Cn [mem, i32]]
+    auto main_t                 = w.cn({mem_t, i32_t, argv_t, w.cn({mem_t, i32_t}, w.dbg("return"))});
+    auto main                   = w.nom_lam(main_t, w.dbg("main"));
+    auto [mem, argc, argv, ret] = main->vars<4>();
+
+    auto body_t = w.cn(mem_t);
+
+    auto lt     = w.fn(ICmp::ul, i32_w);
+    auto loop_t = w.cn({mem_t, i32_t, i32_t});
+    auto loop   = w.nom_lam(loop_t, w.dbg("loop"));
+
+    auto body = w.nom_lam(body_t, w.dbg("body"));
+    auto exit = w.nom_lam(body_t, w.dbg("exit"));
+
+    {
+        auto [lMem, iterVar, accumulator] = loop->vars<3>();
+        loop->app(false, w.select(body, exit, w.app(lt, {iterVar, l32})), lMem);
+    }
+
+    auto add = w.fn(Wrap::add, w.lit_nat(0), i32_w);
+    {
+        auto [lMem, iterVar, accumulator] = loop->vars<3>();
+
+        auto accumAdd = w.app(add, {iterVar, accumulator});
+        auto iterInc  = w.app(add, {iterVar, w.lit_int(1)});
+        body->app(false, loop, {lMem, iterInc, accumAdd});
+    }
+    {
+        auto [lMem, iterVar, accumulator] = loop->vars<3>();
+        exit->app(false, main->var(3), {main->var(0, nullptr), accumulator});
+    }
+
+    main->app(false, loop, {mem, w.lit_int(0), w.lit_int(0)});
+    main->make_external();
+
+    std::ofstream file("test.ll");
+    Stream s(file);
+    thorin::ll::emit(w, s);
+    file.close();
+
+    // TODO make sure that proper clang is in path on Windows
+#ifndef _MSC_VER
+    std::system("clang test.ll -o `pwd`/test");
+    EXPECT_EQ(240, WEXITSTATUS(std::system("./test a b c")));
+#endif
+}
+
+TEST(Main, loop) {
+    World w;
+    auto mem_t  = w.type_mem();
+    auto i32_t  = w.type_int_width(32);
+    auto i64_t  = w.type_int_width(64);
+    auto argv_t = w.type_ptr(w.type_ptr(i32_t));
+
+    // Cn [mem, i32, ptr(ptr(i32, 0), 0) Cn [mem, i32]]
+    auto main_t = w.cn({mem_t, i32_t, argv_t, w.cn({mem_t, i32_t})});
+    auto main   = w.nom_lam(main_t, w.dbg("main"));
+
+    {
+        auto loop = w.fn_loop({i32_t, i64_t});
+        auto accumulator_type = w.sigma({i32_t, i64_t});
+        auto cont_type        = w.cn({mem_t, accumulator_type});
+        auto body_type        = w.cn({mem_t, i32_t, accumulator_type, cont_type});
+
+        auto body = w.nom_lam(body_type, w.dbg("body"));
+        {
+            auto [mem, i, acctpl, cont] = body->vars<4>({w.dbg("mem"), w.dbg("i"), w.dbg("acctpl"), w.dbg("cont")});
+            auto add = w.op(Wrap::add, w.lit_nat(0), w.extract(acctpl, 0_s), i);
+            auto mul = w.op(Wrap::mul, w.lit_nat(0), w.extract(acctpl, 1_s), w.op_bitcast(i64_t, i));
+            body->app(false, cont, {mem, w.tuple({add, mul})});
+        }
+
+        auto brk = w.nom_lam(w.cn({mem_t, accumulator_type}), w.dbg("break"));
+        {
+            auto [main_mem, argc, argv, ret] =
+                main->vars<4>({w.dbg("mem"), w.dbg("argc"), w.dbg("argv"), w.dbg("exit")});
+            auto [mem, acctpl] = brk->vars<2>();
+            brk->app(false, ret, {mem, w.extract(acctpl, 0_s)});
+            main->app(false, loop, {main_mem, w.lit_int(0), argc, w.lit_int(1), w.tuple({w.lit_int(0), w.lit_int(i64_t, 5)}), body, brk});
+        }
+    }
+
+    main->make_external();
+
+    std::ofstream file("test.ll");
+    Stream s(file);
+    ll::emit(w, s);
+    file.close();
+}

--- a/gtest/test.cpp
+++ b/gtest/test.cpp
@@ -62,7 +62,7 @@ TEST(Main, ll) {
 
 #ifndef _MSC_VER
     // TODO make sure that proper clang is in path on Windows
-    std::system("clang test.ll -o test");
+    std::system("clang test.ll -o test -Wno-override-module");
     EXPECT_EQ(4, WEXITSTATUS(std::system("./test a b c")));
     EXPECT_EQ(7, WEXITSTATUS(std::system("./test a b c d e f")));
 #endif
@@ -128,7 +128,7 @@ TEST(Main, loop) {
 
     // TODO make sure that proper clang is in path on Windows
 #ifndef _MSC_VER
-    EXPECT_EQ(0, WEXITSTATUS(std::system("clang test.ll -o `pwd`/test")));
+    EXPECT_EQ(0, WEXITSTATUS(std::system("clang test.ll -o `pwd`/test -Wno-override-module")));
     EXPECT_EQ(6, WEXITSTATUS(std::system("./test a b c")));
     EXPECT_EQ(10, WEXITSTATUS(std::system("./test a b c d")));
 #endif

--- a/src/thorin/CMakeLists.txt
+++ b/src/thorin/CMakeLists.txt
@@ -64,6 +64,8 @@ add_library(libthorin
     pass/rw/alloc2malloc.h
     pass/rw/partial_eval.cpp
     pass/rw/partial_eval.h
+    pass/rw/lower_for.cpp
+    pass/rw/lower_for.h
     pass/rw/remem_elim.cpp
     pass/rw/remem_elim.h
     pass/rw/ret_wrap.cpp

--- a/src/thorin/be/ll/ll.cpp
+++ b/src/thorin/be/ll/ll.cpp
@@ -156,7 +156,8 @@ std::string CodeGen::convert(const Def* type) {
         s.fmt("{} (", convert(pi->doms().back()->as<Pi>()->dom()));
 
         std::string_view sep = "";
-        for (auto dom : pi->doms().skip_back()) {
+        auto doms = pi->doms();
+        for (auto dom : doms.skip_back()) {
             if (isa<Tag::Mem>(dom)) continue;
             s << sep << convert(dom);
             sep = ", ";

--- a/src/thorin/pass/rw/lower_for.cpp
+++ b/src/thorin/pass/rw/lower_for.cpp
@@ -1,7 +1,6 @@
 #include "thorin/pass/rw/lower_for.h"
 
 #include "thorin/lam.h"
-#include "thorin/tables.h"
 
 namespace thorin {
 
@@ -10,7 +9,7 @@ const Def* LowerFor::rewrite(const Def* def) {
         if (auto for_ax = app->axiom(); for_ax && for_ax->tag() == Tag::For) {
             auto& w = def->world();
             w.DLOG("rewriting for axiom: {} within {}", app, curr_nom());
-            
+
             auto for_pi  = app->callee_type();
             auto for_lam = w.nom_lam(for_pi, w.dbg("for"));
 

--- a/src/thorin/pass/rw/lower_for.cpp
+++ b/src/thorin/pass/rw/lower_for.cpp
@@ -39,7 +39,7 @@ const Def* LowerFor::rewrite(const Def* def) {
             auto if_else    = w.nom_lam(if_else_cn, nullptr);
             if_else->app(false, brk, {if_else->mem_var(w.dbg("mem")), acc});
 
-            auto cmp = w.op(ICmp::sl, iter, stop);
+            auto cmp = w.op(ICmp::ul, iter, stop);
             for_lam->branch(false, cmp, if_then, if_else, mem);
         }
 

--- a/src/thorin/pass/rw/lower_for.cpp
+++ b/src/thorin/pass/rw/lower_for.cpp
@@ -5,48 +5,46 @@
 namespace thorin {
 
 const Def* LowerFor::rewrite(const Def* def) {
-    if (auto app = def->isa<App>())
-        if (auto for_ax = app->axiom(); for_ax && for_ax->tag() == Tag::For) {
-            auto& w = def->world();
-            w.DLOG("rewriting for axiom: {} within {}", app, curr_nom());
+    if (auto for_ax = isa<Tag::For>(def)) {
+        auto& w = world();
+        w.DLOG("rewriting for axiom: {} within {}", for_ax, curr_nom());
 
-            auto for_pi  = app->callee_type();
-            auto for_lam = w.nom_lam(for_pi, w.dbg("for"));
+        auto for_pi  = for_ax->callee_type();
+        auto for_lam = w.nom_lam(for_pi, w.dbg("for"));
 
-            auto body      = app->args()[app->num_args() - 2];
-            auto body_type = body->type()->as<Pi>();
-            auto cont_pi   = body_type->dom(body_type->num_doms() - 1)->as<Pi>();
-            auto cont_lam  = w.nom_lam(cont_pi, w.dbg("continue"));
+        auto org_body  = for_ax->arg(for_ax->num_args() - 2);
+        auto body_type = org_body->type()->as<Pi>();
+        auto cont_pi   = body_type->doms().back()->as<Pi>();
+        auto cont_lam  = w.nom_lam(cont_pi, w.dbg("continue"));
 
-            { // construct cont
-                auto [mem, iter, stop, step, acc, body, brk] =
-                    for_lam->vars<7>({w.dbg("mem"), w.dbg("start"), w.dbg("stop"), w.dbg("step"), w.dbg("acc"),
-                                      w.dbg("body"), w.dbg("break")});
-                auto [cont_mem, cont_acc] = cont_lam->vars<2>();
+        { // construct cont
+            auto [mem, iter, stop, step, acc, body, brk] =
+                for_lam->vars<7>({w.dbg("mem"), w.dbg("start"), w.dbg("stop"), w.dbg("step"), w.dbg("acc"),
+                                  w.dbg("body"), w.dbg("break")});
+            auto [cont_mem, cont_acc] = cont_lam->vars<2>();
 
-                auto add = w.op(Wrap::add, w.lit_nat_0(), iter, step);
-                cont_lam->app(false, for_lam, {cont_mem, add, stop, step, cont_acc, body, brk});
-            }
-            { // construct for
-                auto [mem, iter, stop, step, acc, body, brk] = for_lam->vars<7>();
-
-                // continue
-                auto if_then_cn = w.cn(w.type_mem());
-                auto if_then    = w.nom_lam(if_then_cn, nullptr);
-                if_then->app(false, body, {if_then->mem_var(w.dbg("mem")), iter, acc, cont_lam});
-
-                // break
-                auto if_else_cn = w.cn(w.type_mem());
-                auto if_else    = w.nom_lam(if_else_cn, nullptr);
-                if_else->app(false, brk, {if_else->mem_var(w.dbg("mem")), acc});
-
-                auto cmp    = w.op(ICmp::sl, iter, stop);
-                auto select = w.select(if_then, if_else, cmp);
-                for_lam->app(false, select, mem);
-            }
-
-            return app->rebuild(w, nullptr, {for_lam, app->op(1)}, app->dbg());
+            auto add = w.op(Wrap::add, w.lit_nat_0(), iter, step);
+            cont_lam->app(false, for_lam, {cont_mem, add, stop, step, cont_acc, body, brk});
         }
+        { // construct for
+            auto [mem, iter, stop, step, acc, body, brk] = for_lam->vars<7>();
+
+            // continue
+            auto if_then_cn = w.cn(w.type_mem());
+            auto if_then    = w.nom_lam(if_then_cn, nullptr);
+            if_then->app(false, body, {if_then->mem_var(w.dbg("mem")), iter, acc, cont_lam});
+
+            // break
+            auto if_else_cn = w.cn(w.type_mem());
+            auto if_else    = w.nom_lam(if_else_cn, nullptr);
+            if_else->app(false, brk, {if_else->mem_var(w.dbg("mem")), acc});
+
+            auto cmp = w.op(ICmp::sl, iter, stop);
+            for_lam->branch(false, cmp, if_then, if_else, mem);
+        }
+
+        return w.app(for_lam, for_ax->arg(), for_ax->dbg());
+    }
 
     return def;
 }

--- a/src/thorin/pass/rw/lower_for.cpp
+++ b/src/thorin/pass/rw/lower_for.cpp
@@ -14,32 +14,32 @@ const Def* LowerFor::rewrite(const Def* def) {
 
         auto org_body  = for_ax->arg(for_ax->num_args() - 2);
         auto body_type = org_body->type()->as<Pi>();
-        auto cont_pi   = body_type->doms().back()->as<Pi>();
-        auto cont_lam  = w.nom_lam(cont_pi, w.dbg("continue"));
+        auto yield_pi  = body_type->doms().back()->as<Pi>();
+        auto yield_lam = w.nom_lam(yield_pi, w.dbg("yield"));
 
-        { // construct cont
-            auto [mem, iter, stop, step, acc, body, brk] =
-                for_lam->vars<7>({w.dbg("mem"), w.dbg("start"), w.dbg("stop"), w.dbg("step"), w.dbg("acc"),
+        { // construct yield
+            auto [mem, iter, end, step, acc, body, brk] =
+                for_lam->vars<7>({w.dbg("mem"), w.dbg("begin"), w.dbg("end"), w.dbg("step"), w.dbg("acc"),
                                   w.dbg("body"), w.dbg("break")});
-            auto [cont_mem, cont_acc] = cont_lam->vars<2>();
+            auto [yield_mem, yield_acc] = yield_lam->vars<2>();
 
             auto add = w.op(Wrap::add, w.lit_nat_0(), iter, step);
-            cont_lam->app(false, for_lam, {cont_mem, add, stop, step, cont_acc, body, brk});
+            yield_lam->app(false, for_lam, {yield_mem, add, end, step, yield_acc, body, brk});
         }
         { // construct for
-            auto [mem, iter, stop, step, acc, body, brk] = for_lam->vars<7>();
+            auto [mem, iter, end, step, acc, body, brk] = for_lam->vars<7>();
 
             // continue
             auto if_then_cn = w.cn(w.type_mem());
             auto if_then    = w.nom_lam(if_then_cn, nullptr);
-            if_then->app(false, body, {if_then->mem_var(w.dbg("mem")), iter, acc, cont_lam});
+            if_then->app(false, body, {if_then->mem_var(w.dbg("mem")), iter, acc, yield_lam});
 
             // break
             auto if_else_cn = w.cn(w.type_mem());
             auto if_else    = w.nom_lam(if_else_cn, nullptr);
             if_else->app(false, brk, {if_else->mem_var(w.dbg("mem")), acc});
 
-            auto cmp = w.op(ICmp::ul, iter, stop);
+            auto cmp = w.op(ICmp::ul, iter, end);
             for_lam->branch(false, cmp, if_then, if_else, mem);
         }
 

--- a/src/thorin/pass/rw/lower_for.cpp
+++ b/src/thorin/pass/rw/lower_for.cpp
@@ -1,0 +1,55 @@
+#include "thorin/pass/rw/lower_for.h"
+
+#include "thorin/lam.h"
+#include "thorin/tables.h"
+
+namespace thorin {
+
+const Def* LowerFor::rewrite(const Def* def) {
+    if (auto app = def->isa<App>())
+        if (auto for_ax = app->axiom(); for_ax && for_ax->tag() == Tag::For) {
+            auto& w = def->world();
+            w.DLOG("rewriting for axiom: {} within {}", app, curr_nom());
+            
+            auto for_pi  = app->callee_type();
+            auto for_lam = w.nom_lam(for_pi, w.dbg("for"));
+
+            auto body      = app->args()[app->num_args() - 2];
+            auto body_type = body->type()->as<Pi>();
+            auto cont_pi   = body_type->dom(body_type->num_doms() - 1)->as<Pi>();
+            auto cont_lam  = w.nom_lam(cont_pi, w.dbg("continue"));
+
+            { // construct cont
+                auto [mem, iter, stop, step, acc, body, brk] =
+                    for_lam->vars<7>({w.dbg("mem"), w.dbg("start"), w.dbg("stop"), w.dbg("step"), w.dbg("acc"),
+                                      w.dbg("body"), w.dbg("break")});
+                auto [cont_mem, cont_acc] = cont_lam->vars<2>();
+
+                auto add = w.op(Wrap::add, w.lit_nat_0(), iter, step);
+                cont_lam->app(false, for_lam, {cont_mem, add, stop, step, cont_acc, body, brk});
+            }
+            { // construct for
+                auto [mem, iter, stop, step, acc, body, brk] = for_lam->vars<7>();
+
+                // continue
+                auto if_then_cn = w.cn(w.type_mem());
+                auto if_then    = w.nom_lam(if_then_cn, nullptr);
+                if_then->app(false, body, {if_then->mem_var(w.dbg("mem")), iter, acc, cont_lam});
+
+                // break
+                auto if_else_cn = w.cn(w.type_mem());
+                auto if_else    = w.nom_lam(if_else_cn, nullptr);
+                if_else->app(false, brk, {if_else->mem_var(w.dbg("mem")), acc});
+
+                auto cmp    = w.op(ICmp::sl, iter, stop);
+                auto select = w.select(if_then, if_else, cmp);
+                for_lam->app(false, select, mem);
+            }
+
+            return app->rebuild(w, nullptr, {for_lam, app->op(1)}, app->dbg());
+        }
+
+    return def;
+}
+
+} // namespace thorin

--- a/src/thorin/pass/rw/lower_for.h
+++ b/src/thorin/pass/rw/lower_for.h
@@ -6,6 +6,8 @@
 namespace thorin {
 
 /// Lowers the for axiom to actual control flow in CPS style
+/// Requires CopyProp to cleanup afterwards.
+/// Should run in a dedicated lowering phase.
 class LowerFor : public RWPass<Lam> {
 public:
     LowerFor(PassMan& man)

--- a/src/thorin/pass/rw/lower_for.h
+++ b/src/thorin/pass/rw/lower_for.h
@@ -1,0 +1,22 @@
+#ifndef THORIN_PASS_RW_LOWER_FOR_H
+#define THORIN_PASS_RW_LOWER_FOR_H
+
+#include "thorin/pass/pass.h"
+
+namespace thorin {
+
+
+/// Lowers the for axiom to actual control flow in CPS style
+class LowerFor : public RWPass<Lam> {
+public:
+    LowerFor(PassMan& man)
+        : RWPass(man, "lower_affine_for") {}
+
+    const Def* rewrite(const Def*) override;
+
+private:
+};
+
+}
+
+#endif

--- a/src/thorin/pass/rw/lower_for.h
+++ b/src/thorin/pass/rw/lower_for.h
@@ -5,7 +5,6 @@
 
 namespace thorin {
 
-
 /// Lowers the for axiom to actual control flow in CPS style
 class LowerFor : public RWPass<Lam> {
 public:
@@ -13,8 +12,6 @@ public:
         : RWPass(man, "lower_affine_for") {}
 
     const Def* rewrite(const Def*) override;
-
-private:
 };
 
 }

--- a/src/thorin/tables.h
+++ b/src/thorin/tables.h
@@ -38,7 +38,7 @@ using nat_t    = u64;
     m(Alloc, alloc) m(Slot, slot) m(Malloc, malloc) m(Mslot, mslot) \
     m(Load, load) m(Remem, remem) m(Store, store)                   \
     m(Atomic, atomic)                                               \
-    m(Zip, zip)                                                     \
+    m(Zip, zip) m(For, affine_for)                                  \
     m(RevDiff, rev_diff) m(TangentVector, tangent_vector)
 
 namespace WMode {

--- a/src/thorin/world.cpp
+++ b/src/thorin/world.cpp
@@ -607,7 +607,7 @@ const Def* World::test(const Def* value, const Def* probe, const Def* match, con
     return unify<Test>(4, pi(c_pi->dom(), codom), value, probe, match, clash, dbg);
 }
 
-const Def* World::fn_loop(Defs params) {
+const Def* World::fn_for(Defs params) {
     return app(ax_for(), {lit_nat(width2mod(32)), lit_nat(params.size()), tuple(params)});
 }
 
@@ -636,6 +636,10 @@ const Def* World::op_malloc(const Def* type, const Def* mem, const Def* dbg /*= 
 const Def* World::op_mslot(const Def* type, const Def* mem, const Def* id, const Def* dbg /*= {}*/) {
     auto size = op(Trait::size, type);
     return app(app(ax_mslot(), {type, lit_nat_0()}), {mem, size, id}, dbg);
+}
+
+const Def* World::op_for(Defs accumulatorTypes, const Def* mem, const Def* start, const Def* stop, const Def* step, Defs initAcc, const Def* body, const Def* brk) {
+    return app(fn_for(accumulatorTypes), {mem, start, stop, step, tuple(initAcc), body, brk});
 }
 
 /*

--- a/src/thorin/world.h
+++ b/src/thorin/world.h
@@ -615,7 +615,7 @@ private:
         assert(!def->isa_nom());
         auto [i, inserted] = data_.defs_.emplace(def);
         if (inserted) {
-#ifndef NDEBUG
+#if THORIN_ENABLE_CHECKS
             if (state_.breakpoints.contains(def->gid())) thorin::breakpoint();
             for (auto op : def->ops()) {
                 if (state_.use_breakpoints.contains(op->gid())) thorin::breakpoint();
@@ -632,7 +632,7 @@ private:
     template<class T, class... Args>
     T* insert(size_t num_ops, Args&&... args) {
         auto def = arena_.allocate<T>(num_ops, std::forward<Args&&>(args)...);
-#ifndef NDEBUG
+#if THORIN_ENABLE_CHECKS
         if (state_.breakpoints.contains(def->gid())) thorin::breakpoint();
 #endif
         auto p = data_.defs_.emplace(def);

--- a/src/thorin/world.h
+++ b/src/thorin/world.h
@@ -411,7 +411,7 @@ public:
     const Def* fn_bitcast(const Def* dst_t, const Def* src_t, const Def* dbg = {}) {
         return app(ax_bitcast(), {dst_t, src_t}, dbg);
     }
-    const Def* fn_loop(Defs params);
+    const Def* fn_for(Defs params);
     ///@}
 
     /// @name op - these guys build the final function application for the various operations
@@ -472,6 +472,7 @@ public:
     }
     const Def* op_malloc(const Def* type, const Def* mem, const Def* dbg = {});
     const Def* op_mslot(const Def* type, const Def* mem, const Def* id, const Def* dbg = {});
+    const Def* op_for(Defs paramTypes, const Def* mem, const Def* start, const Def* stop, const Def* step, Defs initAcc, const Def* body, const Def* brk);
     ///@}
 
     /// @name wrappers for unary operations

--- a/src/thorin/world.h
+++ b/src/thorin/world.h
@@ -373,6 +373,7 @@ public:
     const Axiom* ax_malloc()  const { return data_.malloc_;  }
     const Axiom* ax_mslot()   const { return data_.mslot_;   }
     const Axiom* ax_zip()     const { return data_.zip_;     }
+    const Axiom* ax_for()    const { return data_.for_;    }
     const Axiom* ax_load()    const { return data_.load_;    }
     const Axiom* ax_remem()   const { return data_.remem_;   }
     const Axiom* ax_slot()    const { return data_.slot_;    }
@@ -410,6 +411,7 @@ public:
     const Def* fn_bitcast(const Def* dst_t, const Def* src_t, const Def* dbg = {}) {
         return app(ax_bitcast(), {dst_t, src_t}, dbg);
     }
+    const Def* fn_loop(Defs params);
     ///@}
 
     /// @name op - these guys build the final function application for the various operations
@@ -765,6 +767,7 @@ private:
         const Axiom* type_ptr_;
         const Axiom* type_real_;
         const Axiom* zip_;
+        const Axiom* for_;
         std::string name_;
         Externals externals_;
         Sea defs_;

--- a/src/thorin/world.h
+++ b/src/thorin/world.h
@@ -373,7 +373,7 @@ public:
     const Axiom* ax_malloc()  const { return data_.malloc_;  }
     const Axiom* ax_mslot()   const { return data_.mslot_;   }
     const Axiom* ax_zip()     const { return data_.zip_;     }
-    const Axiom* ax_for()    const { return data_.for_;    }
+    const Axiom* ax_for()     const { return data_.for_;     }
     const Axiom* ax_load()    const { return data_.load_;    }
     const Axiom* ax_remem()   const { return data_.remem_;   }
     const Axiom* ax_slot()    const { return data_.slot_;    }
@@ -472,7 +472,9 @@ public:
     }
     const Def* op_malloc(const Def* type, const Def* mem, const Def* dbg = {});
     const Def* op_mslot(const Def* type, const Def* mem, const Def* id, const Def* dbg = {});
+    // clang-format off
     const Def* op_for(Defs paramTypes, const Def* mem, const Def* start, const Def* stop, const Def* step, Defs initAcc, const Def* body, const Def* brk);
+    // clang-format on
     ///@}
 
     /// @name wrappers for unary operations


### PR DESCRIPTION
This adds a `For` axiom including a `LowerFor` rewrite pass that lowers the axiom to a CPS loop.
The axiom is defined following this scheme:
` for :: [m: Nat , n: Nat , Ts: «n; *»] → [Mem , Int m, Int m, Int m, «i: n; Is#i», Cn [Mem , «i: n; Is#i», Cn [Mem , «i: n; Is#i»]], Cn [Mem , «i: n; Is#i»]];`

Note, that due to 1. the design of the return cn (doesn't have a continuation itself) and 2. some _unexpected_ indirection, the LL backend currently requires all passes including `CopyProp` to run in an optimization phase after the lowering. Otherwise, assertion failures/crashes occur.

Happy about any feedback!