### PR TITLE
remove -e/--emit option from cli

### DIFF
--- a/cmake/Thorin.cmake
+++ b/cmake/Thorin.cmake
@@ -97,7 +97,7 @@ function(add_thorin_dialect)
 
     add_custom_command(
         OUTPUT ${DIALECT_MD} ${DIALECT_H}
-        COMMAND $<TARGET_FILE:${THORIN_TARGET_NAMESPACE}thorin> -e md -e h ${THORIN_FILE_LIB_DIR} -D ${THORIN_LIB_DIR} --output-h ${DIALECT_H} --output-md ${DIALECT_MD}
+        COMMAND $<TARGET_FILE:${THORIN_TARGET_NAMESPACE}thorin> ${THORIN_FILE_LIB_DIR} -D ${THORIN_LIB_DIR} --output-h ${DIALECT_H} --output-md ${DIALECT_MD}
         DEPENDS ${THORIN_TARGET_NAMESPACE}thorin ${THORIN_FILE_LIB_DIR}
         COMMENT "Bootstrapping Thorin dialect '${DIALECT}' from '${THORIN_FILE}'"
     )

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -6,17 +6,6 @@
 
 \include "cli-help.md"
 
-## Emitters {#emitters}
-
-* `-e thorin` emits Thorin code again.
-* `-e h` emits a header file to be used to interface with a dialect in C++.
-* `-e md` emits the input formatted as [Markdown](https://www.doxygen.nl/manual/markdown.html).
-    * Single-line `/// xxx` comments will put `xxx` directly into the Markdown output.
-        You can put an optional space after the `///` that will be elided in the Markdown output.
-    * Everything else will be put verbatim within a [fenced code block](https://www.doxygen.nl/manual/markdown.html#md_fenced).
-* `-e dot` emit the Thorin program as a graph using [Graphviz' DOT language](https://graphviz.org/doc/info/lang.html).
-* `-e ll` compiles the Thorin code to [LLVM](https://llvm.org/docs/LangRef.html).
-
 ## Debugging Features {#clidebug}
 
 * You can increase the log level with `-V`.

--- a/docs/langref.md
+++ b/docs/langref.md
@@ -98,9 +98,12 @@ However, the terminal *Ax* also uses the shorthand rule *sym*.
 ### Comments
 
 In addition, the following comments are available:
-* `/* ... */` multi-line comment
-* `//` single-line comment
-* `///` single-line comment that is put into the Markdown output (see [Emitters](@ref emitters))
+* `/* ... */`: multi-line comment
+* `//`: single-line comment
+* `///`: single-line comment for [Markdown](https://www.doxygen.nl/manual/markdown.html) [output](@ref cli):
+    - Single-line `/// xxx` comments will put `xxx` directly into the Markdown output.
+        You can put an optional space after the `///` that will be elided in the Markdown output.
+    - Everything else will be put verbatim within a [fenced code block](https://www.doxygen.nl/manual/markdown.html#md_fenced).
 
 ## Grammar {#grammar}
 

--- a/lit/affine/dynamic_for.thorin
+++ b/lit/affine/dynamic_for.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d affine -e thorin %s -e ll -o %t --output-thorin - | FileCheck %s
+// RUN: %thorin -d affine %s --output-ll %t.ll --output-thorin - | FileCheck %s
 // RUN: clang %t.ll -o %t -Wno-override-module
 // RUN: %t 1 3 1; test $? -eq 3
 // RUN: %t 0 5 2 ; test $? -eq 6

--- a/lit/affine/for_2acc.thorin
+++ b/lit/affine/for_2acc.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d affine -e thorin %s -e ll -o %t --output-thorin - | FileCheck %s
+// RUN: %thorin -d affine %s --output-ll %t.ll --output-thorin - | FileCheck %s
 // RUN: clang %t.ll -o %t -Wno-override-module
 // RUN: %t ; test $? -eq 0
 // RUN: %t 1 2 3 ; test $? -eq 6

--- a/lit/affine/for_2acc_2types.thorin
+++ b/lit/affine/for_2acc_2types.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d affine -e thorin %s -e ll -o %t --output-thorin - | FileCheck %s
+// RUN: %thorin -d affine %s --output-ll %t.ll --output-thorin - | FileCheck %s
 // RUN: clang %t.ll -o %t -Wno-override-module
 // RUN: %t ; test $? -eq 0
 // RUN: %t 1 2 3 ; test $? -eq 6

--- a/lit/affine/for_2acc_real.thorin
+++ b/lit/affine/for_2acc_real.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d affine -e thorin %s -e ll -o %t --output-thorin - | FileCheck %s
+// RUN: %thorin -d affine %s --output-ll %t.ll --output-thorin - | FileCheck %s
 // RUN: clang %t.ll -o %t -Wno-override-module
 // RUN: %t ; test $? -eq 0
 // RUN: %t 1 2 3 ; test $? -eq 6

--- a/lit/affine/lower_for.thorin
+++ b/lit/affine/lower_for.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d affine -e thorin %s -e ll -o %t --output-thorin - | FileCheck %s
+// RUN: %thorin -d affine %s --output-ll %t.ll --output-thorin - | FileCheck %s
 // RUN: clang %t.ll -o %t -Wno-override-module
 // RUN: %t ; test $? -eq 0
 // RUN: %t 1 2 3 ; test $? -eq 6

--- a/lit/core/normalize_add.thorin
+++ b/lit/core/normalize_add.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -e thorin %s --output-thorin - | FileCheck %s
+// RUN: %thorin %s --output-thorin - | FileCheck %s
 
 .import core;
 

--- a/lit/core/normalize_and_ff.thorin
+++ b/lit/core/normalize_and_ff.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -e thorin %s -o %t --output-thorin - | FileCheck %s
+// RUN: %thorin %s --output-thorin - | FileCheck %s
 
 .import core;
 

--- a/lit/core/normalize_and_ff_tt.thorin
+++ b/lit/core/normalize_and_ff_tt.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -e thorin %s --output-thorin - | FileCheck %s
+// RUN: %thorin %s --output-thorin - | FileCheck %s
 
 .import core;
 

--- a/lit/core/normalize_and_icmps.thorin
+++ b/lit/core/normalize_and_icmps.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -e thorin %s --output-thorin - | FileCheck %s
+// RUN: %thorin %s --output-thorin - | FileCheck %s
 
 .import core;
 

--- a/lit/core/normalize_and_icmps_lit.thorin
+++ b/lit/core/normalize_and_icmps_lit.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -e thorin %s --output-thorin - | FileCheck %s
+// RUN: %thorin %s --output-thorin - | FileCheck %s
 
 .import core;
 

--- a/lit/core/normalize_and_tree.thorin
+++ b/lit/core/normalize_and_tree.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -e thorin %s -o %t --output-thorin - | FileCheck %s
+// RUN: %thorin %s --output-thorin - | FileCheck %s
 
 .import core;
 

--- a/lit/core/normalize_and_tt.thorin
+++ b/lit/core/normalize_and_tt.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -e thorin %s -o %t --output-thorin - | FileCheck %s
+// RUN: %thorin %s --output-thorin - | FileCheck %s
 
 .import core;
 

--- a/lit/core/normalize_and_tt_tt.thorin
+++ b/lit/core/normalize_and_tt_tt.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -e thorin %s --output-thorin - | FileCheck %s
+// RUN: %thorin %s --output-thorin - | FileCheck %s
 
 .import core;
 

--- a/lit/core/normalize_bitcast.thorin
+++ b/lit/core/normalize_bitcast.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -e thorin %s -o %t -e ll --output-thorin - | FileCheck %s
+// RUN: %thorin %s --output-ll %t.ll --output-thorin - | FileCheck %s
 // RUN: clang -c %t.ll -o %t -Wno-override-module
 
 .import core;

--- a/lit/core/normalize_icmp.thorin
+++ b/lit/core/normalize_icmp.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -e thorin %s --output-thorin - | FileCheck %s
+// RUN: %thorin %s --output-thorin - | FileCheck %s
 
 .import core;
 

--- a/lit/core/ret_add.thorin
+++ b/lit/core/ret_add.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -e thorin %s -e ll -o %t --output-thorin - | FileCheck %s
+// RUN: %thorin %s --output-ll %t.ll --output-thorin - | FileCheck %s
 // RUN: clang %t.ll -o %t -Wno-override-module
 // RUN: %t 1 2 ; test $? -eq 3
 // RUN: %t 4 5 ; test $? -eq 9

--- a/lit/core/ret_and.thorin
+++ b/lit/core/ret_and.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -e thorin %s -e ll -o %t --output-thorin - | FileCheck %s
+// RUN: %thorin %s --output-ll %t.ll --output-thorin - | FileCheck %s
 // RUN: clang %t.ll -o %t -Wno-override-module
 // RUN: %t 3 1 ; test $? -eq 1
 // RUN: %t 7 5 ; test $? -eq 5

--- a/lit/core/ret_lshr.thorin
+++ b/lit/core/ret_lshr.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -e thorin %s -e ll -o %t --output-thorin - | FileCheck %s
+// RUN: %thorin %s --output-ll %t.ll --output-thorin - | FileCheck %s
 // RUN: clang %t.ll -o %t -Wno-override-module
 // RUN: %t 2 1 ; test $? -eq 1
 // RUN: %t 16 3 ; test $? -eq 2

--- a/lit/main_loop.thorin
+++ b/lit/main_loop.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -e thorin %s -e ll -o %t --output-thorin - | FileCheck %s
+// RUN: %thorin %s --output-ll %t.ll --output-thorin - | FileCheck %s
 // RUN: clang %t.ll -o %t -Wno-override-module
 // RUN: %t ; test $? -eq 0
 // RUN: %t 1 2 3 ; test $? -eq 6

--- a/lit/main_loop_nom.thorin
+++ b/lit/main_loop_nom.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -e thorin %s -e ll -o %t --output-thorin - | FileCheck %s
+// RUN: %thorin %s --output-ll %t.ll --output-thorin - | FileCheck %s
 // RUN: clang %t.ll -o %t -Wno-override-module
 // RUN: %t ; test $? -eq 0
 // RUN: %t 1 2 3 ; test $? -eq 6

--- a/lit/mem/alloc_load_store.thorin
+++ b/lit/mem/alloc_load_store.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -e thorin %s -e ll -o %t --output-thorin - | FileCheck %s
+// RUN: %thorin %s --output-ll %t.ll --output-thorin - | FileCheck %s
 // RUN: clang %t.ll -o %t -Wno-override-module
 // RUN: %t; test $? -eq 1
 // RUN: %t 1 2 3; test $? -eq 4

--- a/lit/mem/malloc_load_store.thorin
+++ b/lit/mem/malloc_load_store.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -e thorin %s -e ll -o %t --output-thorin - | FileCheck %s
+// RUN: %thorin %s --output-ll %t.ll --output-thorin - | FileCheck %s
 // RUN: clang %t.ll -o %t -Wno-override-module
 // RUN: %t; test $? -eq 1
 // RUN: %t 1 2 3; test $? -eq 4

--- a/lit/mem/mslot_load_store.thorin
+++ b/lit/mem/mslot_load_store.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -e thorin %s -e ll -o %t --output-thorin - | FileCheck %s
+// RUN: %thorin %s --output-ll %t.ll --output-thorin - | FileCheck %s
 // RUN: clang %t.ll -o %t -Wno-override-module
 // RUN: %t; test $? -eq 1
 // RUN: %t 1 2 3; test $? -eq 4

--- a/lit/mem/slot_load_store.thorin
+++ b/lit/mem/slot_load_store.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -e thorin %s -e ll -o %t --output-thorin - | FileCheck %s
+// RUN: %thorin %s --output-ll %t.ll --output-thorin - | FileCheck %s
 // RUN: clang %t.ll -o %t -Wno-override-module
 // RUN: %t; test $? -eq 1
 // RUN: %t 1 2 3; test $? -eq 4

--- a/lit/parse_output_parse.thorin
+++ b/lit/parse_output_parse.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -e thorin --output-thorin - %s > %t.thorin && %thorin -e thorin %t.thorin -e ll -o %t --output-thorin - | FileCheck %s
+// RUN: %thorin --output-thorin - %s > %t.thorin && %thorin %t.thorin --output-ll %t.ll --output-thorin - | FileCheck %s
 // RUN: clang %t.ll -o %t -Wno-override-module
 // RUN: %t ; test $? -eq 1
 // RUN: %t 1 2 3 ; test $? -eq 4

--- a/lit/ret_argc.thorin
+++ b/lit/ret_argc.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -e thorin %s -e ll -o %t --output-thorin - | FileCheck %s
+// RUN: %thorin %s --output-ll %t.ll --output-thorin - | FileCheck %s
 // RUN: clang %t.ll -o %t -Wno-override-module
 // RUN: %t ; test $? -eq 1
 // RUN: %t 1 2 3 ; test $? -eq 4


### PR DESCRIPTION
Also removes the -o/--output option. Instead, simply directly specify
the output file and backend via --output-h <file> etc.