### PR TITLE
Add `make install` support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,13 +48,14 @@ include(CTest)
 if(BUILD_TESTING AND THORIN_BUILD_TESTING)
     include(GoogleTest)
     set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-    add_subdirectory(modules/googletest)
+    add_subdirectory(modules/googletest EXCLUDE_FROM_ALL)
 endif()
 
 set(ABSL_PROPAGATE_CXX_STD ON)
 set(ABSL_USE_EXTERNAL_GOOGLETEST ON)
+set(ABSL_ENABLE_INSTALL ON)
 add_subdirectory(modules/abseil-cpp)
-add_subdirectory(modules/lyra)
+add_subdirectory(modules/lyra EXCLUDE_FROM_ALL)
 
 add_subdirectory(thorin)
 add_subdirectory(cli)
@@ -71,3 +72,28 @@ if(THORIN_BUILD_DOCS)
         add_subdirectory(docs)
     endif()
 endif()
+
+include(CMakePackageConfigHelpers)
+
+write_basic_package_version_file(
+  "${PROJECT_BINARY_DIR}/thorin-config-version.cmake"
+  VERSION ${Thorin_VERSION}
+  COMPATIBILITY SameMajorVersion
+)
+
+set(THORIN_CMAKE_INSTALL_DIR lib/cmake/thorin)
+
+install(FILES cmake/Thorin.cmake DESTINATION ${THORIN_CMAKE_INSTALL_DIR})
+install(EXPORT install_exports FILE "thorin-targets.cmake" NAMESPACE thorin:: DESTINATION ${THORIN_CMAKE_INSTALL_DIR})
+
+configure_package_config_file(
+    ${PROJECT_SOURCE_DIR}/cmake/thorin-config.cmake.in
+    ${PROJECT_BINARY_DIR}/thorin-config.cmake
+    INSTALL_DESTINATION ${THORIN_CMAKE_INSTALL_DIR}
+)
+
+install(FILES
+  ${PROJECT_BINARY_DIR}/thorin-config.cmake
+  ${PROJECT_BINARY_DIR}/thorin-config-version.cmake
+  DESTINATION ${THORIN_CMAKE_INSTALL_DIR}
+)

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -2,3 +2,6 @@ add_executable(thorin
     main.cpp)
 
 target_link_libraries(thorin libthorin lyra)
+
+set_target_properties(thorin PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+install(TARGETS thorin EXPORT install_exports)

--- a/cmake/Thorin.cmake
+++ b/cmake/Thorin.cmake
@@ -2,24 +2,30 @@
 SET(THORIN_DIALECT_LIST    "" CACHE INTERNAL "THORIN_DIALECT_LIST") 
 SET(THORIN_DIALECT_LAYOUT  "" CACHE INTERNAL "THORIN_DIALECT_LAYOUT")
 
+if(NOT THORIN_TARGET_NAMESPACE)
+    set(THORIN_TARGET_NAMESPACE "")
+endif()
+
 function(add_thorin_dialect)
     set(DIALECT ${ARGV0})
     list(SUBLIST ARGV 1 -1 UNPARSED)
     cmake_parse_arguments(
         PARSED              # prefix of output variables
-        ""                  # list of names of the boolean arguments (only defined ones will be true)
+        "INSTALL"           # list of names of the boolean arguments (only defined ones will be true)
         "DIALECT"           # list of names of mono-valued arguments
         "SOURCES;DEPENDS"   # list of names of multi-valued arguments (output variables are lists)
         ${UNPARSED}         # arguments of the function to parse, here we take the all original ones
     )
 
-    list(TRANSFORM PARSED_DEPENDS       PREPEND ${CMAKE_CURRENT_BINARY_DIR}/../lib/thorin/ OUTPUT_VARIABLE DEPENDS_THORIN_FILES)
+    set(THORIN_LIB_DIR ${CMAKE_BINARY_DIR}/lib/thorin)
+
+    list(TRANSFORM PARSED_DEPENDS       PREPEND ${THORIN_LIB_DIR}/ OUTPUT_VARIABLE DEPENDS_THORIN_FILES)
     list(TRANSFORM DEPENDS_THORIN_FILES  APPEND .thorin)
     list(TRANSFORM PARSED_DEPENDS       PREPEND ${CMAKE_CURRENT_BINARY_DIR}/ OUTPUT_VARIABLE DEPENDS_HEADER_FILES)
     list(TRANSFORM DEPENDS_HEADER_FILES  APPEND .h)
 
     set(THORIN_FILE     ${CMAKE_CURRENT_SOURCE_DIR}/${DIALECT}/${DIALECT}.thorin)
-    set(THORIN_FILE_BIN ${CMAKE_CURRENT_BINARY_DIR}/../lib/thorin/${DIALECT}.thorin)
+    set(THORIN_FILE_LIB_DIR ${THORIN_LIB_DIR}/${DIALECT}.thorin)
     set(DIALECT_H       ${CMAKE_CURRENT_BINARY_DIR}/${DIALECT}.h)
     set(DIALECT_MD      ${CMAKE_CURRENT_BINARY_DIR}/${DIALECT}.md)
 
@@ -31,15 +37,15 @@ function(add_thorin_dialect)
     SET(THORIN_DIALECT_LAYOUT "${THORIN_DIALECT_LAYOUT}" CACHE INTERNAL "THORIN_DIALECT_LAYOUT")
 
     # copy dialect thorin file to lib/thorin/${DIALECT}.thorin
-    add_custom_command(OUTPUT ${THORIN_FILE_BIN}
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${THORIN_FILE} ${THORIN_FILE_BIN}
+    add_custom_command(OUTPUT ${THORIN_FILE_LIB_DIR}
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${THORIN_FILE} ${THORIN_FILE_LIB_DIR}
         DEPENDS ${THORIN_FILE} ${DEPENDS_THORIN_FILES}
     )
 
     add_custom_command(
         OUTPUT ${DIALECT_MD} ${DIALECT_H}
-        COMMAND thorin -e md -e h ${THORIN_FILE_BIN} -D ${CMAKE_CURRENT_BINARY_DIR}/../lib/thorin/
-        DEPENDS thorin ${THORIN_FILE_BIN}
+        COMMAND $<TARGET_FILE:${THORIN_TARGET_NAMESPACE}thorin> -e md -e h ${THORIN_FILE_LIB_DIR} -D ${THORIN_LIB_DIR}
+        DEPENDS ${THORIN_TARGET_NAMESPACE}thorin ${THORIN_FILE_LIB_DIR}
         COMMENT "Bootstrapping Thorin dialect '${DIALECT}' from '${THORIN_FILE}'"
     )
     add_custom_target(${DIALECT} ALL DEPENDS ${DIALECT_MD} ${DIALECT_H})
@@ -56,7 +62,15 @@ function(add_thorin_dialect)
             CXX_VISIBILITY_PRESET hidden
             VISIBILITY_INLINES_HIDDEN 1
             WINDOWS_EXPORT_ALL_SYMBOLS OFF
+            LIBRARY_OUTPUT_DIRECTORY ${THORIN_LIB_DIR}
     )
 
-    target_link_libraries(thorin_${DIALECT} libthorin)
+    target_link_libraries(thorin_${DIALECT} ${THORIN_TARGET_NAMESPACE}libthorin)
+
+    if(${PARSED_INSTALL})
+        install(TARGETS thorin_${DIALECT} EXPORT install_exports LIBRARY DESTINATION lib/thorin RUNTIME DESTINATION lib/thorin INCLUDES DESTINATION include)
+        install(FILES ${THORIN_FILE_LIB_DIR} DESTINATION lib/thorin)
+        install(FILES ${DIALECT_H} DESTINATION include/dialects)
+        install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${DIALECT} DESTINATION include/dialects FILES_MATCHING PATTERN *.h)
+    endif()
 endfunction()

--- a/cmake/thorin-config.cmake.in
+++ b/cmake/thorin-config.cmake.in
@@ -1,0 +1,8 @@
+@PACKAGE_INIT@
+
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
+
+include(../absl/abslConfig)
+include(thorin-targets)
+set(THORIN_TARGET_NAMESPACE "thorin::")
+include(Thorin)

--- a/dialects/CMakeLists.txt
+++ b/dialects/CMakeLists.txt
@@ -14,6 +14,7 @@ add_thorin_dialect(mem
         mem/mem.cpp
         mem/mem.h
         mem/normalizers.cpp
+    INSTALL
 )
 
 add_thorin_dialect(clos
@@ -32,6 +33,7 @@ add_thorin_dialect(clos
         clos/lower_typed_clos.cpp
     DEPENDS
         mem
+    INSTALL
 )
 
 add_thorin_dialect(core
@@ -44,6 +46,7 @@ add_thorin_dialect(core
     DEPENDS
         mem
         clos
+    INSTALL
 )
 
 add_thorin_dialect(affine
@@ -54,4 +57,5 @@ add_thorin_dialect(affine
         affine/passes/lower_for.h
     DEPENDS
         core
+    INSTALL
 )

--- a/thorin/CMakeLists.txt
+++ b/thorin/CMakeLists.txt
@@ -95,11 +95,15 @@ add_library(libthorin
 
 set_target_properties(libthorin PROPERTIES PREFIX "")
 
+get_target_property(libthorin_HEADERS libthorin SOURCES)
+list(FILTER libthorin_HEADERS INCLUDE REGEX ".*\.h")
+
 configure_file(config.h.in config.h)
-target_include_directories(libthorin PUBLIC 
-    ${CMAKE_CURRENT_BINARY_DIR}/.. # for config.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/..
-    ${PROJECT_SOURCE_DIR}/modules/half/include
+target_include_directories(libthorin PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/..> # for config.h
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..> # for thorin/*
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/modules/half/include>
+    $<INSTALL_INTERFACE:include>
 )
 target_link_libraries(libthorin 
     PUBLIC 
@@ -108,6 +112,13 @@ target_link_libraries(libthorin
         ${CMAKE_DL_LIBS}
 )
 
+target_compile_features(libthorin PUBLIC cxx_std_${CMAKE_CXX_STANDARD}) # make property public.
+
 if(MSVC AND BUILD_SHARED_LIBS)
     target_compile_definitions(libthorin PUBLIC ABSL_CONSUME_DLL)
 endif()
+
+install(TARGETS libthorin EXPORT install_exports INCLUDES DESTINATION include)
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} DESTINATION include FILES_MATCHING PATTERN "*.h")
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/config.h DESTINATION include/thorin)
+install(FILES ${PROJECT_SOURCE_DIR}/modules/half/include/half.hpp DESTINATION include)


### PR DESCRIPTION
I did not change the directory layout of thorin for now. Some things I'd preferably change, like the fact that we pollute the `include` folder with `dialects`. Also, we could remove some matching overhead if we had a single `include` folder, but it's not an incredible overhead.

This installs thorin to `CMAKE_INSTALL_PREFIX` with the following structure:
```
bin
\ thorin
include
\ absl
\ dialects
\ thorin
\ half.hpp
lib
\ cmake
  \ absl
    \ *.cmake
  \ thorin
    \ thorin-config.cmake
    \ thorin-config-version.cmake
    \ thorin-targets-[debug|release].cmake
    \ thorin-targets.cmake
    \ Thorin.cmake
\ thorin
  \ *.thorin
  \ libthorin_*.so
\ libabsl_*.so
\ libthorin.so
```

After installing, external dialects just need to find the package:
```
cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
project(dialect)

find_package(thorin)

add_thorin_dialect(dialect
    SOURCES
        dialect/dialect.h
        dialect/dialect.cpp
)
```
and use `cmake .. -Dthorin_DIR=<THORIN_INSTALL_PREFIX>/lib/cmake/thorin` to configure the project.

Other projects using thorin internally, such as Impala, could use `find_package(thorin)` and then link against `thorin::libthorin`.

One possible point of discussion is whether setting `set(ABSL_ENABLE_INSTALL ON)` really is a good idea, or whether we should instead list all targets that we transitively depend on manually, like so: `install(TARGETS absl_.. absl_.. EXPORT absl_export)`. With the current solution, Abseil complains, when `CMAKE_INSTALL_PREFIX` is not set to some local folder: `The default and system-level install directories are unsupported except in LTS   releases of Abseil.  Please set CMAKE_INSTALL_PREFIX to install Abseil in your   source or build tree directly.` Another option to silence that, is likely switching to a tagged version of Abseil?