### PR TITLE
LowerFor should cache the rewritten axioms.

### DIFF
--- a/gtest/for_ax.cpp
+++ b/gtest/for_ax.cpp
@@ -62,11 +62,8 @@ TEST_P(ForAxiomTest, for) {
 
     main->make_external();
 
-    PassMan man{w};
-    man.add<LowerFor>();
-    man.run();
-
     PassMan opt{w};
+    opt.add<LowerFor>();
     auto br = opt.add<BetaRed>();
     auto er = opt.add<EtaRed>();
     auto ee = opt.add<EtaExp>(er);
@@ -160,11 +157,8 @@ TEST_P(ForAxiomTest, for_dynamic_iters) {
 
     main->make_external();
 
-    PassMan man{w};
-    man.add<LowerFor>();
-    man.run();
-
     PassMan opt{w};
+    opt.add<LowerFor>();
     auto br = opt.add<BetaRed>();
     auto er = opt.add<EtaRed>();
     auto ee = opt.add<EtaExp>(er);

--- a/src/thorin/pass/rw/lower_for.cpp
+++ b/src/thorin/pass/rw/lower_for.cpp
@@ -5,6 +5,8 @@
 namespace thorin {
 
 const Def* LowerFor::rewrite(const Def* def) {
+    if (auto rewrote = rewritten_.lookup(def)) return rewrote.value();
+
     if (auto for_ax = isa<Tag::For>(def)) {
         auto& w = world();
         w.DLOG("rewriting for axiom: {} within {}", for_ax, curr_nom());
@@ -43,7 +45,7 @@ const Def* LowerFor::rewrite(const Def* def) {
             for_lam->branch(false, cmp, if_then, if_else, mem);
         }
 
-        return w.app(for_lam, for_ax->arg(), for_ax->dbg());
+        return rewritten_[def] = w.app(for_lam, for_ax->arg(), for_ax->dbg());
     }
 
     return def;

--- a/src/thorin/pass/rw/lower_for.h
+++ b/src/thorin/pass/rw/lower_for.h
@@ -1,21 +1,25 @@
 #ifndef THORIN_PASS_RW_LOWER_FOR_H
 #define THORIN_PASS_RW_LOWER_FOR_H
 
+#include "thorin/def.h"
+
 #include "thorin/pass/pass.h"
 
 namespace thorin {
 
 /// Lowers the for axiom to actual control flow in CPS style
 /// Requires CopyProp to cleanup afterwards.
-/// Should run in a dedicated lowering phase.
 class LowerFor : public RWPass<Lam> {
 public:
     LowerFor(PassMan& man)
         : RWPass(man, "lower_affine_for") {}
 
     const Def* rewrite(const Def*) override;
+
+private:
+    Def2Def rewritten_;
 };
 
-}
+} // namespace thorin
 
 #endif


### PR DESCRIPTION
With this in place, LowerFor can be used in the same PM as CopyProp.