### PR TITLE
Make thorin output parsable by frontend.

### DIFF
--- a/docs/langref.md
+++ b/docs/langref.md
@@ -130,7 +130,7 @@ The following tables comprise all production rules:
 | d           | `.pack` Sym ( `:` e<sub>type</sub> )? `,` e<sub>shape</sub> v? n  |            | nominal pack declaration       | thorin::Pack  |
 | d           | `.Sigma` Sym ( `:` e<sub>type</sub> )? `,` L<sub>arity</sub> v? n |            | nominal sigma declaration      | thorin::Sigma |
 | d           | `.def` Sym n                                                      |            | nominal definition             | nominals      |
-| v           | `:` Sym \| `(` Sym `,` ... `,` Sym `)`                            |            | nominal variable declaration   | nominals      |
+| v           | `,` `@` Sym \| `,` `@` `(` Sym `,` ... `,` Sym `)`                |            | nominal variable declaration   | nominals      |
 | n           | `;` \| o                                                          |            | nominal definition             | -             |
 | o           | `=` e `;`                                                         |            | operand of nominal definition  | -             |
 | o           | `=` `{` e `,` ... `,` e  `}` `;`                                  | ✓          | operands of nominal definition | -             |

--- a/docs/langref.md
+++ b/docs/langref.md
@@ -120,19 +120,20 @@ The following tables comprise all production rules:
 
 #### Declarations
 
-| Nonterminal | Right-Hand Side                                                | New Scope? | Comment                        | Thorin Class  |
-|-------------|----------------------------------------------------------------|------------|--------------------------------|---------------|
-| d           | `.ax` Ax `:` e<sub>type</sub> `;`                              |            | axiom                          | thorin::Axiom |
-| d           | `.let` Sym `:` e<sub>type</sub> `=` e `;`                      |            | let                            | -             |
-| d           | `.Pi` Sym ( `:` e<sub>type</sub> )? `,` e<sub>dom</sub> n      |            | nominal Pi declaration         | thorin::Pi    |
-| d           | `.lam` Sym `:` e<sub>type</sub> n                              |            | nominal lambda declaration     | thorin::Lam   |
-| d           | `.Arr` Sym ( `:` e<sub>type</sub> )? `,` e<sub>shape</sub> n   |            | nominal array declaration      | thorin::Arr   |
-| d           | `.pack` Sym ( `:` e<sub>type</sub> )? `,` e<sub>shape</sub> n  |            | nominal pack declaration       | thorin::Pack  |
-| d           | `.Sigma` Sym ( `:` e<sub>type</sub> )? `,` L<sub>arity</sub> n |            | nominal sigma declaration      | thorin::Sigma |
-| d           | `.def` Sym n                                                   |            | nominal definition             | nominals      |
-| n           | `;` \| o                                                       |            | nominal definition             | -             |
-| o           | `=` e `;`                                                      |            | operand of nominal definition  | -             |
-| o           | `=` `{` e `,` ... `,` e  `}` `;`                               | ✓          | operands of nominal definition | -             |
+| Nonterminal | Right-Hand Side                                                   | New Scope? | Comment                        | Thorin Class  |
+|-------------|-------------------------------------------------------------------|------------|--------------------------------|---------------|
+| d           | `.ax` Ax `:` e<sub>type</sub> `;`                                 |            | axiom                          | thorin::Axiom |
+| d           | `.let` Sym `:` e<sub>type</sub> `=` e `;`                         |            | let                            | -             |
+| d           | `.Pi` Sym ( `:` e<sub>type</sub> )? `,` e<sub>dom</sub> n         |            | nominal Pi declaration         | thorin::Pi    |
+| d           | `.lam` Sym `:` e<sub>type</sub> v? n                              |            | nominal lambda declaration     | thorin::Lam   |
+| d           | `.Arr` Sym ( `:` e<sub>type</sub> )? `,` e<sub>shape</sub> v? n   |            | nominal array declaration      | thorin::Arr   |
+| d           | `.pack` Sym ( `:` e<sub>type</sub> )? `,` e<sub>shape</sub> v? n  |            | nominal pack declaration       | thorin::Pack  |
+| d           | `.Sigma` Sym ( `:` e<sub>type</sub> )? `,` L<sub>arity</sub> v? n |            | nominal sigma declaration      | thorin::Sigma |
+| d           | `.def` Sym n                                                      |            | nominal definition             | nominals      |
+| v           | `:` Sym \| `(` Sym `,` ... `,` Sym `)`                            |            | nominal variable declaration   | nominals      |
+| n           | `;` \| o                                                          |            | nominal definition             | -             |
+| o           | `=` e `;`                                                         |            | operand of nominal definition  | -             |
+| o           | `=` `{` e `,` ... `,` e  `}` `;`                                  | ✓          | operands of nominal definition | -             |
 
 #### Expressions
 

--- a/lit/affine/lower_for.thorin
+++ b/lit/affine/lower_for.thorin
@@ -21,28 +21,29 @@
     %affine.For (4294967296, 1, (%Int 4294967296)) (mem, 0:(%Int 4294967296), argc, 1:(%Int 4294967296), (0:(%Int 4294967296)), for_body, for_exit)
 };
 
-// CHECK-DAG: main_[[mainId:[0-9]+]]: Cn [%mem.M, i32, %mem.Ptr (%mem.Ptr (i8, 0:nat), 0:nat), Cn [%mem.M, i32]]: (_{{[0-9]+}}, _{{[0-9]+}}, _{{[0-9]+}}, _{{[0-9]+}}) = {
-// CHECK-DAG: for_[[forId:[0-9]+]]
-// CHECK-NOT: %affine.For
+// CHECK-DAG: .lam .extern main: .Cn [%mem.M, (%Int 4294967296), %mem.Ptr (%mem.Ptr ((%Int 256), 0:.Nat), 0:.Nat), .Cn [%mem.M, (%Int 4294967296)]]: (_{{[0-9]+}}, _{{[0-9]+}}, _{{[0-9]+}}, _{{[0-9]+}}) = {
 
-// CHECK-DAG: _[[exitId:[0-9]+]]: Cn [%mem.M, i32]
+// CHECK-DAG: .lam _[[exitId:[0-9]+]]: .Cn [%mem.M, (%Int 4294967296)]
 
-// CHECK-DAG: for_[[forId]]: Cn [%mem.M, i32, i32]:
-// CHECK-DAG: _[[cmpId:[0-9]+]]: i1 = ICmp_ul
+// CHECK-DAG: .lam for_[[forId:[0-9]+]]: .Cn [%mem.M, (%Int 4294967296), (%Int 4294967296)]:
+// CHECK-DAG: _[[cmpId:[0-9]+]]: (%Int 2) = %ICmp_ul
 // CHECK-DAG: _[[appId:[0-9]+]]: ⊥:★ = (_[[falseId:[0-9]+]], _[[trueId:[0-9]+]])#_[[cmpId]]
-// CHECK-DAG: λ@(0:i1) _[[appId]]
+// CHECK-DAG: _[[appId]]
 
-// CHECK-DAG: _{{[0-9]+}}: Cn %mem.M: _{{[0-9]+}} = {
+// CHECK-DAG: .lam _{{[0-9]+}}: .Cn %mem.M: _{{[0-9]+}} = {
 // CHECK-DAG: _[[appIdExit:[0-9]+]]: ⊥:★ = _[[exitId]] (@_{{[0-9]+}}, _{{[0-9]+}});
-// CHECK-DAG: λ@(0:i1) _[[appIdExit]]
+// CHECK-DAG: _[[appIdExit]]
 
 
-// CHECK-DAG: for_body_[[forBodyId:[0-9]+]]: Cn %mem.M:
-// CHECK-DAG: = Wrap_add
-// CHECK-DAG: = Wrap_add
+// CHECK-DAG: .lam for_body_[[forBodyId:[0-9]+]]: .Cn %mem.M:
+// CHECK-DAG: = %Wrap_add
+// CHECK-DAG: = %Wrap_add
 // CHECK-DAG: _[[appIdFor:[0-9]+]]: ⊥:★ = for_[[forId]]
-// CHECK-DAG: λ@(0:i1) _[[appIdFor]]
+// CHECK-DAG: _[[appIdFor]]
 
-// CHECK-DAG: _{{[0-9]+}}: Cn %mem.M: _{{[0-9]+}} = {
+// CHECK-DAG: .lam _{{[0-9]+}}: .Cn %mem.M: _{{[0-9]+}} = {
 // CHECK-DAG: _[[appIdBody:[0-9]+]]: ⊥:★ = for_body_[[forBodyId]]
-// CHECK-DAG: λ@(0:i1) _[[appIdBody]]
+// CHECK-DAG: _[[appIdBody]]
+
+// CHECK-DAG: for_[[forId]]
+// CHECK-NOT: %affine.For

--- a/lit/affine/lower_for.thorin
+++ b/lit/affine/lower_for.thorin
@@ -21,27 +21,27 @@
     %affine.For (4294967296, 1, (%Int 4294967296)) (mem, 0:(%Int 4294967296), argc, 1:(%Int 4294967296), (0:(%Int 4294967296)), for_body, for_exit)
 };
 
-// CHECK-DAG: .lam .extern main: .Cn [%mem.M, (%Int 4294967296), %mem.Ptr (%mem.Ptr ((%Int 256), 0:.Nat), 0:.Nat), .Cn [%mem.M, (%Int 4294967296)]]: (_{{[0-9]+}}, _{{[0-9]+}}, _{{[0-9]+}}, _{{[0-9]+}}) = {
+// CHECK-DAG: .lam .extern main: .Cn [%mem.M, (%Int 4294967296), %mem.Ptr (%mem.Ptr ((%Int 256), 0:.Nat), 0:.Nat), .Cn [%mem.M, (%Int 4294967296)]], @(_{{[0-9]+}}, _{{[0-9]+}}, _{{[0-9]+}}, _{{[0-9]+}}) = {
 
 // CHECK-DAG: .lam _[[exitId:[0-9]+]]: .Cn [%mem.M, (%Int 4294967296)]
 
-// CHECK-DAG: .lam for_[[forId:[0-9]+]]: .Cn [%mem.M, (%Int 4294967296), (%Int 4294967296)]:
+// CHECK-DAG: .lam for_[[forId:[0-9]+]]: .Cn [%mem.M, (%Int 4294967296), (%Int 4294967296)], @
 // CHECK-DAG: _[[cmpId:[0-9]+]]: (%Int 2) = %ICmp_ul
 // CHECK-DAG: _[[appId:[0-9]+]]: ⊥:★ = (_[[falseId:[0-9]+]], _[[trueId:[0-9]+]])#_[[cmpId]]
 // CHECK-DAG: _[[appId]]
 
-// CHECK-DAG: .lam _{{[0-9]+}}: .Cn %mem.M: _{{[0-9]+}} = {
-// CHECK-DAG: _[[appIdExit:[0-9]+]]: ⊥:★ = _[[exitId]] (@_{{[0-9]+}}, _{{[0-9]+}});
+// CHECK-DAG: .lam _{{[0-9]+}}: .Cn %mem.M, @_[[exitVarId:[0-9]+]] = {
+// CHECK-DAG: _[[appIdExit:[0-9]+]]: ⊥:★ = _[[exitId]] (_[[exitVarId]], _{{[0-9]+}});
 // CHECK-DAG: _[[appIdExit]]
 
 
-// CHECK-DAG: .lam for_body_[[forBodyId:[0-9]+]]: .Cn %mem.M:
+// CHECK-DAG: .lam for_body_[[forBodyId:[0-9]+]]: .Cn %mem.M, @
 // CHECK-DAG: = %Wrap_add
 // CHECK-DAG: = %Wrap_add
 // CHECK-DAG: _[[appIdFor:[0-9]+]]: ⊥:★ = for_[[forId]]
 // CHECK-DAG: _[[appIdFor]]
 
-// CHECK-DAG: .lam _{{[0-9]+}}: .Cn %mem.M: _{{[0-9]+}} = {
+// CHECK-DAG: .lam _{{[0-9]+}}: .Cn %mem.M, @_{{[0-9]+}} = {
 // CHECK-DAG: _[[appIdBody:[0-9]+]]: ⊥:★ = for_body_[[forBodyId]]
 // CHECK-DAG: _[[appIdBody]]
 

--- a/lit/core/normalize_add.thorin
+++ b/lit/core/normalize_add.thorin
@@ -8,12 +8,12 @@
     return (%core.wrap.add (0, 256) (i, 0 : (%Int 256)))
 };
 
-// CHECK-DAG: add0: .Cn [(%Int 256), .Cn (%Int 256)]: (_[[valId:[0-9]+]], _[[retId:[0-9]+]]) = {
+// CHECK-DAG: add0: .Cn [(%Int 256), .Cn (%Int 256)], @(_[[valId:[0-9]+]], _[[retId:[0-9]+]]) = {
 // CHECK-DAG: _[[appId:[0-9]+]]: ⊥:★ = _[[etaId:[0-9]+]] _[[valId]];
 // CHECK-DAG: _[[appId]]
 
-// CHECK-DAG: _[[etaId]]: .Cn (%Int 256): _[[etaVar:[0-9]+]] = {
-// CHECK-DAG: _[[appRetId:[0-9]+]]: ⊥:★ = _[[retId]] @_[[etaVar]];
+// CHECK-DAG: _[[etaId]]: .Cn (%Int 256), @_[[etaVar:[0-9]+]] = {
+// CHECK-DAG: _[[appRetId:[0-9]+]]: ⊥:★ = _[[retId]] _[[etaVar]];
 // CHECK-DAG: _[[appRetId]]
 
 .lam .extern add_lit: .Cn [return : .Cn %Int 256] = {
@@ -21,11 +21,11 @@
     return (%core.wrap.add (0, 256) (6 : (%Int 256), 0 : (%Int 256)))
 };
 
-// CHECK-DAG: add_lit: .Cn .Cn (%Int 256): _[[retId:[0-9]+]] = {
+// CHECK-DAG: add_lit: .Cn .Cn (%Int 256), @_[[retId:[0-9]+]] = {
 // CHECK-DAG: _[[appId:[0-9]+]]: ⊥:★ = _[[etaId:[0-9]+]] 6:(%Int 256);
 // CHECK-DAG: _[[appId]]
 
-// CHECK-DAG: _[[etaId]]: .Cn (%Int 256): _[[etaVar:[0-9]+]] = {
-// CHECK-DAG: _[[appRetId:[0-9]+]]: ⊥:★ = @_[[retId]] @_[[etaVar]];
+// CHECK-DAG: _[[etaId]]: .Cn (%Int 256), @_[[etaVar:[0-9]+]] = {
+// CHECK-DAG: _[[appRetId:[0-9]+]]: ⊥:★ = _[[retId]] _[[etaVar]];
 // CHECK-DAG: _[[appRetId]]
 

--- a/lit/core/normalize_add.thorin
+++ b/lit/core/normalize_add.thorin
@@ -8,24 +8,24 @@
     return (%core.wrap.add (0, 256) (i, 0 : (%Int 256)))
 };
 
-// CHECK-DAG: add0_{{[0-9]+}}: Cn [i8, Cn i8]: (_[[valId:[0-9]+]], _[[retId:[0-9]+]]) = {
+// CHECK-DAG: add0: .Cn [(%Int 256), .Cn (%Int 256)]: (_[[valId:[0-9]+]], _[[retId:[0-9]+]]) = {
 // CHECK-DAG: _[[appId:[0-9]+]]: ⊥:★ = _[[etaId:[0-9]+]] _[[valId]];
-// CHECK-DAG: λ@(0:i1) _[[appId]]
+// CHECK-DAG: _[[appId]]
 
-// CHECK-DAG: _[[etaId]]: Cn i8: _[[etaVar:[0-9]+]] = {
+// CHECK-DAG: _[[etaId]]: .Cn (%Int 256): _[[etaVar:[0-9]+]] = {
 // CHECK-DAG: _[[appRetId:[0-9]+]]: ⊥:★ = _[[retId]] @_[[etaVar]];
-// CHECK-DAG: λ@(0:i1) _[[appRetId]]
+// CHECK-DAG: _[[appRetId]]
 
 .lam .extern add_lit: .Cn [return : .Cn %Int 256] = {
     .ff,
     return (%core.wrap.add (0, 256) (6 : (%Int 256), 0 : (%Int 256)))
 };
 
-// CHECK-DAG: add_lit_{{[0-9]+}}: Cn Cn i8: _[[retId:[0-9]+]] = {
-// CHECK-DAG: _[[appId:[0-9]+]]: ⊥:★ = _[[etaId:[0-9]+]] 6:i8;
-// CHECK-DAG: λ@(0:i1) _[[appId]]
+// CHECK-DAG: add_lit: .Cn .Cn (%Int 256): _[[retId:[0-9]+]] = {
+// CHECK-DAG: _[[appId:[0-9]+]]: ⊥:★ = _[[etaId:[0-9]+]] 6:(%Int 256);
+// CHECK-DAG: _[[appId]]
 
-// CHECK-DAG: _[[etaId]]: Cn i8: _[[etaVar:[0-9]+]] = {
+// CHECK-DAG: _[[etaId]]: .Cn (%Int 256): _[[etaVar:[0-9]+]] = {
 // CHECK-DAG: _[[appRetId:[0-9]+]]: ⊥:★ = @_[[retId]] @_[[etaVar]];
-// CHECK-DAG: λ@(0:i1) _[[appRetId]]
+// CHECK-DAG: _[[appRetId]]
 

--- a/lit/core/normalize_and_ff.thorin
+++ b/lit/core/normalize_and_ff.thorin
@@ -8,10 +8,12 @@
     return (%core.bit2._and 2 (i, .ff))
 };
 
-// CHECK-DAG: and_ff_{{[0-9]+}}: Cn [i1, Cn i1]: (_[[valId:[0-9]+]], _[[retId:[0-9]+]]) = {
-// CHECK-DAG: _[[appId:[0-9]+]]: ⊥:★ = _[[etaId:[0-9]+]] 0:i1;
-// CHECK-DAG: λ@(0:i1) _[[appId]]
+// CHECK-DAG: .lam .extern and_ff: .Cn [(%Int 2), .Cn (%Int 2)]: (_[[valId:[0-9]+]], _[[retId:[0-9]+]]) = {
+// CHECK-DAG: 0:(%Int 2),
+// CHECK-DAG: .let _[[appId:[0-9]+]]: ⊥:★ = _[[etaId:[0-9]+]] 0:(%Int 2);
+// CHECK-DAG: _[[appId]]
 
-// CHECK-DAG: _[[etaId]]: Cn i1: _[[etaVar:[0-9]+]] = {
-// CHECK-DAG: _[[appRetId:[0-9]+]]: ⊥:★ = _[[retId]] @_[[etaVar]];
-// CHECK-DAG: λ@(0:i1) _[[appRetId]]
+// CHECK-DAG: .lam _[[etaId]]: .Cn (%Int 2): _[[etaVar:[0-9]+]] = {
+// CHECK-DAG: 0:(%Int 2),
+// CHECK-DAG: .let _[[appRetId:[0-9]+]]: ⊥:★ = _[[retId]] @_[[etaVar]];
+// CHECK-DAG: _[[appRetId]]

--- a/lit/core/normalize_and_ff.thorin
+++ b/lit/core/normalize_and_ff.thorin
@@ -8,12 +8,12 @@
     return (%core.bit2._and 2 (i, .ff))
 };
 
-// CHECK-DAG: .lam .extern and_ff: .Cn [(%Int 2), .Cn (%Int 2)]: (_[[valId:[0-9]+]], _[[retId:[0-9]+]]) = {
+// CHECK-DAG: .lam .extern and_ff: .Cn [(%Int 2), .Cn (%Int 2)], @(_[[valId:[0-9]+]], _[[retId:[0-9]+]]) = {
 // CHECK-DAG: 0:(%Int 2),
 // CHECK-DAG: .let _[[appId:[0-9]+]]: ⊥:★ = _[[etaId:[0-9]+]] 0:(%Int 2);
 // CHECK-DAG: _[[appId]]
 
-// CHECK-DAG: .lam _[[etaId]]: .Cn (%Int 2): _[[etaVar:[0-9]+]] = {
+// CHECK-DAG: .lam _[[etaId]]: .Cn (%Int 2), @_[[etaVar:[0-9]+]] = {
 // CHECK-DAG: 0:(%Int 2),
-// CHECK-DAG: .let _[[appRetId:[0-9]+]]: ⊥:★ = _[[retId]] @_[[etaVar]];
+// CHECK-DAG: .let _[[appRetId:[0-9]+]]: ⊥:★ = _[[retId]] _[[etaVar]];
 // CHECK-DAG: _[[appRetId]]

--- a/lit/core/normalize_and_ff_tt.thorin
+++ b/lit/core/normalize_and_ff_tt.thorin
@@ -8,11 +8,11 @@
     return (%core.bit2._and 2 (.ff, .tt))
 };
 
-// CHECK-DAG: and_lit_ff_tt_{{[0-9]+}}: Cn Cn i1: _[[retId_ff_tt:[0-9]+]] = {
-// CHECK-DAG: _[[appId_ff_tt:[0-9]+]]: ⊥:★ = _[[etaId_ff_tt:[0-9]+]] 0:i1;
-// CHECK-DAG: λ@(0:i1) _[[appId_ff_tt]]
+// CHECK-DAG: and_lit_ff_tt: .Cn .Cn (%Int 2): _[[retId_ff_tt:[0-9]+]] = {
+// CHECK-DAG: _[[appId_ff_tt:[0-9]+]]: ⊥:★ = _[[etaId_ff_tt:[0-9]+]] 0:(%Int 2);
+// CHECK-DAG: _[[appId_ff_tt]]
 
-// CHECK-DAG: _[[etaId_ff_tt]]: Cn i1: _[[etaVar_ff_tt:[0-9]+]] = {
+// CHECK-DAG: _[[etaId_ff_tt]]: .Cn (%Int 2): _[[etaVar_ff_tt:[0-9]+]] = {
 // CHECK-DAG: _[[appRetId_ff_tt:[0-9]+]]: ⊥:★ = @_[[retId_ff_tt]] @_[[etaVar_ff_tt]];
-// CHECK-DAG: λ@(0:i1) _[[appRetId_ff_tt]]
+// CHECK-DAG: _[[appRetId_ff_tt]]
 

--- a/lit/core/normalize_and_ff_tt.thorin
+++ b/lit/core/normalize_and_ff_tt.thorin
@@ -8,11 +8,11 @@
     return (%core.bit2._and 2 (.ff, .tt))
 };
 
-// CHECK-DAG: and_lit_ff_tt: .Cn .Cn (%Int 2): _[[retId_ff_tt:[0-9]+]] = {
+// CHECK-DAG: and_lit_ff_tt: .Cn .Cn (%Int 2), @_[[retId_ff_tt:[0-9]+]] = {
 // CHECK-DAG: _[[appId_ff_tt:[0-9]+]]: ⊥:★ = _[[etaId_ff_tt:[0-9]+]] 0:(%Int 2);
 // CHECK-DAG: _[[appId_ff_tt]]
 
-// CHECK-DAG: _[[etaId_ff_tt]]: .Cn (%Int 2): _[[etaVar_ff_tt:[0-9]+]] = {
-// CHECK-DAG: _[[appRetId_ff_tt:[0-9]+]]: ⊥:★ = @_[[retId_ff_tt]] @_[[etaVar_ff_tt]];
+// CHECK-DAG: _[[etaId_ff_tt]]: .Cn (%Int 2), @_[[etaVar_ff_tt:[0-9]+]] = {
+// CHECK-DAG: _[[appRetId_ff_tt:[0-9]+]]: ⊥:★ = _[[retId_ff_tt]] _[[etaVar_ff_tt]];
 // CHECK-DAG: _[[appRetId_ff_tt]]
 

--- a/lit/core/normalize_and_icmps.thorin
+++ b/lit/core/normalize_and_icmps.thorin
@@ -13,11 +13,13 @@
             (a, b)))
 };
 
-// CHECK-DAG: and_{{[0-9]+}}: Cn [i1, i1, Cn i1]: (_[[aId:[0-9]+]], _[[bId:[0-9]+]], _[[retId:[0-9]+]]) = {
-// CHECK-DAG: _[[cmpId:[0-9]+]]: i1 = %core.icmp.xYGle 2:nat (_[[aId]], _[[bId]]);
-// CHECK-DAG: _[[appId:[0-9]+]]: ⊥:★ = _[[etaId:[0-9]+]] _[[cmpId]];
-// CHECK-DAG: λ@(0:i1) _[[appId]]
+// CHECK-DAG: .lam .extern and: .Cn [(%Int 2), (%Int 2), .Cn (%Int 2)]: (_[[aId:[0-9]+]], _[[bId:[0-9]+]], _[[retId:[0-9]+]]) = {
+// CHECK-DAG: 0:(%Int 2),
+// CHECK-DAG: .let _[[cmpId:[0-9]+]]: (%Int 2) = %core.icmp.xYGle 2:.Nat (_[[aId]], _[[bId]]);
+// CHECK-DAG: .let _[[appId:[0-9]+]]: ⊥:★ = _[[etaId:[0-9]+]] _[[cmpId]];
+// CHECK-DAG: _[[appId]]
 
-// CHECK-DAG: _[[etaId]]: Cn i1: _[[etaVar:[0-9]+]] = {
-// CHECK-DAG: _[[appRetId:[0-9]+]]: ⊥:★ = _[[retId]] @_[[etaVar]];
-// CHECK-DAG: λ@(0:i1) _[[appRetId]]
+// CHECK-DAG: .lam _[[etaId]]: .Cn (%Int 2): _[[etaVar:[0-9]+]] = {
+// CHECK-DAG: 0:(%Int 2),
+// CHECK-DAG: .let _[[appRetId:[0-9]+]]: ⊥:★ = _[[retId]] @_[[etaVar]];
+// CHECK-DAG: _[[appRetId]]

--- a/lit/core/normalize_and_icmps.thorin
+++ b/lit/core/normalize_and_icmps.thorin
@@ -13,13 +13,13 @@
             (a, b)))
 };
 
-// CHECK-DAG: .lam .extern and: .Cn [(%Int 2), (%Int 2), .Cn (%Int 2)]: (_[[aId:[0-9]+]], _[[bId:[0-9]+]], _[[retId:[0-9]+]]) = {
+// CHECK-DAG: .lam .extern and: .Cn [(%Int 2), (%Int 2), .Cn (%Int 2)], @(_[[aId:[0-9]+]], _[[bId:[0-9]+]], _[[retId:[0-9]+]]) = {
 // CHECK-DAG: 0:(%Int 2),
 // CHECK-DAG: .let _[[cmpId:[0-9]+]]: (%Int 2) = %core.icmp.xYGle 2:.Nat (_[[aId]], _[[bId]]);
 // CHECK-DAG: .let _[[appId:[0-9]+]]: ⊥:★ = _[[etaId:[0-9]+]] _[[cmpId]];
 // CHECK-DAG: _[[appId]]
 
-// CHECK-DAG: .lam _[[etaId]]: .Cn (%Int 2): _[[etaVar:[0-9]+]] = {
+// CHECK-DAG: .lam _[[etaId]]: .Cn (%Int 2), @_[[etaVar:[0-9]+]] = {
 // CHECK-DAG: 0:(%Int 2),
-// CHECK-DAG: .let _[[appRetId:[0-9]+]]: ⊥:★ = _[[retId]] @_[[etaVar]];
+// CHECK-DAG: .let _[[appRetId:[0-9]+]]: ⊥:★ = _[[retId]] _[[etaVar]];
 // CHECK-DAG: _[[appRetId]]

--- a/lit/core/normalize_and_icmps_lit.thorin
+++ b/lit/core/normalize_and_icmps_lit.thorin
@@ -13,10 +13,10 @@
             (.tt, .ff)))
 };
 
-// CHECK-DAG: and_lit_{{[0-9]+}}: Cn Cn i1: _[[retId:[0-9]+]] = {
-// CHECK-DAG: _[[appId:[0-9]+]]: ⊥:★ = _[[etaId:[0-9]+]] 1:i1;
-// CHECK-DAG: λ@(0:i1) _[[appId]]
+// CHECK-DAG: and_lit: .Cn .Cn (%Int 2): _[[retId:[0-9]+]] = {
+// CHECK-DAG: _[[appId:[0-9]+]]: ⊥:★ = _[[etaId:[0-9]+]] 1:(%Int 2);
+// CHECK-DAG: _[[appId]]
 
-// CHECK-DAG: _[[etaId]]: Cn i1: _[[etaVar:[0-9]+]] = {
+// CHECK-DAG: _[[etaId]]: .Cn (%Int 2): _[[etaVar:[0-9]+]] = {
 // CHECK-DAG: _[[appRetId:[0-9]+]]: ⊥:★ = @_[[retId]] @_[[etaVar]];
-// CHECK-DAG: λ@(0:i1) _[[appRetId]]
+// CHECK-DAG: _[[appRetId]]

--- a/lit/core/normalize_and_icmps_lit.thorin
+++ b/lit/core/normalize_and_icmps_lit.thorin
@@ -13,10 +13,10 @@
             (.tt, .ff)))
 };
 
-// CHECK-DAG: and_lit: .Cn .Cn (%Int 2): _[[retId:[0-9]+]] = {
+// CHECK-DAG: and_lit: .Cn .Cn (%Int 2), @_[[retId:[0-9]+]] = {
 // CHECK-DAG: _[[appId:[0-9]+]]: ⊥:★ = _[[etaId:[0-9]+]] 1:(%Int 2);
 // CHECK-DAG: _[[appId]]
 
-// CHECK-DAG: _[[etaId]]: .Cn (%Int 2): _[[etaVar:[0-9]+]] = {
-// CHECK-DAG: _[[appRetId:[0-9]+]]: ⊥:★ = @_[[retId]] @_[[etaVar]];
+// CHECK-DAG: _[[etaId]]: .Cn (%Int 2), @_[[etaVar:[0-9]+]] = {
+// CHECK-DAG: _[[appRetId:[0-9]+]]: ⊥:★ = _[[retId]] _[[etaVar]];
 // CHECK-DAG: _[[appRetId]]

--- a/lit/core/normalize_and_tree.thorin
+++ b/lit/core/normalize_and_tree.thorin
@@ -15,11 +15,11 @@
              %core.bit2._and 2 (.tt, .ff))))
 };
 
-// CHECK-DAG: and_lit_{{[0-9]+}}: Cn Cn i1: _[[retId:[0-9]+]] = {
-// CHECK-DAG: _[[appId:[0-9]+]]: ⊥:★ = _[[etaId:[0-9]+]] 0:i1;
-// CHECK-DAG: λ@(0:i1) _[[appId]]
+// CHECK-DAG: and_lit: .Cn .Cn (%Int 2): _[[retId:[0-9]+]] = {
+// CHECK-DAG: _[[appId:[0-9]+]]: ⊥:★ = _[[etaId:[0-9]+]] 0:(%Int 2);
+// CHECK-DAG: _[[appId]]
 
-// CHECK-DAG: _[[etaId]]: Cn i1: _[[etaVar:[0-9]+]] = {
+// CHECK-DAG: _[[etaId]]: .Cn (%Int 2): _[[etaVar:[0-9]+]] = {
 // CHECK-DAG: _[[appRetId:[0-9]+]]: ⊥:★ = @_[[retId]] @_[[etaVar]];
-// CHECK-DAG: λ@(0:i1) _[[appRetId]]
+// CHECK-DAG: _[[appRetId]]
 

--- a/lit/core/normalize_and_tree.thorin
+++ b/lit/core/normalize_and_tree.thorin
@@ -15,11 +15,11 @@
              %core.bit2._and 2 (.tt, .ff))))
 };
 
-// CHECK-DAG: and_lit: .Cn .Cn (%Int 2): _[[retId:[0-9]+]] = {
+// CHECK-DAG: .lam .extern and_lit: .Cn .Cn (%Int 2), @_[[retId:[0-9]+]] = {
 // CHECK-DAG: _[[appId:[0-9]+]]: ⊥:★ = _[[etaId:[0-9]+]] 0:(%Int 2);
 // CHECK-DAG: _[[appId]]
 
-// CHECK-DAG: _[[etaId]]: .Cn (%Int 2): _[[etaVar:[0-9]+]] = {
-// CHECK-DAG: _[[appRetId:[0-9]+]]: ⊥:★ = @_[[retId]] @_[[etaVar]];
+// CHECK-DAG: .lam _[[etaId]]: .Cn (%Int 2), @_[[etaVar:[0-9]+]] = {
+// CHECK-DAG: _[[appRetId:[0-9]+]]: ⊥:★ = _[[retId]] _[[etaVar]];
 // CHECK-DAG: _[[appRetId]]
 

--- a/lit/core/normalize_and_tt.thorin
+++ b/lit/core/normalize_and_tt.thorin
@@ -8,10 +8,10 @@
     return (%core.bit2._and 2 (i, .tt))
 };
 
-// CHECK-DAG: and_tt: .Cn [(%Int 2), .Cn (%Int 2)]: (_[[valId_tt:[0-9]+]], _[[retId_tt:[0-9]+]]) = {
+// CHECK-DAG: and_tt: .Cn [(%Int 2), .Cn (%Int 2)], @(_[[valId_tt:[0-9]+]], _[[retId_tt:[0-9]+]]) = {
 // CHECK-DAG: _[[appId_tt:[0-9]+]]: ⊥:★ = _[[etaId_tt:[0-9]+]] _[[valId_tt]];
 // CHECK-DAG: _[[appId_tt]]
 
-// CHECK-DAG: _[[etaId_tt]]: .Cn (%Int 2): _[[etaVar_tt:[0-9]+]] = {
-// CHECK-DAG: _[[appRetId_tt:[0-9]+]]: ⊥:★ = _[[retId_tt]] @_[[etaVar_tt]];
+// CHECK-DAG: _[[etaId_tt]]: .Cn (%Int 2), @_[[etaVar_tt:[0-9]+]] = {
+// CHECK-DAG: _[[appRetId_tt:[0-9]+]]: ⊥:★ = _[[retId_tt]] _[[etaVar_tt]];
 // CHECK-DAG: _[[appRetId_tt]]

--- a/lit/core/normalize_and_tt.thorin
+++ b/lit/core/normalize_and_tt.thorin
@@ -8,10 +8,10 @@
     return (%core.bit2._and 2 (i, .tt))
 };
 
-// CHECK-DAG: and_tt_{{[0-9]+}}: Cn [i1, Cn i1]: (_[[valId_tt:[0-9]+]], _[[retId_tt:[0-9]+]]) = {
+// CHECK-DAG: and_tt: .Cn [(%Int 2), .Cn (%Int 2)]: (_[[valId_tt:[0-9]+]], _[[retId_tt:[0-9]+]]) = {
 // CHECK-DAG: _[[appId_tt:[0-9]+]]: ⊥:★ = _[[etaId_tt:[0-9]+]] _[[valId_tt]];
-// CHECK-DAG: λ@(0:i1) _[[appId_tt]]
+// CHECK-DAG: _[[appId_tt]]
 
-// CHECK-DAG: _[[etaId_tt]]: Cn i1: _[[etaVar_tt:[0-9]+]] = {
+// CHECK-DAG: _[[etaId_tt]]: .Cn (%Int 2): _[[etaVar_tt:[0-9]+]] = {
 // CHECK-DAG: _[[appRetId_tt:[0-9]+]]: ⊥:★ = _[[retId_tt]] @_[[etaVar_tt]];
-// CHECK-DAG: λ@(0:i1) _[[appRetId_tt]]
+// CHECK-DAG: _[[appRetId_tt]]

--- a/lit/core/normalize_and_tt_tt.thorin
+++ b/lit/core/normalize_and_tt_tt.thorin
@@ -8,11 +8,13 @@
     return (%core.bit2._and 2 (.tt, .tt))
 };
 
-// CHECK-DAG: and_lit_tt_tt_{{[0-9]+}}: Cn Cn i1: _[[retId:[0-9]+]] = {
-// CHECK-DAG: _[[appId:[0-9]+]]: ⊥:★ = _[[etaId:[0-9]+]] 1:i1;
-// CHECK-DAG: λ@(0:i1) _[[appId]]
+// CHECK-DAG: .lam .extern and_lit_tt_tt: .Cn .Cn (%Int 2): _[[retId:[0-9]+]] = {
+// CHECK-DAG: 0:(%Int 2),
+// CHECK-DAG: .let _[[appId:[0-9]+]]: ⊥:★ = _[[etaId:[0-9]+]] 1:(%Int 2);
+// CHECK-DAG: _[[appId]]
 
-// CHECK-DAG: _[[etaId]]: Cn i1: _[[etaVar:[0-9]+]] = {
-// CHECK-DAG: _[[appRetId:[0-9]+]]: ⊥:★ = @_[[retId]] @_[[etaVar]];
-// CHECK-DAG: λ@(0:i1) _[[appRetId]]
+// CHECK-DAG: .lam _[[etaId]]: .Cn (%Int 2): _[[etaVar:[0-9]+]] = {
+// CHECK-DAG: 0:(%Int 2),
+// CHECK-DAG: .let _[[appRetId:[0-9]+]]: ⊥:★ = @_[[retId]] @_[[etaVar]];
+// CHECK-DAG: _[[appRetId]]
 

--- a/lit/core/normalize_and_tt_tt.thorin
+++ b/lit/core/normalize_and_tt_tt.thorin
@@ -8,13 +8,13 @@
     return (%core.bit2._and 2 (.tt, .tt))
 };
 
-// CHECK-DAG: .lam .extern and_lit_tt_tt: .Cn .Cn (%Int 2): _[[retId:[0-9]+]] = {
+// CHECK-DAG: .lam .extern and_lit_tt_tt: .Cn .Cn (%Int 2), @_[[retId:[0-9]+]] = {
 // CHECK-DAG: 0:(%Int 2),
 // CHECK-DAG: .let _[[appId:[0-9]+]]: ⊥:★ = _[[etaId:[0-9]+]] 1:(%Int 2);
 // CHECK-DAG: _[[appId]]
 
-// CHECK-DAG: .lam _[[etaId]]: .Cn (%Int 2): _[[etaVar:[0-9]+]] = {
+// CHECK-DAG: .lam _[[etaId]]: .Cn (%Int 2), @_[[etaVar:[0-9]+]] = {
 // CHECK-DAG: 0:(%Int 2),
-// CHECK-DAG: .let _[[appRetId:[0-9]+]]: ⊥:★ = @_[[retId]] @_[[etaVar]];
+// CHECK-DAG: .let _[[appRetId:[0-9]+]]: ⊥:★ = _[[retId]] _[[etaVar]];
 // CHECK-DAG: _[[appRetId]]
 

--- a/lit/core/normalize_icmp.thorin
+++ b/lit/core/normalize_icmp.thorin
@@ -13,10 +13,10 @@
             (.tt, .ff)))
 };
 
-// CHECK-DAG: icmp_lit_{{[0-9]+}}: Cn Cn i1: _[[retId:[0-9]+]] = {
-// CHECK-DAG: _[[appId:[0-9]+]]: ⊥:★ = _[[etaId:[0-9]+]] 1:i1;
-// CHECK-DAG: λ@(0:i1) _[[appId]]
+// CHECK-DAG: icmp_lit: .Cn .Cn (%Int 2): _[[retId:[0-9]+]] = {
+// CHECK-DAG: _[[appId:[0-9]+]]: ⊥:★ = _[[etaId:[0-9]+]] 1:(%Int 2);
+// CHECK-DAG: _[[appId]]
 
-// CHECK-DAG: _[[etaId]]: Cn i1: _[[etaVar:[0-9]+]] = {
+// CHECK-DAG: _[[etaId]]: .Cn (%Int 2): _[[etaVar:[0-9]+]] = {
 // CHECK-DAG: _[[appRetId:[0-9]+]]: ⊥:★ = @_[[retId]] @_[[etaVar]];
-// CHECK-DAG: λ@(0:i1) _[[appRetId]]
+// CHECK-DAG: _[[appRetId]]

--- a/lit/core/normalize_icmp.thorin
+++ b/lit/core/normalize_icmp.thorin
@@ -13,10 +13,10 @@
             (.tt, .ff)))
 };
 
-// CHECK-DAG: icmp_lit: .Cn .Cn (%Int 2): _[[retId:[0-9]+]] = {
+// CHECK-DAG: icmp_lit: .Cn .Cn (%Int 2), @_[[retId:[0-9]+]] = {
 // CHECK-DAG: _[[appId:[0-9]+]]: ⊥:★ = _[[etaId:[0-9]+]] 1:(%Int 2);
 // CHECK-DAG: _[[appId]]
 
-// CHECK-DAG: _[[etaId]]: .Cn (%Int 2): _[[etaVar:[0-9]+]] = {
-// CHECK-DAG: _[[appRetId:[0-9]+]]: ⊥:★ = @_[[retId]] @_[[etaVar]];
+// CHECK-DAG: _[[etaId]]: .Cn (%Int 2), @_[[etaVar:[0-9]+]] = {
+// CHECK-DAG: _[[appRetId:[0-9]+]]: ⊥:★ = _[[retId]] _[[etaVar]];
 // CHECK-DAG: _[[appRetId]]

--- a/lit/core/ret_add.thorin
+++ b/lit/core/ret_add.thorin
@@ -29,10 +29,10 @@
     atoi (argv_load_a#.ff, argv_load_a#.tt, atoi_cont_a)
 };
 
-// CHECK-DAG: main: .Cn [%mem.M, (%Int 4294967296), %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (%Int 256)», 0:.Nat)», 0:.Nat), .Cn [%mem.M, (%Int 4294967296)]]: (_[[memId:[0-9]+]], _[[argcId:[0-9]+]], _{{[0-9]+}}, _[[returnId:[0-9]+]]) = {
+// CHECK-DAG: main: .Cn [%mem.M, (%Int 4294967296), %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (%Int 256)», 0:.Nat)», 0:.Nat), .Cn [%mem.M, (%Int 4294967296)]], @(_[[memId:[0-9]+]], _[[argcId:[0-9]+]], _{{[0-9]+}}, _[[returnId:[0-9]+]]) = {
 
-// CHECK-DAG: atoi_cont_a_[[aContId:[0-9]+]]: .Cn [%mem.M, (%Int 4294967296)]: (_{{[0-9]+}}, _[[aId:[0-9]+]])
+// CHECK-DAG: atoi_cont_a_[[aContId:[0-9]+]]: .Cn [%mem.M, (%Int 4294967296)], @(_{{[0-9]+}}, _[[aId:[0-9]+]])
 
-// CHECK-DAG: atoi_cont_b_[[bContId:[0-9]+]]: .Cn [%mem.M, (%Int 4294967296)]: (_{{[0-9]+}}, _[[bId:[0-9]+]])
+// CHECK-DAG: atoi_cont_b_[[bContId:[0-9]+]]: .Cn [%mem.M, (%Int 4294967296)], @(_{{[0-9]+}}, _[[bId:[0-9]+]])
 // CHECK-DAG: _[[wrapAdd:[0-9]+]]: (%Int 4294967296) = %core.wrap.add (0:.Nat, 4294967296:.Nat) (_[[aId]], _[[bId]]);
 // CHECK-DAG: _{{[0-9]+}}: ⊥:★ = _{{[0-9]+}} (_{{[0-9]+}}, _[[wrapAdd]]);

--- a/lit/core/ret_add.thorin
+++ b/lit/core/ret_add.thorin
@@ -29,10 +29,10 @@
     atoi (argv_load_a#.ff, argv_load_a#.tt, atoi_cont_a)
 };
 
-// CHECK-DAG: main_[[mainId:[0-9]+]]: Cn [%mem.M, i32, %mem.Ptr («⊤:nat; %mem.Ptr («⊤:nat; i8», 0:nat)», 0:nat), Cn [%mem.M, i32]]: (_[[memId:[0-9]+]], _[[argcId:[0-9]+]], _{{[0-9]+}}, _[[returnId:[0-9]+]]) = {
+// CHECK-DAG: main: .Cn [%mem.M, (%Int 4294967296), %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (%Int 256)», 0:.Nat)», 0:.Nat), .Cn [%mem.M, (%Int 4294967296)]]: (_[[memId:[0-9]+]], _[[argcId:[0-9]+]], _{{[0-9]+}}, _[[returnId:[0-9]+]]) = {
 
-// CHECK-DAG: atoi_cont_a_[[aContId:[0-9]+]]: Cn [%mem.M, i32]: (_{{[0-9]+}}, _[[aId:[0-9]+]])
+// CHECK-DAG: atoi_cont_a_[[aContId:[0-9]+]]: .Cn [%mem.M, (%Int 4294967296)]: (_{{[0-9]+}}, _[[aId:[0-9]+]])
 
-// CHECK-DAG: atoi_cont_b_[[bContId:[0-9]+]]: Cn [%mem.M, i32]: (_{{[0-9]+}}, _[[bId:[0-9]+]])
-// CHECK-DAG: _[[wrapAdd:[0-9]+]]: i32 = %core.wrap.add (0:nat, 4294967296:nat) (_[[aId]], _[[bId]]);
+// CHECK-DAG: atoi_cont_b_[[bContId:[0-9]+]]: .Cn [%mem.M, (%Int 4294967296)]: (_{{[0-9]+}}, _[[bId:[0-9]+]])
+// CHECK-DAG: _[[wrapAdd:[0-9]+]]: (%Int 4294967296) = %core.wrap.add (0:.Nat, 4294967296:.Nat) (_[[aId]], _[[bId]]);
 // CHECK-DAG: _{{[0-9]+}}: ⊥:★ = _{{[0-9]+}} (_{{[0-9]+}}, _[[wrapAdd]]);

--- a/lit/core/ret_and.thorin
+++ b/lit/core/ret_and.thorin
@@ -29,10 +29,10 @@
     atoi (argv_load_a#.ff, argv_load_a#.tt, atoi_cont_a)
 };
 
-// CHECK-DAG: main_[[mainId:[0-9]+]]: Cn [%mem.M, i32, %mem.Ptr («⊤:nat; %mem.Ptr («⊤:nat; i8», 0:nat)», 0:nat), Cn [%mem.M, i32]]: (_[[memId:[0-9]+]], _[[argcId:[0-9]+]], _{{[0-9]+}}, _[[returnId:[0-9]+]]) = {
+// CHECK-DAG: main: .Cn [%mem.M, (%Int 4294967296), %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (%Int 256)», 0:.Nat)», 0:.Nat), .Cn [%mem.M, (%Int 4294967296)]]: (_[[memId:[0-9]+]], _[[argcId:[0-9]+]], _{{[0-9]+}}, _[[returnId:[0-9]+]]) = {
 
-// CHECK-DAG: atoi_cont_a_[[aContId:[0-9]+]]: Cn [%mem.M, i32]: (_{{[0-9]+}}, _[[aId:[0-9]+]])
+// CHECK-DAG: atoi_cont_a_[[aContId:[0-9]+]]: .Cn [%mem.M, (%Int 4294967296)]: (_{{[0-9]+}}, _[[aId:[0-9]+]])
 
-// CHECK-DAG: atoi_cont_b_[[bContId:[0-9]+]]: Cn [%mem.M, i32]: (_{{[0-9]+}}, _[[bId:[0-9]+]])
-// CHECK-DAG: _[[andId:[0-9]+]]: i32 = %core.bit2._and 4294967296:nat (_[[aId]], _[[bId]]);
+// CHECK-DAG: atoi_cont_b_[[bContId:[0-9]+]]: .Cn [%mem.M, (%Int 4294967296)]: (_{{[0-9]+}}, _[[bId:[0-9]+]])
+// CHECK-DAG: _[[andId:[0-9]+]]: (%Int 4294967296) = %core.bit2._and 4294967296:.Nat (_[[aId]], _[[bId]]);
 // CHECK-DAG: _{{[0-9]+}}: ⊥:★ = _{{[0-9]+}} (_{{[0-9]+}}, _[[andId]]);

--- a/lit/core/ret_and.thorin
+++ b/lit/core/ret_and.thorin
@@ -29,10 +29,10 @@
     atoi (argv_load_a#.ff, argv_load_a#.tt, atoi_cont_a)
 };
 
-// CHECK-DAG: main: .Cn [%mem.M, (%Int 4294967296), %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (%Int 256)», 0:.Nat)», 0:.Nat), .Cn [%mem.M, (%Int 4294967296)]]: (_[[memId:[0-9]+]], _[[argcId:[0-9]+]], _{{[0-9]+}}, _[[returnId:[0-9]+]]) = {
+// CHECK-DAG: main: .Cn [%mem.M, (%Int 4294967296), %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (%Int 256)», 0:.Nat)», 0:.Nat), .Cn [%mem.M, (%Int 4294967296)]], @(_[[memId:[0-9]+]], _[[argcId:[0-9]+]], _{{[0-9]+}}, _[[returnId:[0-9]+]]) = {
 
-// CHECK-DAG: atoi_cont_a_[[aContId:[0-9]+]]: .Cn [%mem.M, (%Int 4294967296)]: (_{{[0-9]+}}, _[[aId:[0-9]+]])
+// CHECK-DAG: atoi_cont_a_[[aContId:[0-9]+]]: .Cn [%mem.M, (%Int 4294967296)], @(_{{[0-9]+}}, _[[aId:[0-9]+]])
 
-// CHECK-DAG: atoi_cont_b_[[bContId:[0-9]+]]: .Cn [%mem.M, (%Int 4294967296)]: (_{{[0-9]+}}, _[[bId:[0-9]+]])
+// CHECK-DAG: atoi_cont_b_[[bContId:[0-9]+]]: .Cn [%mem.M, (%Int 4294967296)], @(_{{[0-9]+}}, _[[bId:[0-9]+]])
 // CHECK-DAG: _[[andId:[0-9]+]]: (%Int 4294967296) = %core.bit2._and 4294967296:.Nat (_[[aId]], _[[bId]]);
 // CHECK-DAG: _{{[0-9]+}}: ⊥:★ = _{{[0-9]+}} (_{{[0-9]+}}, _[[andId]]);

--- a/lit/core/ret_lshr.thorin
+++ b/lit/core/ret_lshr.thorin
@@ -29,10 +29,10 @@
     atoi (argv_load_a#.ff, argv_load_a#.tt, atoi_cont_a)
 };
 
-// CHECK-DAG: main: .Cn [%mem.M, (%Int 4294967296), %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (%Int 256)», 0:.Nat)», 0:.Nat), .Cn [%mem.M, (%Int 4294967296)]]: (_[[memId:[0-9]+]], _[[argcId:[0-9]+]], _{{[0-9]+}}, _[[returnId:[0-9]+]]) = {
+// CHECK-DAG: main: .Cn [%mem.M, (%Int 4294967296), %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (%Int 256)», 0:.Nat)», 0:.Nat), .Cn [%mem.M, (%Int 4294967296)]], @(_[[memId:[0-9]+]], _[[argcId:[0-9]+]], _{{[0-9]+}}, _[[returnId:[0-9]+]]) = {
 
-// CHECK-DAG: atoi_cont_a_[[aContId:[0-9]+]]: .Cn [%mem.M, (%Int 4294967296)]: (_{{[0-9]+}}, _[[aId:[0-9]+]])
+// CHECK-DAG: atoi_cont_a_[[aContId:[0-9]+]]: .Cn [%mem.M, (%Int 4294967296)], @(_{{[0-9]+}}, _[[aId:[0-9]+]])
 
-// CHECK-DAG: atoi_cont_b_[[bContId:[0-9]+]]: .Cn [%mem.M, (%Int 4294967296)]: (_{{[0-9]+}}, _[[bId:[0-9]+]])
+// CHECK-DAG: atoi_cont_b_[[bContId:[0-9]+]]: .Cn [%mem.M, (%Int 4294967296)], @(_{{[0-9]+}}, _[[bId:[0-9]+]])
 // CHECK-DAG: _[[shrLshr:[0-9]+]]: (%Int 4294967296) = %core.shr.lshr 4294967296:.Nat (_[[aId]], _[[bId]]);
 // CHECK-DAG: _{{[0-9]+}}: ⊥:★ = _{{[0-9]+}} (_{{[0-9]+}}, _[[shrLshr]]);

--- a/lit/core/ret_lshr.thorin
+++ b/lit/core/ret_lshr.thorin
@@ -29,10 +29,10 @@
     atoi (argv_load_a#.ff, argv_load_a#.tt, atoi_cont_a)
 };
 
-// CHECK-DAG: main_[[mainId:[0-9]+]]: Cn [%mem.M, i32, %mem.Ptr («⊤:nat; %mem.Ptr («⊤:nat; i8», 0:nat)», 0:nat), Cn [%mem.M, i32]]: (_[[memId:[0-9]+]], _[[argcId:[0-9]+]], _{{[0-9]+}}, _[[returnId:[0-9]+]]) = {
+// CHECK-DAG: main: .Cn [%mem.M, (%Int 4294967296), %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (%Int 256)», 0:.Nat)», 0:.Nat), .Cn [%mem.M, (%Int 4294967296)]]: (_[[memId:[0-9]+]], _[[argcId:[0-9]+]], _{{[0-9]+}}, _[[returnId:[0-9]+]]) = {
 
-// CHECK-DAG: atoi_cont_a_[[aContId:[0-9]+]]: Cn [%mem.M, i32]: (_{{[0-9]+}}, _[[aId:[0-9]+]])
+// CHECK-DAG: atoi_cont_a_[[aContId:[0-9]+]]: .Cn [%mem.M, (%Int 4294967296)]: (_{{[0-9]+}}, _[[aId:[0-9]+]])
 
-// CHECK-DAG: atoi_cont_b_[[bContId:[0-9]+]]: Cn [%mem.M, i32]: (_{{[0-9]+}}, _[[bId:[0-9]+]])
-// CHECK-DAG: _[[shrLshr:[0-9]+]]: i32 = %core.shr.lshr 4294967296:nat (_[[aId]], _[[bId]]);
+// CHECK-DAG: atoi_cont_b_[[bContId:[0-9]+]]: .Cn [%mem.M, (%Int 4294967296)]: (_{{[0-9]+}}, _[[bId:[0-9]+]])
+// CHECK-DAG: _[[shrLshr:[0-9]+]]: (%Int 4294967296) = %core.shr.lshr 4294967296:.Nat (_[[aId]], _[[bId]]);
 // CHECK-DAG: _{{[0-9]+}}: ⊥:★ = _{{[0-9]+}} (_{{[0-9]+}}, _[[shrLshr]]);

--- a/lit/main_loop.thorin
+++ b/lit/main_loop.thorin
@@ -30,25 +30,25 @@
 };
 
 
-// CHECK-DAG: main_{{[0-9]+}}: Cn [%mem.M, i32, %mem.Ptr (%mem.Ptr (i8, 0:nat), 0:nat), Cn [%mem.M, i32]]: (_[[memId:[0-9]+]], _[[argcId:[0-9]+]], _{{[0-9]+}}, _[[returnId:[0-9]+]]) = {
-// CHECK-DAG: _[[appLoopId:[0-9]+]]: ⊥:★ = loop_[[loopId:[0-9]+]] (_[[memId]], 0:i32, 0:i32);
-// CHECK-DAG: λ@(0:i1) _[[appLoopId]]
+// CHECK-DAG: main: .Cn [%mem.M, (%Int 4294967296), %mem.Ptr (%mem.Ptr ((%Int 256), 0:.Nat), 0:.Nat), .Cn [%mem.M, (%Int 4294967296)]]: (_[[memId:[0-9]+]], _[[argcId:[0-9]+]], _{{[0-9]+}}, _[[returnId:[0-9]+]]) = {
+// CHECK-DAG: _[[appLoopId:[0-9]+]]: ⊥:★ = loop_[[loopId:[0-9]+]] (_[[memId]], 0:(%Int 4294967296), 0:(%Int 4294967296));
+// CHECK-DAG: _[[appLoopId]]
 
-// CHECK-DAG: _[[exitEtaId:[0-9]+]]: Cn [%mem.M, i32]: (_{{[0-9]+}}, _{{[0-9]+}}) = {
+// CHECK-DAG: _[[exitEtaId:[0-9]+]]: .Cn [%mem.M, (%Int 4294967296)]: (_{{[0-9]+}}, _{{[0-9]+}}) = {
 // CHECK-DAG:    _[[appReturnId:[0-9]+]]: ⊥:★ = _[[returnId]] @_[[exitEtaId]];
-// CHECK-DAG:    λ@(0:i1) _[[appReturnId:[0-9]+]]
+// CHECK-DAG:    _[[appReturnId:[0-9]+]]
 
-// CHECK-DAG: loop_[[loopId]]: Cn [%mem.M, i32, i32]: (_[[loopMemId:[0-9]+]], _[[iterId:[0-9]+]], _[[accId:[0-9]+]]) = {
-// CHECK-DAG: _[[condId:[0-9]+]]: i1 = %core.icmp.XygLe 4294967296:nat (_[[iterId]], _[[argcId]]);
+// CHECK-DAG: loop_[[loopId]]: .Cn [%mem.M, (%Int 4294967296), (%Int 4294967296)]: (_[[loopMemId:[0-9]+]], _[[iterId:[0-9]+]], _[[accId:[0-9]+]]) = {
+// CHECK-DAG: _[[condId:[0-9]+]]: (%Int 2) = %core.icmp.XygLe 4294967296:.Nat (_[[iterId]], _[[argcId]]);
 // CHECK-DAG: _[[appCondId:[0-9]+]]: ⊥:★ = (exit_[[exitId:[0-9]+]], body_[[bodyId:[0-9]+]])#_[[condId]] _[[loopMemId]];
-// CHECK-DAG: λ@(0:i1) _[[appCondId]]
+// CHECK-DAG: _[[appCondId]]
 
-// CHECK-DAG: exit_[[exitId]]: Cn %mem.M: exit_[[exitVarId:[0-9]+]] = {
+// CHECK-DAG: exit_[[exitId]]: .Cn %mem.M: exit_[[exitVarId:[0-9]+]] = {
 // CHECK-DAG: _[[appExitEtaId:[0-9]+]]: ⊥:★ = _[[exitEtaId]] (@exit_[[exitVarId]], _[[accId]]);
-// CHECK-DAG: λ@(0:i1) _[[appExitEtaId]]
+// CHECK-DAG: _[[appExitEtaId]]
 
-// CHECK-DAG: body_[[bodyId]]: Cn %mem.M: body_[[bodyVarId:[0-9]+]] = {
-// CHECK-DAG: _[[addIterId:[0-9]+]]: i32 = Wrap_add (0:nat, 4294967296:nat) (1:i32, _[[iterId]]);
-// CHECK-DAG: _[[addAccId:[0-9]+]]: i32 = Wrap_add (0:nat, 4294967296:nat) (_[[accId]], _[[iterId]]);
+// CHECK-DAG: body_[[bodyId]]: .Cn %mem.M: body_[[bodyVarId:[0-9]+]] = {
+// CHECK-DAG: _[[addIterId:[0-9]+]]: (%Int 4294967296) = %Wrap_add (0:.Nat, 4294967296:.Nat) (1:(%Int 4294967296), _[[iterId]]);
+// CHECK-DAG: _[[addAccId:[0-9]+]]: (%Int 4294967296) = %Wrap_add (0:.Nat, 4294967296:.Nat) (_[[accId]], _[[iterId]]);
 // CHECK-DAG: _[[appLoopIdBody:[0-9]+]]: ⊥:★ = loop_[[loopId]] (@body_[[bodyVarId]], _[[addIterId]], _[[addAccId]]);
-// CHECK-DAG: λ@(0:i1) _[[appLoopIdBody]]
+// CHECK-DAG: _[[appLoopIdBody]]

--- a/lit/main_loop.thorin
+++ b/lit/main_loop.thorin
@@ -30,25 +30,25 @@
 };
 
 
-// CHECK-DAG: main: .Cn [%mem.M, (%Int 4294967296), %mem.Ptr (%mem.Ptr ((%Int 256), 0:.Nat), 0:.Nat), .Cn [%mem.M, (%Int 4294967296)]]: (_[[memId:[0-9]+]], _[[argcId:[0-9]+]], _{{[0-9]+}}, _[[returnId:[0-9]+]]) = {
+// CHECK-DAG: main: .Cn [%mem.M, (%Int 4294967296), %mem.Ptr (%mem.Ptr ((%Int 256), 0:.Nat), 0:.Nat), .Cn [%mem.M, (%Int 4294967296)]], @(_[[memId:[0-9]+]], _[[argcId:[0-9]+]], _{{[0-9]+}}, _[[returnId:[0-9]+]]) = {
 // CHECK-DAG: _[[appLoopId:[0-9]+]]: ⊥:★ = loop_[[loopId:[0-9]+]] (_[[memId]], 0:(%Int 4294967296), 0:(%Int 4294967296));
 // CHECK-DAG: _[[appLoopId]]
 
-// CHECK-DAG: _[[exitEtaId:[0-9]+]]: .Cn [%mem.M, (%Int 4294967296)]: (_{{[0-9]+}}, _{{[0-9]+}}) = {
+// CHECK-DAG: _[[exitEtaId:[0-9]+]]: .Cn [%mem.M, (%Int 4294967296)], @(_{{[0-9]+}}, _{{[0-9]+}}) = {
 // CHECK-DAG:    _[[appReturnId:[0-9]+]]: ⊥:★ = _[[returnId]] @_[[exitEtaId]];
 // CHECK-DAG:    _[[appReturnId:[0-9]+]]
 
-// CHECK-DAG: loop_[[loopId]]: .Cn [%mem.M, (%Int 4294967296), (%Int 4294967296)]: (_[[loopMemId:[0-9]+]], _[[iterId:[0-9]+]], _[[accId:[0-9]+]]) = {
+// CHECK-DAG: loop_[[loopId]]: .Cn [%mem.M, (%Int 4294967296), (%Int 4294967296)], @(_[[loopMemId:[0-9]+]], _[[iterId:[0-9]+]], _[[accId:[0-9]+]]) = {
 // CHECK-DAG: _[[condId:[0-9]+]]: (%Int 2) = %core.icmp.XygLe 4294967296:.Nat (_[[iterId]], _[[argcId]]);
 // CHECK-DAG: _[[appCondId:[0-9]+]]: ⊥:★ = (exit_[[exitId:[0-9]+]], body_[[bodyId:[0-9]+]])#_[[condId]] _[[loopMemId]];
 // CHECK-DAG: _[[appCondId]]
 
-// CHECK-DAG: exit_[[exitId]]: .Cn %mem.M: exit_[[exitVarId:[0-9]+]] = {
-// CHECK-DAG: _[[appExitEtaId:[0-9]+]]: ⊥:★ = _[[exitEtaId]] (@exit_[[exitVarId]], _[[accId]]);
+// CHECK-DAG: exit_[[exitId]]: .Cn %mem.M, @exit_[[exitVarId:[0-9]+]] = {
+// CHECK-DAG: _[[appExitEtaId:[0-9]+]]: ⊥:★ = _[[exitEtaId]] (exit_[[exitVarId]], _[[accId]]);
 // CHECK-DAG: _[[appExitEtaId]]
 
-// CHECK-DAG: body_[[bodyId]]: .Cn %mem.M: body_[[bodyVarId:[0-9]+]] = {
+// CHECK-DAG: body_[[bodyId]]: .Cn %mem.M, @body_[[bodyVarId:[0-9]+]] = {
 // CHECK-DAG: _[[addIterId:[0-9]+]]: (%Int 4294967296) = %Wrap_add (0:.Nat, 4294967296:.Nat) (1:(%Int 4294967296), _[[iterId]]);
 // CHECK-DAG: _[[addAccId:[0-9]+]]: (%Int 4294967296) = %Wrap_add (0:.Nat, 4294967296:.Nat) (_[[accId]], _[[iterId]]);
-// CHECK-DAG: _[[appLoopIdBody:[0-9]+]]: ⊥:★ = loop_[[loopId]] (@body_[[bodyVarId]], _[[addIterId]], _[[addAccId]]);
+// CHECK-DAG: _[[appLoopIdBody:[0-9]+]]: ⊥:★ = loop_[[loopId]] (body_[[bodyVarId]], _[[addIterId]], _[[addAccId]]);
 // CHECK-DAG: _[[appLoopIdBody]]

--- a/lit/main_loop_nom.thorin
+++ b/lit/main_loop_nom.thorin
@@ -30,25 +30,25 @@
 };
 
 
-// CHECK-DAG: main_{{[0-9]+}}: Cn [%mem.M, i32, %mem.Ptr (%mem.Ptr (i8, 0:nat), 0:nat), Cn [%mem.M, i32]]: (_[[memId:[0-9]+]], _[[argcId:[0-9]+]], _{{[0-9]+}}, _[[returnId:[0-9]+]]) = {
-// CHECK-DAG: _[[appLoopId:[0-9]+]]: ⊥:★ = loop_[[loopId:[0-9]+]] (_[[memId]], 0:i32, 0:i32);
-// CHECK-DAG: λ@(0:i1) _[[appLoopId]]
+// CHECK-DAG: main: .Cn [%mem.M, (%Int 4294967296), %mem.Ptr (%mem.Ptr ((%Int 256), 0:.Nat), 0:.Nat), .Cn [%mem.M, (%Int 4294967296)]]: (_[[memId:[0-9]+]], _[[argcId:[0-9]+]], _{{[0-9]+}}, _[[returnId:[0-9]+]]) = {
+// CHECK-DAG: _[[appLoopId:[0-9]+]]: ⊥:★ = loop_[[loopId:[0-9]+]] (_[[memId]], 0:(%Int 4294967296), 0:(%Int 4294967296));
+// CHECK-DAG: _[[appLoopId]]
 
-// CHECK-DAG: _[[exitEtaId:[0-9]+]]: Cn [%mem.M, i32]: (_{{[0-9]+}}, _{{[0-9]+}}) = {
+// CHECK-DAG: _[[exitEtaId:[0-9]+]]: .Cn [%mem.M, (%Int 4294967296)]: (_{{[0-9]+}}, _{{[0-9]+}}) = {
 // CHECK-DAG:    _[[appReturnId:[0-9]+]]: ⊥:★ = _[[returnId]] @_[[exitEtaId]];
-// CHECK-DAG:    λ@(0:i1) _[[appReturnId:[0-9]+]]
+// CHECK-DAG:    _[[appReturnId:[0-9]+]]
 
-// CHECK-DAG: loop_[[loopId]]: Cn [%mem.M, i32, i32]: (_[[loopMemId:[0-9]+]], _[[iterId:[0-9]+]], _[[accId:[0-9]+]]) = {
-// CHECK-DAG: _[[condId:[0-9]+]]: i1 = %core.icmp.XygLe 4294967296:nat (_[[iterId]], _[[argcId]]);
+// CHECK-DAG: loop_[[loopId]]: .Cn [%mem.M, (%Int 4294967296), (%Int 4294967296)]: (_[[loopMemId:[0-9]+]], _[[iterId:[0-9]+]], _[[accId:[0-9]+]]) = {
+// CHECK-DAG: _[[condId:[0-9]+]]: (%Int 2) = %core.icmp.XygLe 4294967296:.Nat (_[[iterId]], _[[argcId]]);
 // CHECK-DAG: _[[appCondId:[0-9]+]]: ⊥:★ = (exit_[[exitId:[0-9]+]], body_[[bodyId:[0-9]+]])#_[[condId]] _[[loopMemId]];
-// CHECK-DAG: λ@(0:i1) _[[appCondId]]
+// CHECK-DAG: _[[appCondId]]
 
-// CHECK-DAG: exit_[[exitId]]: Cn %mem.M: _[[exitVarId:[0-9]+]] = {
+// CHECK-DAG: exit_[[exitId]]: .Cn %mem.M: _[[exitVarId:[0-9]+]] = {
 // CHECK-DAG: _[[appExitEtaId:[0-9]+]]: ⊥:★ = _[[exitEtaId]] (@_[[exitVarId]], _[[accId]]);
-// CHECK-DAG: λ@(0:i1) _[[appExitEtaId]]
+// CHECK-DAG: _[[appExitEtaId]]
 
-// CHECK-DAG: body_[[bodyId]]: Cn %mem.M: _[[bodyVarId:[0-9]+]] = {
-// CHECK-DAG: _[[addIterId:[0-9]+]]: i32 = Wrap_add (0:nat, 4294967296:nat) (1:i32, _[[iterId]]);
-// CHECK-DAG: _[[addAccId:[0-9]+]]: i32 = Wrap_add (0:nat, 4294967296:nat) (_[[accId]], _[[iterId]]);
+// CHECK-DAG: body_[[bodyId]]: .Cn %mem.M: _[[bodyVarId:[0-9]+]] = {
+// CHECK-DAG: _[[addIterId:[0-9]+]]: (%Int 4294967296) = %Wrap_add (0:.Nat, 4294967296:.Nat) (1:(%Int 4294967296), _[[iterId]]);
+// CHECK-DAG: _[[addAccId:[0-9]+]]: (%Int 4294967296) = %Wrap_add (0:.Nat, 4294967296:.Nat) (_[[accId]], _[[iterId]]);
 // CHECK-DAG: _[[appLoopIdBody:[0-9]+]]: ⊥:★ = loop_[[loopId]] (@_[[bodyVarId]], _[[addIterId]], _[[addAccId]]);
-// CHECK-DAG: λ@(0:i1) _[[appLoopIdBody]]
+// CHECK-DAG: _[[appLoopIdBody]]

--- a/lit/main_loop_nom.thorin
+++ b/lit/main_loop_nom.thorin
@@ -30,25 +30,25 @@
 };
 
 
-// CHECK-DAG: main: .Cn [%mem.M, (%Int 4294967296), %mem.Ptr (%mem.Ptr ((%Int 256), 0:.Nat), 0:.Nat), .Cn [%mem.M, (%Int 4294967296)]]: (_[[memId:[0-9]+]], _[[argcId:[0-9]+]], _{{[0-9]+}}, _[[returnId:[0-9]+]]) = {
+// CHECK-DAG: main: .Cn [%mem.M, (%Int 4294967296), %mem.Ptr (%mem.Ptr ((%Int 256), 0:.Nat), 0:.Nat), .Cn [%mem.M, (%Int 4294967296)]], @(_[[memId:[0-9]+]], _[[argcId:[0-9]+]], _{{[0-9]+}}, _[[returnId:[0-9]+]]) = {
 // CHECK-DAG: _[[appLoopId:[0-9]+]]: ⊥:★ = loop_[[loopId:[0-9]+]] (_[[memId]], 0:(%Int 4294967296), 0:(%Int 4294967296));
 // CHECK-DAG: _[[appLoopId]]
 
-// CHECK-DAG: _[[exitEtaId:[0-9]+]]: .Cn [%mem.M, (%Int 4294967296)]: (_{{[0-9]+}}, _{{[0-9]+}}) = {
+// CHECK-DAG: _[[exitEtaId:[0-9]+]]: .Cn [%mem.M, (%Int 4294967296)], @(_{{[0-9]+}}, _{{[0-9]+}}) = {
 // CHECK-DAG:    _[[appReturnId:[0-9]+]]: ⊥:★ = _[[returnId]] @_[[exitEtaId]];
 // CHECK-DAG:    _[[appReturnId:[0-9]+]]
 
-// CHECK-DAG: loop_[[loopId]]: .Cn [%mem.M, (%Int 4294967296), (%Int 4294967296)]: (_[[loopMemId:[0-9]+]], _[[iterId:[0-9]+]], _[[accId:[0-9]+]]) = {
+// CHECK-DAG: loop_[[loopId]]: .Cn [%mem.M, (%Int 4294967296), (%Int 4294967296)], @(_[[loopMemId:[0-9]+]], _[[iterId:[0-9]+]], _[[accId:[0-9]+]]) = {
 // CHECK-DAG: _[[condId:[0-9]+]]: (%Int 2) = %core.icmp.XygLe 4294967296:.Nat (_[[iterId]], _[[argcId]]);
 // CHECK-DAG: _[[appCondId:[0-9]+]]: ⊥:★ = (exit_[[exitId:[0-9]+]], body_[[bodyId:[0-9]+]])#_[[condId]] _[[loopMemId]];
 // CHECK-DAG: _[[appCondId]]
 
-// CHECK-DAG: exit_[[exitId]]: .Cn %mem.M: _[[exitVarId:[0-9]+]] = {
-// CHECK-DAG: _[[appExitEtaId:[0-9]+]]: ⊥:★ = _[[exitEtaId]] (@_[[exitVarId]], _[[accId]]);
+// CHECK-DAG: exit_[[exitId]]: .Cn %mem.M, @_[[exitVarId:[0-9]+]] = {
+// CHECK-DAG: _[[appExitEtaId:[0-9]+]]: ⊥:★ = _[[exitEtaId]] (_[[exitVarId]], _[[accId]]);
 // CHECK-DAG: _[[appExitEtaId]]
 
-// CHECK-DAG: body_[[bodyId]]: .Cn %mem.M: _[[bodyVarId:[0-9]+]] = {
+// CHECK-DAG: body_[[bodyId]]: .Cn %mem.M, @_[[bodyVarId:[0-9]+]] = {
 // CHECK-DAG: _[[addIterId:[0-9]+]]: (%Int 4294967296) = %Wrap_add (0:.Nat, 4294967296:.Nat) (1:(%Int 4294967296), _[[iterId]]);
 // CHECK-DAG: _[[addAccId:[0-9]+]]: (%Int 4294967296) = %Wrap_add (0:.Nat, 4294967296:.Nat) (_[[accId]], _[[iterId]]);
-// CHECK-DAG: _[[appLoopIdBody:[0-9]+]]: ⊥:★ = loop_[[loopId]] (@_[[bodyVarId]], _[[addIterId]], _[[addAccId]]);
+// CHECK-DAG: _[[appLoopIdBody:[0-9]+]]: ⊥:★ = loop_[[loopId]] (_[[bodyVarId]], _[[addIterId]], _[[addAccId]]);
 // CHECK-DAG: _[[appLoopIdBody]]

--- a/lit/mem/alloc_load_store.thorin
+++ b/lit/mem/alloc_load_store.thorin
@@ -17,13 +17,13 @@
     return load
 };
 
-// CHECK-DAG: main: .Cn [%mem.M, (%Int 4294967296), %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (%Int 256)», 0:.Nat)», 0:.Nat), .Cn [%mem.M, (%Int 4294967296)]]: (_[[mainMemId:[0-9]+]], _[[argcId:[0-9]+]], _{{[0-9]+}}, _[[returnId:[0-9]+]]) = {
+// CHECK-DAG: main: .Cn [%mem.M, (%Int 4294967296), %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (%Int 256)», 0:.Nat)», 0:.Nat), .Cn [%mem.M, (%Int 4294967296)]], @(_[[mainMemId:[0-9]+]], _[[argcId:[0-9]+]], _{{[0-9]+}}, _[[returnId:[0-9]+]]) = {
 // CHECK-DAG: _[[appMSlotId:[0-9]+]]: [%mem.M, %mem.Ptr ((%Int 4294967296), 0:.Nat)] = %mem.malloc ((%Int 4294967296), 0:.Nat) (_[[mainMemId]], 4:.Nat);
 // CHECK-DAG: _[[appStoreId:[0-9]+]]: %mem.M = %mem.store ((%Int 4294967296), 0:.Nat) (_[[appMSlotId]]#0:(%Int 2), _[[appMSlotId]]#1:(%Int 2), _[[argcId]]);
 // CHECK-DAG: _[[appLoadId:[0-9]+]]: [%mem.M, (%Int 4294967296)] = %mem.load ((%Int 4294967296), 0:.Nat) (_[[appStoreId]], _[[appMSlotId]]#1:(%Int 2));
 // CHECK-DAG: _[[appExitId:[0-9]+]]: ⊥:★ = _[[exitId:[0-9]+]] _[[appLoadId]];
 // CHECK-DAG: _[[appExitId]]
 
-// CHECK-DAG: _[[exitId]]: .Cn [%mem.M, (%Int 4294967296)]: (_{{[0-9]+}}, _{{[0-9]+}}) = {
+// CHECK-DAG: _[[exitId]]: .Cn [%mem.M, (%Int 4294967296)], @(_{{[0-9]+}}, _{{[0-9]+}}) = {
 // CHECK-DAG: _[[appReturnId:[0-9]+]]: ⊥:★ = _[[returnId]] @_[[exitId]];
 // CHECK-DAG: _[[appReturnId]]

--- a/lit/mem/alloc_load_store.thorin
+++ b/lit/mem/alloc_load_store.thorin
@@ -17,13 +17,13 @@
     return load
 };
 
-// CHECK-DAG: main_[[mainId:[0-9]+]]: Cn [%mem.M, i32, %mem.Ptr («⊤:nat; %mem.Ptr («⊤:nat; i8», 0:nat)», 0:nat), Cn [%mem.M, i32]]: (_[[mainMemId:[0-9]+]], _[[argcId:[0-9]+]], _{{[0-9]+}}, _[[returnId:[0-9]+]]) = {
-// CHECK-DAG: _[[appMSlotId:[0-9]+]]: [%mem.M, %mem.Ptr (i32, 0:nat)] = %mem.malloc (i32, 0:nat) (_[[mainMemId]], 4:nat);
-// CHECK-DAG: _[[appStoreId:[0-9]+]]: %mem.M = %mem.store (i32, 0:nat) (_[[appMSlotId]]#0:i1, _[[appMSlotId]]#1:i1, _[[argcId]]);
-// CHECK-DAG: _[[appLoadId:[0-9]+]]: [%mem.M, i32] = %mem.load (i32, 0:nat) (_[[appStoreId]], _[[appMSlotId]]#1:i1);
+// CHECK-DAG: main: .Cn [%mem.M, (%Int 4294967296), %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (%Int 256)», 0:.Nat)», 0:.Nat), .Cn [%mem.M, (%Int 4294967296)]]: (_[[mainMemId:[0-9]+]], _[[argcId:[0-9]+]], _{{[0-9]+}}, _[[returnId:[0-9]+]]) = {
+// CHECK-DAG: _[[appMSlotId:[0-9]+]]: [%mem.M, %mem.Ptr ((%Int 4294967296), 0:.Nat)] = %mem.malloc ((%Int 4294967296), 0:.Nat) (_[[mainMemId]], 4:.Nat);
+// CHECK-DAG: _[[appStoreId:[0-9]+]]: %mem.M = %mem.store ((%Int 4294967296), 0:.Nat) (_[[appMSlotId]]#0:(%Int 2), _[[appMSlotId]]#1:(%Int 2), _[[argcId]]);
+// CHECK-DAG: _[[appLoadId:[0-9]+]]: [%mem.M, (%Int 4294967296)] = %mem.load ((%Int 4294967296), 0:.Nat) (_[[appStoreId]], _[[appMSlotId]]#1:(%Int 2));
 // CHECK-DAG: _[[appExitId:[0-9]+]]: ⊥:★ = _[[exitId:[0-9]+]] _[[appLoadId]];
-// CHECK-DAG: λ@(0:i1) _[[appExitId]]
+// CHECK-DAG: _[[appExitId]]
 
-// CHECK-DAG: _[[exitId]]: Cn [%mem.M, i32]: (_{{[0-9]+}}, _{{[0-9]+}}) = {
+// CHECK-DAG: _[[exitId]]: .Cn [%mem.M, (%Int 4294967296)]: (_{{[0-9]+}}, _{{[0-9]+}}) = {
 // CHECK-DAG: _[[appReturnId:[0-9]+]]: ⊥:★ = _[[returnId]] @_[[exitId]];
-// CHECK-DAG: λ@(0:i1) _[[appReturnId]]
+// CHECK-DAG: _[[appReturnId]]

--- a/lit/mem/malloc_load_store.thorin
+++ b/lit/mem/malloc_load_store.thorin
@@ -17,13 +17,13 @@
     return load
 };
 
-// CHECK-DAG: main: .Cn [%mem.M, (%Int 4294967296), %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (%Int 256)», 0:.Nat)», 0:.Nat), .Cn [%mem.M, (%Int 4294967296)]]: (_[[mainMemId:[0-9]+]], _[[argcId:[0-9]+]], _{{[0-9]+}}, _[[returnId:[0-9]+]]) = {
+// CHECK-DAG: main: .Cn [%mem.M, (%Int 4294967296), %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (%Int 256)», 0:.Nat)», 0:.Nat), .Cn [%mem.M, (%Int 4294967296)]], @(_[[mainMemId:[0-9]+]], _[[argcId:[0-9]+]], _{{[0-9]+}}, _[[returnId:[0-9]+]]) = {
 // CHECK-DAG: _[[appMSlotId:[0-9]+]]: [%mem.M, %mem.Ptr ((%Int 4294967296), 0:.Nat)] = %mem.malloc ((%Int 4294967296), 0:.Nat) (_[[mainMemId]], 4:.Nat);
 // CHECK-DAG: _[[appStoreId:[0-9]+]]: %mem.M = %mem.store ((%Int 4294967296), 0:.Nat) (_[[appMSlotId]]#0:(%Int 2), _[[appMSlotId]]#1:(%Int 2), _[[argcId]]);
 // CHECK-DAG: _[[appLoadId:[0-9]+]]: [%mem.M, (%Int 4294967296)] = %mem.load ((%Int 4294967296), 0:.Nat) (_[[appStoreId]], _[[appMSlotId]]#1:(%Int 2));
 // CHECK-DAG: _[[appExitId:[0-9]+]]: ⊥:★ = _[[exitId:[0-9]+]] _[[appLoadId]];
 // CHECK-DAG: _[[appExitId]]
 
-// CHECK-DAG: _[[exitId]]: .Cn [%mem.M, (%Int 4294967296)]: (_{{[0-9]+}}, _{{[0-9]+}}) = {
+// CHECK-DAG: _[[exitId]]: .Cn [%mem.M, (%Int 4294967296)], @(_{{[0-9]+}}, _{{[0-9]+}}) = {
 // CHECK-DAG: _[[appReturnId:[0-9]+]]: ⊥:★ = _[[returnId]] @_[[exitId]];
 // CHECK-DAG: _[[appReturnId]]

--- a/lit/mem/malloc_load_store.thorin
+++ b/lit/mem/malloc_load_store.thorin
@@ -17,13 +17,13 @@
     return load
 };
 
-// CHECK-DAG: main_[[mainId:[0-9]+]]: Cn [%mem.M, i32, %mem.Ptr («⊤:nat; %mem.Ptr («⊤:nat; i8», 0:nat)», 0:nat), Cn [%mem.M, i32]]: (_[[mainMemId:[0-9]+]], _[[argcId:[0-9]+]], _{{[0-9]+}}, _[[returnId:[0-9]+]]) = {
-// CHECK-DAG: _[[appMSlotId:[0-9]+]]: [%mem.M, %mem.Ptr (i32, 0:nat)] = %mem.malloc (i32, 0:nat) (_[[mainMemId]], 4:nat);
-// CHECK-DAG: _[[appStoreId:[0-9]+]]: %mem.M = %mem.store (i32, 0:nat) (_[[appMSlotId]]#0:i1, _[[appMSlotId]]#1:i1, _[[argcId]]);
-// CHECK-DAG: _[[appLoadId:[0-9]+]]: [%mem.M, i32] = %mem.load (i32, 0:nat) (_[[appStoreId]], _[[appMSlotId]]#1:i1);
+// CHECK-DAG: main: .Cn [%mem.M, (%Int 4294967296), %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (%Int 256)», 0:.Nat)», 0:.Nat), .Cn [%mem.M, (%Int 4294967296)]]: (_[[mainMemId:[0-9]+]], _[[argcId:[0-9]+]], _{{[0-9]+}}, _[[returnId:[0-9]+]]) = {
+// CHECK-DAG: _[[appMSlotId:[0-9]+]]: [%mem.M, %mem.Ptr ((%Int 4294967296), 0:.Nat)] = %mem.malloc ((%Int 4294967296), 0:.Nat) (_[[mainMemId]], 4:.Nat);
+// CHECK-DAG: _[[appStoreId:[0-9]+]]: %mem.M = %mem.store ((%Int 4294967296), 0:.Nat) (_[[appMSlotId]]#0:(%Int 2), _[[appMSlotId]]#1:(%Int 2), _[[argcId]]);
+// CHECK-DAG: _[[appLoadId:[0-9]+]]: [%mem.M, (%Int 4294967296)] = %mem.load ((%Int 4294967296), 0:.Nat) (_[[appStoreId]], _[[appMSlotId]]#1:(%Int 2));
 // CHECK-DAG: _[[appExitId:[0-9]+]]: ⊥:★ = _[[exitId:[0-9]+]] _[[appLoadId]];
-// CHECK-DAG: λ@(0:i1) _[[appExitId]]
+// CHECK-DAG: _[[appExitId]]
 
-// CHECK-DAG: _[[exitId]]: Cn [%mem.M, i32]: (_{{[0-9]+}}, _{{[0-9]+}}) = {
+// CHECK-DAG: _[[exitId]]: .Cn [%mem.M, (%Int 4294967296)]: (_{{[0-9]+}}, _{{[0-9]+}}) = {
 // CHECK-DAG: _[[appReturnId:[0-9]+]]: ⊥:★ = _[[returnId]] @_[[exitId]];
-// CHECK-DAG: λ@(0:i1) _[[appReturnId]]
+// CHECK-DAG: _[[appReturnId]]

--- a/lit/mem/mslot_load_store.thorin
+++ b/lit/mem/mslot_load_store.thorin
@@ -17,13 +17,13 @@
     return load
 };
 
-// CHECK-DAG: main: .Cn [%mem.M, (%Int 4294967296), %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (%Int 256)», 0:.Nat)», 0:.Nat), .Cn [%mem.M, (%Int 4294967296)]]: (_[[mainMemId:[0-9]+]], _[[argcId:[0-9]+]], _{{[0-9]+}}, _[[returnId:[0-9]+]]) = {
+// CHECK-DAG: .lam .extern main: .Cn [%mem.M, (%Int 4294967296), %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (%Int 256)», 0:.Nat)», 0:.Nat), .Cn [%mem.M, (%Int 4294967296)]], @(_[[mainMemId:[0-9]+]], _[[argcId:[0-9]+]], _{{[0-9]+}}, _[[returnId:[0-9]+]]) = {
 // CHECK-DAG: _[[appMSlotId:[0-9]+]]: [%mem.M, %mem.Ptr ((%Int 4294967296), 0:.Nat)] = %mem.mslot ((%Int 4294967296), 0:.Nat) (_[[mainMemId]], 4:.Nat, 0:.Nat);
 // CHECK-DAG: _[[appStoreId:[0-9]+]]: %mem.M = %mem.store ((%Int 4294967296), 0:.Nat) (_[[appMSlotId]]#0:(%Int 2), _[[appMSlotId]]#1:(%Int 2), _[[argcId]]);
 // CHECK-DAG: _[[appLoadId:[0-9]+]]: [%mem.M, (%Int 4294967296)] = %mem.load ((%Int 4294967296), 0:.Nat) (_[[appStoreId]], _[[appMSlotId]]#1:(%Int 2));
 // CHECK-DAG: _[[appExitId:[0-9]+]]: ⊥:★ = _[[exitId:[0-9]+]] _[[appLoadId]];
 // CHECK-DAG: _[[appExitId]]
 
-// CHECK-DAG: _[[exitId]]: .Cn [%mem.M, (%Int 4294967296)]: (_{{[0-9]+}}, _{{[0-9]+}}) = {
+// CHECK-DAG: .lam _[[exitId]]: .Cn [%mem.M, (%Int 4294967296)], @(_{{[0-9]+}}, _{{[0-9]+}}) = {
 // CHECK-DAG: _[[appReturnId:[0-9]+]]: ⊥:★ = _[[returnId]] @_[[exitId]];
 // CHECK-DAG: _[[appReturnId]]

--- a/lit/mem/mslot_load_store.thorin
+++ b/lit/mem/mslot_load_store.thorin
@@ -17,13 +17,13 @@
     return load
 };
 
-// CHECK-DAG: main_[[mainId:[0-9]+]]: Cn [%mem.M, i32, %mem.Ptr («⊤:nat; %mem.Ptr («⊤:nat; i8», 0:nat)», 0:nat), Cn [%mem.M, i32]]: (_[[mainMemId:[0-9]+]], _[[argcId:[0-9]+]], _{{[0-9]+}}, _[[returnId:[0-9]+]]) = {
-// CHECK-DAG: _[[appMSlotId:[0-9]+]]: [%mem.M, %mem.Ptr (i32, 0:nat)] = %mem.mslot (i32, 0:nat) (_[[mainMemId]], 4:nat, 0:nat);
-// CHECK-DAG: _[[appStoreId:[0-9]+]]: %mem.M = %mem.store (i32, 0:nat) (_[[appMSlotId]]#0:i1, _[[appMSlotId]]#1:i1, _[[argcId]]);
-// CHECK-DAG: _[[appLoadId:[0-9]+]]: [%mem.M, i32] = %mem.load (i32, 0:nat) (_[[appStoreId]], _[[appMSlotId]]#1:i1);
+// CHECK-DAG: main: .Cn [%mem.M, (%Int 4294967296), %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (%Int 256)», 0:.Nat)», 0:.Nat), .Cn [%mem.M, (%Int 4294967296)]]: (_[[mainMemId:[0-9]+]], _[[argcId:[0-9]+]], _{{[0-9]+}}, _[[returnId:[0-9]+]]) = {
+// CHECK-DAG: _[[appMSlotId:[0-9]+]]: [%mem.M, %mem.Ptr ((%Int 4294967296), 0:.Nat)] = %mem.mslot ((%Int 4294967296), 0:.Nat) (_[[mainMemId]], 4:.Nat, 0:.Nat);
+// CHECK-DAG: _[[appStoreId:[0-9]+]]: %mem.M = %mem.store ((%Int 4294967296), 0:.Nat) (_[[appMSlotId]]#0:(%Int 2), _[[appMSlotId]]#1:(%Int 2), _[[argcId]]);
+// CHECK-DAG: _[[appLoadId:[0-9]+]]: [%mem.M, (%Int 4294967296)] = %mem.load ((%Int 4294967296), 0:.Nat) (_[[appStoreId]], _[[appMSlotId]]#1:(%Int 2));
 // CHECK-DAG: _[[appExitId:[0-9]+]]: ⊥:★ = _[[exitId:[0-9]+]] _[[appLoadId]];
-// CHECK-DAG: λ@(0:i1) _[[appExitId]]
+// CHECK-DAG: _[[appExitId]]
 
-// CHECK-DAG: _[[exitId]]: Cn [%mem.M, i32]: (_{{[0-9]+}}, _{{[0-9]+}}) = {
+// CHECK-DAG: _[[exitId]]: .Cn [%mem.M, (%Int 4294967296)]: (_{{[0-9]+}}, _{{[0-9]+}}) = {
 // CHECK-DAG: _[[appReturnId:[0-9]+]]: ⊥:★ = _[[returnId]] @_[[exitId]];
-// CHECK-DAG: λ@(0:i1) _[[appReturnId]]
+// CHECK-DAG: _[[appReturnId]]

--- a/lit/mem/slot_load_store.thorin
+++ b/lit/mem/slot_load_store.thorin
@@ -17,10 +17,10 @@
     return load
 };
 
-// CHECK-DAG: main_[[mainId:[0-9]+]]: Cn [%mem.M, i32, %mem.Ptr («⊤:nat; %mem.Ptr («⊤:nat; i8», 0:nat)», 0:nat), Cn [%mem.M, i32]]: (_[[mainMemId:[0-9]+]], _[[argcId:[0-9]+]], _{{[0-9]+}}, _[[returnId:[0-9]+]]) = {
+// CHECK-DAG: main: .Cn [%mem.M, (%Int 4294967296), %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (%Int 256)», 0:.Nat)», 0:.Nat), .Cn [%mem.M, (%Int 4294967296)]]: (_[[mainMemId:[0-9]+]], _[[argcId:[0-9]+]], _{{[0-9]+}}, _[[returnId:[0-9]+]]) = {
 // CHECK-DAG: _[[appExitId:[0-9]+]]: ⊥:★ = _[[exitId:[0-9]+]] (_[[mainMemId]], _[[argcId]]);
-// CHECK-DAG: λ@(0:i1) _[[appExitId]]
+// CHECK-DAG: _[[appExitId]]
 
-// CHECK-DAG: _[[exitId]]: Cn [%mem.M, i32]: (_{{[0-9]+}}, _{{[0-9]+}}) = {
+// CHECK-DAG: _[[exitId]]: .Cn [%mem.M, (%Int 4294967296)]: (_{{[0-9]+}}, _{{[0-9]+}}) = {
 // CHECK-DAG: _[[appReturnId:[0-9]+]]: ⊥:★ = _[[returnId]] @_[[exitId]];
-// CHECK-DAG: λ@(0:i1) _[[appReturnId]]
+// CHECK-DAG: _[[appReturnId]]

--- a/lit/mem/slot_load_store.thorin
+++ b/lit/mem/slot_load_store.thorin
@@ -17,10 +17,10 @@
     return load
 };
 
-// CHECK-DAG: main: .Cn [%mem.M, (%Int 4294967296), %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (%Int 256)», 0:.Nat)», 0:.Nat), .Cn [%mem.M, (%Int 4294967296)]]: (_[[mainMemId:[0-9]+]], _[[argcId:[0-9]+]], _{{[0-9]+}}, _[[returnId:[0-9]+]]) = {
+// CHECK-DAG: .lam .extern main: .Cn [%mem.M, (%Int 4294967296), %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (%Int 256)», 0:.Nat)», 0:.Nat), .Cn [%mem.M, (%Int 4294967296)]], @(_[[mainMemId:[0-9]+]], _[[argcId:[0-9]+]], _{{[0-9]+}}, _[[returnId:[0-9]+]]) = {
 // CHECK-DAG: _[[appExitId:[0-9]+]]: ⊥:★ = _[[exitId:[0-9]+]] (_[[mainMemId]], _[[argcId]]);
 // CHECK-DAG: _[[appExitId]]
 
-// CHECK-DAG: _[[exitId]]: .Cn [%mem.M, (%Int 4294967296)]: (_{{[0-9]+}}, _{{[0-9]+}}) = {
+// CHECK-DAG: .lam _[[exitId]]: .Cn [%mem.M, (%Int 4294967296)], @(_{{[0-9]+}}, _{{[0-9]+}}) = {
 // CHECK-DAG: _[[appReturnId:[0-9]+]]: ⊥:★ = _[[returnId]] @_[[exitId]];
 // CHECK-DAG: _[[appReturnId]]

--- a/lit/parse_output_parse.thorin
+++ b/lit/parse_output_parse.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -e thorin %s -e ll -o %t > %t.thorin && %thorin -e thorin %t.thorin -e ll -o %t | FileCheck %s
+// RUN: %thorin -e thorin %s > %t.thorin && %thorin -e thorin %t.thorin -e ll -o %t | FileCheck %s
 // RUN: clang %t.ll -o %t -Wno-override-module
 // RUN: %t ; test $? -eq 1
 // RUN: %t 1 2 3 ; test $? -eq 4
@@ -7,15 +7,19 @@
 
 .import mem;
 
-.lam .extern main: .Cn [mem : %mem.M, argc : %Int 4294967296, argv : %mem.Ptr (%mem.Ptr (%Int 256, 0:.Nat), 0:.Nat), return : .Cn [%mem.M, %Int 4294967296]]: (var0, var1, var2, var3) = {
+.lam .extern main: .Cn [mem : %mem.M, argc : %Int 4294967296, argv : %mem.Ptr (%mem.Ptr (%Int 256, 0:.Nat), 0:.Nat), return : .Cn [%mem.M, %Int 4294967296]], @(var0, var1, var2, var3) = {
     0: (%Int 2),
-    return (var0, argc)
+    .lam single_arg_parse_test: .Cn %mem.M, @mem = {
+        0: (%Int 2),
+        return (mem, argc)
+    };
+    single_arg_parse_test var0
 };
 
-// CHECK-DAG: .lam .extern main: .Cn [%mem.M, (%Int 4294967296), %mem.Ptr (%mem.Ptr ((%Int 256), 0:.Nat), 0:.Nat), .Cn [%mem.M, (%Int 4294967296)]]: (_[[memId:[_0-9]*]], _[[argcId:[_0-9]*]], _{{[_0-9]*}}, _[[returnId:[_0-9]*]]) = {
+// CHECK-DAG: .lam .extern main: .Cn [%mem.M, (%Int 4294967296), %mem.Ptr (%mem.Ptr ((%Int 256), 0:.Nat), 0:.Nat), .Cn [%mem.M, (%Int 4294967296)]], @(_[[memId:[_0-9]*]], _[[argcId:[_0-9]*]], _{{[_0-9]*}}, _[[returnId:[_0-9]*]]) = {
 // CHECK-DAG: _[[appId:[_0-9]*]]: ⊥:★ = _[[returnEtaId:[_0-9]*]] (_[[memId]], _[[argcId]]);
 // CHECK-DAG: _[[appId]]
 
-// CHECK-DAG: .lam _[[returnEtaId]]: .Cn [%mem.M, (%Int 4294967296)]: (_{{[_0-9]*}}, _{{[_0-9]*}}) = {
+// CHECK-DAG: .lam _[[returnEtaId]]: .Cn [%mem.M, (%Int 4294967296)], @(_{{[_0-9]*}}, _{{[_0-9]*}}) = {
 // CHECK-DAG: _[[retAppId:[_0-9]*]]: ⊥:★ = _[[returnId]] @_[[returnEtaId]];
 // CHECK-DAG: _[[retAppId]]

--- a/lit/parse_output_parse.thorin
+++ b/lit/parse_output_parse.thorin
@@ -1,0 +1,21 @@
+// RUN: rm -f %t.ll ; \
+// RUN: %thorin -e thorin %s -e ll -o %t > %t.thorin && %thorin -e thorin %t.thorin -e ll -o %t | FileCheck %s
+// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %t ; test $? -eq 1
+// RUN: %t 1 2 3 ; test $? -eq 4
+// RUN: %t a b c d e f ; test $? -eq 7
+
+.import mem;
+
+.lam .extern main: .Cn [mem : %mem.M, argc : %Int 4294967296, argv : %mem.Ptr (%mem.Ptr (%Int 256, 0:.Nat), 0:.Nat), return : .Cn [%mem.M, %Int 4294967296]]: (var0, var1, var2, var3) = {
+    0: (%Int 2),
+    return (var0, argc)
+};
+
+// CHECK-DAG: .lam .extern main: .Cn [%mem.M, (%Int 4294967296), %mem.Ptr (%mem.Ptr ((%Int 256), 0:.Nat), 0:.Nat), .Cn [%mem.M, (%Int 4294967296)]]: (_[[memId:[_0-9]*]], _[[argcId:[_0-9]*]], _{{[_0-9]*}}, _[[returnId:[_0-9]*]]) = {
+// CHECK-DAG: _[[appId:[_0-9]*]]: ⊥:★ = _[[returnEtaId:[_0-9]*]] (_[[memId]], _[[argcId]]);
+// CHECK-DAG: _[[appId]]
+
+// CHECK-DAG: .lam _[[returnEtaId]]: .Cn [%mem.M, (%Int 4294967296)]: (_{{[_0-9]*}}, _{{[_0-9]*}}) = {
+// CHECK-DAG: _[[retAppId:[_0-9]*]]: ⊥:★ = _[[returnId]] @_[[returnEtaId]];
+// CHECK-DAG: _[[retAppId]]

--- a/lit/ret_argc.thorin
+++ b/lit/ret_argc.thorin
@@ -12,10 +12,10 @@
     return (mem, argc)
 };
 
-// CHECK-DAG: main_[[mainId:[0-9]*]]: Cn [%mem.M, i32, %mem.Ptr (%mem.Ptr (i8, 0:nat), 0:nat), Cn [%mem.M, i32]]: (_[[memId:[0-9]*]], _[[argcId:[0-9]*]], _{{[0-9]*}}, _[[returnId:[0-9]*]]) = {
+// CHECK-DAG: main: .Cn [%mem.M, (%Int 4294967296), %mem.Ptr (%mem.Ptr ((%Int 256), 0:.Nat), 0:.Nat), .Cn [%mem.M, (%Int 4294967296)]]: (_[[memId:[0-9]*]], _[[argcId:[0-9]*]], _{{[0-9]*}}, _[[returnId:[0-9]*]]) = {
 // CHECK-DAG: _[[appId:[0-9]*]]: ⊥:★ = _[[returnEtaId:[0-9]*]] (_[[memId]], _[[argcId]]);
-// CHECK-DAG: λ@(0:i1) _[[appId]]
+// CHECK-DAG: _[[appId]]
 
-// CHECK-DAG: _[[returnEtaId]]: Cn [%mem.M, i32]: (_{{[0-9]*}}, _{{[0-9]*}}) = {
+// CHECK-DAG: _[[returnEtaId]]: .Cn [%mem.M, (%Int 4294967296)]: (_{{[0-9]*}}, _{{[0-9]*}}) = {
 // CHECK-DAG: _[[retAppId:[0-9]*]]: ⊥:★ = _[[returnId]] @_[[returnEtaId]];
-// CHECK-DAG: λ@(0:i1) _[[retAppId]]
+// CHECK-DAG: _[[retAppId]]

--- a/lit/ret_argc.thorin
+++ b/lit/ret_argc.thorin
@@ -12,10 +12,10 @@
     return (mem, argc)
 };
 
-// CHECK-DAG: main: .Cn [%mem.M, (%Int 4294967296), %mem.Ptr (%mem.Ptr ((%Int 256), 0:.Nat), 0:.Nat), .Cn [%mem.M, (%Int 4294967296)]]: (_[[memId:[0-9]*]], _[[argcId:[0-9]*]], _{{[0-9]*}}, _[[returnId:[0-9]*]]) = {
+// CHECK-DAG: main: .Cn [%mem.M, (%Int 4294967296), %mem.Ptr (%mem.Ptr ((%Int 256), 0:.Nat), 0:.Nat), .Cn [%mem.M, (%Int 4294967296)]], @(_[[memId:[0-9]*]], _[[argcId:[0-9]*]], _{{[0-9]*}}, _[[returnId:[0-9]*]]) = {
 // CHECK-DAG: _[[appId:[0-9]*]]: ⊥:★ = _[[returnEtaId:[0-9]*]] (_[[memId]], _[[argcId]]);
 // CHECK-DAG: _[[appId]]
 
-// CHECK-DAG: _[[returnEtaId]]: .Cn [%mem.M, (%Int 4294967296)]: (_{{[0-9]*}}, _{{[0-9]*}}) = {
+// CHECK-DAG: _[[returnEtaId]]: .Cn [%mem.M, (%Int 4294967296)], @(_{{[0-9]*}}, _{{[0-9]*}}) = {
 // CHECK-DAG: _[[retAppId:[0-9]*]]: ⊥:★ = _[[returnId]] @_[[returnEtaId]];
 // CHECK-DAG: _[[retAppId]]

--- a/thorin/error.cpp
+++ b/thorin/error.cpp
@@ -20,7 +20,7 @@ void ErrorHandler::index_out_of_range(const Def* arity, const Def* index) {
 }
 
 void ErrorHandler::ill_typed_app(const Def* callee, const Def* arg) {
-    err(arg->loc(), "cannot pass argument '{} of type '{}' to '{}' of domain '{}'", arg, arg->type(), callee,
+    err(arg->loc(), "cannot pass argument '{}' of type '{}' to '{}' of domain '{}'", arg, arg->type(), callee,
         callee->type()->as<Pi>()->dom());
 }
 

--- a/thorin/fe/parser.cpp
+++ b/thorin/fe/parser.cpp
@@ -270,7 +270,7 @@ const Def* Parser::parse_arr() {
     expect(Tok::Tag::D_quote_r, "closing delimiter of an array");
     pop();
 
-    if (arr) return arr->set_body(body);
+    if (arr) return arr->set_body(body)->set_type(body->inf_type());
     return world().arr(shape, body, track);
 }
 
@@ -403,7 +403,9 @@ const Def* Parser::parse_pi() {
     for (auto [sym, i] : binders) insert(sym, pi->var(i)); // TODO location
 
     expect(Tok::Tag::T_arrow, "dependent function type");
-    pi->set_codom(parse_expr("codomain of a dependent function type", Tok::Prec::Arrow));
+    auto codom = parse_expr("codomain of a dependent function type", Tok::Prec::Arrow);
+    pi->set_codom(codom);
+    pi->set_type(codom->inf_type());
     pi->set_dbg(track);
     pop();
     return pi;

--- a/thorin/fe/parser.h
+++ b/thorin/fe/parser.h
@@ -113,6 +113,8 @@ private:
         }
         expect(delim_r, std::string("closing delimiter of a ") + ctxt);
     }
+    
+    void parse_var_list(Binders&);
 
     // parse import statement
     void parse_import();

--- a/thorin/stream.cpp
+++ b/thorin/stream.cpp
@@ -185,8 +185,8 @@ void RecStreamer::run(const DepNode* node) {
         auto nom = noms.pop();
         os << std::endl << std::endl;
 
-        auto id = [&](auto* def) {
-            if (def->is_external() || !def->is_set()) return def->name();
+        auto id = [&](const Def* def) {
+            if (def->is_external() || (!def->is_set() && def->isa<Lam>())) return def->name();
             return def->unique_name();
         };
 
@@ -195,16 +195,13 @@ void RecStreamer::run(const DepNode* node) {
             if (def->isa<Sigma>()) return ".Sigma";
             if (def->isa<Arr>()) return ".Arr";
             if (def->isa<Pack>()) return ".pack";
-            if (auto pi = def->isa<Pi>()) {
-                if (pi->is_cn()) return ".Cn";
-                return ".Pi";
-            }
+            if (def->isa<Pi>()) return ".Pi";
 
             assert(false && "unknown nominal");
         };
 
         auto nom_op0 = [&](const Def* def) -> std::ostream& {
-            if (auto lam = def->isa<Lam>()) return os;
+            if (def->isa<Lam>()) return os;
             if (auto sig = def->isa<Sigma>()) return print(os, ", {}", sig->num_ops());
             if (auto arr = def->isa<Arr>()) return print(os, ", {}", arr->shape());
             if (auto pack = def->isa<Pack>()) return print(os, ", {}", pack->shape());

--- a/thorin/world.cpp
+++ b/thorin/world.cpp
@@ -201,8 +201,9 @@ World::~World() {
 
 World World::stub() {
     World w(name());
-    w.ostream_ = ostream_;
-    w.state_   = state_;
+    w.ostream_                 = ostream_;
+    w.state_                   = state_;
+    w.data_.imported_dialects_ = data_.imported_dialects_;
 
     // bring dialects' axioms into new world.
     Rewriter rewriter{w};

--- a/thorin/world.h
+++ b/thorin/world.h
@@ -572,7 +572,6 @@ public:
         swap(w1.err_,      w2.err_);
         // clang-format on
 
-        swap(w1.data_.imported_dialects_, w2.data_.imported_dialects_);
         swap(w1.data_.univ_->world_, w2.data_.univ_->world_);
         assert(&w1.univ()->world() == &w1);
         assert(&w2.univ()->world() == &w2);

--- a/thorin/world.h
+++ b/thorin/world.h
@@ -3,6 +3,7 @@
 
 #include <sstream>
 #include <string>
+#include <string_view>
 
 #include "thorin/axiom.h"
 #include "thorin/config.h"
@@ -557,6 +558,9 @@ public:
     ErrorHandler* err() { return err_.get(); }
     ///@}
 
+    void add_imported(std::string_view name) { data_.imported_dialects_.emplace(name); }
+    const absl::flat_hash_set<std::string>& imported() const { return data_.imported_dialects_; }
+
     friend void swap(World& w1, World& w2) {
         using std::swap;
         // clang-format off
@@ -568,6 +572,7 @@ public:
         swap(w1.err_,      w2.err_);
         // clang-format on
 
+        swap(w1.data_.imported_dialects_, w2.data_.imported_dialects_);
         swap(w1.data_.univ_->world_, w2.data_.univ_->world_);
         assert(&w1.univ()->world() == &w1);
         assert(&w2.univ()->world() == &w2);
@@ -727,6 +732,7 @@ private:
         Externals externals_;
         Sea defs_;
         DefDefMap<DefArray> cache_;
+        absl::flat_hash_set<std::string> imported_dialects_;
     } data_;
 
     std::unique_ptr<Checker> checker_;


### PR DESCRIPTION
This should make most thorin output (that only uses known axioms) parsable by the frontend.
Very likely still a bunch of cases not correct...

To simplify outputting nom var names, the parser now supports reading a list of var names after the nom's type.
The proposed syntax (to disambiguate from ops) is `.lam name : type, @(var0, var1) = {..};`

Known issues:
- nominal sigmas are emitted as `.Sigma name : type, #ops, @(var,..) = { [..] };`, which cannot be parsed at the moment. To support this, we either need integrated special cases in `parse_nom` and `parse_def` (similar to `parse_sigma`), or great infer support (where even the types of the infer nodes are unknown until parsing the definition..)
