### PR TITLE
Feature/ptrn

### DIFF
--- a/docs/langref.md
+++ b/docs/langref.md
@@ -126,7 +126,7 @@ The following tables comprise all production rules:
 | Nonterminal | Right-Hand Side                                                   | New Scope? | Comment                        | Thorin Class  |
 |-------------|-------------------------------------------------------------------|------------|--------------------------------|---------------|
 | d           | `.ax` Ax `:` e<sub>type</sub> `;`                                 |            | axiom                          | thorin::Axiom |
-| d           | `.let` Sym `:` e<sub>type</sub> `=` e `;`                         |            | let                            | -             |
+| d           | `.let` p  `=` e `;`                                               |            | let                            | -             |
 | d           | `.Pi` Sym ( `:` e<sub>type</sub> )? `,` e<sub>dom</sub> n         |            | nominal Pi declaration         | thorin::Pi    |
 | d           | `.lam` Sym `:` e<sub>type</sub> v? n                              |            | nominal lambda declaration     | thorin::Lam   |
 | d           | `.Arr` Sym ( `:` e<sub>type</sub> )? `,` e<sub>shape</sub> v? n   |            | nominal array declaration      | thorin::Arr   |
@@ -137,6 +137,13 @@ The following tables comprise all production rules:
 | n           | `;` \| o                                                          |            | nominal definition             | -             |
 | o           | `=` e `;`                                                         |            | operand of nominal definition  | -             |
 | o           | `=` `{` e `,` ... `,` e  `}` `;`                                  | ✓          | operands of nominal definition | -             |
+
+### Patterns
+
+| Nonterminal | Right-Hand Side               | New Scope? | Comment            |
+|-------------|-------------------------------|------------|--------------------|
+| p           | Sym ( `:` e<sub>type</sub> )? |            | identifier pattern |
+| p           | `(` p `,` ... `,` p `)`       |            | tuple pattern      |
 
 ### Expressions
 

--- a/lit/ret_argc.thorin
+++ b/lit/ret_argc.thorin
@@ -8,7 +8,7 @@
 .import mem;
 
 .lam .extern main: .Cn [mem : %mem.M, argc : %Int 4294967296, argv : %mem.Ptr (%mem.Ptr (%Int 256, 0:.Nat), 0:.Nat), return : .Cn [%mem.M, %Int 4294967296]] = {
-    0: (%Int 2),
+    .ff,
     return (mem, argc)
 };
 

--- a/thorin/CMakeLists.txt
+++ b/thorin/CMakeLists.txt
@@ -44,6 +44,10 @@ add_library(libthorin
     be/dot/dot.h
     be/h/bootstrapper.cpp
     be/h/bootstrapper.h
+    fe/ast.cpp
+    fe/ast.h
+    fe/binder.cpp
+    fe/binder.h
     fe/lexer.cpp
     fe/lexer.h
     fe/parser.cpp

--- a/thorin/fe/ast.cpp
+++ b/thorin/fe/ast.cpp
@@ -10,7 +10,7 @@ void IdPtrn::scrutinize(Binder& binder, const Def* scrutinee) const { binder.bin
 
 void TuplePtrn::scrutinize(Binder& binder, const Def* scrutinee) const {
     size_t n = ptrns_.size();
-    for (size_t i = 0; i != n; ++i) scrutinize(binder, scrutinee->proj(n, i));
+    for (size_t i = 0; i != n; ++i) ptrns_[i]->scrutinize(binder, scrutinee->proj(n, i));
 }
 
 } // namespace thorin

--- a/thorin/fe/ast.cpp
+++ b/thorin/fe/ast.cpp
@@ -6,9 +6,7 @@
 
 namespace thorin {
 
-void IdPtrn::scrutinize(Binder& binder, const Def* scrutinee) const {
-    binder.bind(sym_, scrutinee);
-}
+void IdPtrn::scrutinize(Binder& binder, const Def* scrutinee) const { binder.bind(sym_, scrutinee); }
 
 void TuplePtrn::scrutinize(Binder& binder, const Def* scrutinee) const {
     size_t n = ptrns_.size();

--- a/thorin/fe/ast.cpp
+++ b/thorin/fe/ast.cpp
@@ -1,0 +1,18 @@
+#include "thorin/fe/ast.h"
+
+#include "thorin/def.h"
+
+#include "thorin/fe/binder.h"
+
+namespace thorin {
+
+void IdPtrn::scrutinize(Binder& binder, const Def* scrutinee) const {
+    binder.bind(sym_, scrutinee);
+}
+
+void TuplePtrn::scrutinize(Binder& binder, const Def* scrutinee) const {
+    size_t n = ptrns_.size();
+    for (size_t i = 0; i != n; ++i) scrutinize(binder, scrutinee->proj(n, i));
+}
+
+} // namespace thorin

--- a/thorin/fe/ast.h
+++ b/thorin/fe/ast.h
@@ -12,8 +12,7 @@ class Binder;
 class Ptrn {
 public:
     Ptrn(Loc loc)
-        : loc_(loc)
-    {}
+        : loc_(loc) {}
     virtual ~Ptrn() {}
 
     virtual void scrutinize(Binder&, const Def*) const = 0;
@@ -48,4 +47,4 @@ private:
     std::deque<std::unique_ptr<Ptrn>> ptrns_;
 };
 
-}
+} // namespace thorin

--- a/thorin/fe/ast.h
+++ b/thorin/fe/ast.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <deque>
+#include <memory>
+
+#include "thorin/fe/tok.h"
+
+namespace thorin {
+
+class Binder;
+
+class Ptrn {
+public:
+    Ptrn(Loc loc)
+        : loc_(loc)
+    {}
+    virtual ~Ptrn() {}
+
+    virtual void scrutinize(Binder&, const Def*) const = 0;
+
+private:
+    Loc loc_;
+};
+
+class IdPtrn : public Ptrn {
+public:
+    IdPtrn(Loc loc, Sym sym, const Def* type)
+        : Ptrn(loc)
+        , sym_(sym)
+        , type_(type) {}
+
+    void scrutinize(Binder&, const Def*) const override;
+
+private:
+    Sym sym_;
+    const Def* type_;
+};
+
+class TuplePtrn : public Ptrn {
+public:
+    TuplePtrn(Loc loc, std::deque<std::unique_ptr<Ptrn>>&& ptrns)
+        : Ptrn(loc)
+        , ptrns_(std::move(ptrns)) {}
+
+    void scrutinize(Binder&, const Def*) const override;
+
+private:
+    std::deque<std::unique_ptr<Ptrn>> ptrns_;
+};
+
+}

--- a/thorin/fe/binder.cpp
+++ b/thorin/fe/binder.cpp
@@ -5,8 +5,7 @@
 namespace thorin {
 
 Binder::Binder(World& world)
-    : anonymous_(world.tuple_str("_"), nullptr)
-{
+    : anonymous_(world.tuple_str("_"), nullptr) {
     push(); // root scope
 }
 

--- a/thorin/fe/binder.cpp
+++ b/thorin/fe/binder.cpp
@@ -15,13 +15,13 @@ void Binder::pop() {
 }
 
 const Def* Binder::find(Sym sym) const {
-    if (sym == anonymous_)
-        thorin::err<ScopeError>(sym.loc(), "the symbol '_' is special and never binds to anything", sym);
+    if (sym == anonymous_) err<ScopeError>(sym.loc(), "the symbol '_' is special and never binds to anything", sym);
 
-    for (auto& scope : scopes_ | std::ranges::views::reverse)
+    for (auto& scope : scopes_ | std::ranges::views::reverse) {
         if (auto i = scope.find(sym); i != scope.end()) return i->second;
+    }
 
-    thorin::err<ScopeError>(sym.loc(), "symbol '{}' not found", sym);
+    err<ScopeError>(sym.loc(), "symbol '{}' not found", sym);
 }
 
 void Binder::bind(Sym sym, const Def* def) {
@@ -30,7 +30,7 @@ void Binder::bind(Sym sym, const Def* def) {
     if (auto [i, ins] = scopes_.back().emplace(sym, def); !ins) {
         auto curr = sym.loc();
         auto prev = i->first.to_loc();
-        thorin::err<ScopeError>(curr, "symbol '{}' already declared in the current scope here: {}", sym, prev);
+        err<ScopeError>(curr, "symbol '{}' already declared in the current scope here: {}", sym, prev);
     }
 }
 

--- a/thorin/fe/binder.cpp
+++ b/thorin/fe/binder.cpp
@@ -1,0 +1,43 @@
+#include "thorin/fe/binder.h"
+
+#include "thorin/world.h"
+
+namespace thorin {
+
+Binder::Binder(World& world)
+    : anonymous_(world.tuple_str("_"), nullptr)
+{
+    push(); // root scope
+}
+
+void Binder::pop() {
+    assert(!scopes_.empty());
+    scopes_.pop_back();
+}
+
+const Def* Binder::find(Sym sym) const {
+    if (sym == anonymous_)
+        thorin::err<ScopeError>(sym.loc(), "the symbol '_' is special and never binds to anything", sym);
+
+    for (auto& scope : scopes_ | std::ranges::views::reverse)
+        if (auto i = scope.find(sym); i != scope.end()) return i->second;
+
+    thorin::err<ScopeError>(sym.loc(), "symbol '{}' not found", sym);
+}
+
+void Binder::bind(Sym sym, const Def* def) {
+    if (sym == anonymous_) return; // don't do anything with '_'
+
+    if (auto [i, ins] = scopes_.back().emplace(sym, def); !ins) {
+        auto curr = sym.loc();
+        auto prev = i->first.to_loc();
+        thorin::err<ScopeError>(curr, "symbol '{}' already declared in the current scope here: {}", sym, prev);
+    }
+}
+
+void Binder::merge(Binder& other) {
+    assert(scopes_.size() == 1 && other.scopes_.size() == 1);
+    scopes_.front().merge(other.scopes_.front());
+}
+
+} // namespace thorin

--- a/thorin/fe/binder.h
+++ b/thorin/fe/binder.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <deque>
+
+#include "thorin/debug.h"
+
+namespace thorin {
+
+class Binder {
+public:
+    Binder(World&);
+
+    void push() { scopes_.emplace_back(); }
+    void pop();
+    const Def* find(Sym) const;
+    void bind(Sym sym, const Def*);
+    void merge(Binder&);
+
+private:
+    using Scope = SymMap<const Def*>;
+
+    std::deque<Scope> scopes_;
+    Sym anonymous_;
+};
+
+}

--- a/thorin/fe/binder.h
+++ b/thorin/fe/binder.h
@@ -23,4 +23,4 @@ private:
     Sym anonymous_;
 };
 
-}
+} // namespace thorin

--- a/thorin/fe/parser.cpp
+++ b/thorin/fe/parser.cpp
@@ -512,7 +512,7 @@ std::unique_ptr<Ptrn> Parser::parse_ptrn(std::string_view ctxt) {
         case Tok::Tag::M_id:      return parse_id_ptrn();
         default:
             if (ctxt.empty()) return nullptr;
-            err("primary expression", ctxt);
+            err("pattern", ctxt);
     }
     // clang-format on
     return nullptr;
@@ -638,14 +638,10 @@ void Parser::parse_ax() {
 
 void Parser::parse_let() {
     eat(Tok::Tag::K_let);
-    auto sym = parse_sym();
-    if (accept(Tok::Tag::T_colon)) {
-        /*auto type = */ parse_expr("type of a let binding");
-        // do sth with type
-    }
+    auto ptrn = parse_ptrn("binding pattern of a let expression");
     eat(Tok::Tag::T_assign);
     auto body = parse_expr("body of a let expression");
-    binder_.bind(sym, body);
+    ptrn->scrutinize(binder_, body);
     eat(Tok::Tag::T_semicolon);
 }
 

--- a/thorin/fe/parser.cpp
+++ b/thorin/fe/parser.cpp
@@ -522,14 +522,14 @@ std::unique_ptr<IdPtrn> Parser::parse_id_ptrn() {
     auto track = tracker();
     auto sym   = parse_sym();
     auto type  = accept(Tok::Tag::T_colon) ? parse_expr("type of an identifier pattern") : nullptr;
-    return std::make_unique<IdPtrn>(track, sym, type);
+    return std::make_unique<IdPtrn>(track.loc(), sym, type);
 }
 
 std::unique_ptr<TuplePtrn> Parser::parse_tuple_ptrn() {
     auto track = tracker();
     std::deque<std::unique_ptr<Ptrn>> ptrns;
     parse_list("tuple pattern", Tok::Tag::D_paren_l, [&]() { ptrns.emplace_back(parse_ptrn("tuple pattern")); });
-    return std::make_unique<TuplePtrn>(track, std::move(ptrns));
+    return std::make_unique<TuplePtrn>(track.loc(), std::move(ptrns));
 }
 
 /*

--- a/thorin/fe/parser.h
+++ b/thorin/fe/parser.h
@@ -6,6 +6,8 @@
 #include "thorin/world.h"
 
 #include "thorin/be/h/bootstrapper.h"
+#include "thorin/fe/ast.h"
+#include "thorin/fe/binder.h"
 #include "thorin/fe/lexer.h"
 
 namespace thorin {
@@ -40,11 +42,14 @@ public:
            std::ostream* md = nullptr);
 
     World& world() { return lexer_.world(); }
-    void parse_module();
-    void bootstrap(std::ostream&);
 
+    /// @name entry points
+    ///@{
     static Parser
     import_module(World&, std::string_view, ArrayRef<std::string> = {}, const Normalizers* normalizers = nullptr);
+    void parse_module();
+    void bootstrap(std::ostream&);
+    ///@}
 
 private:
     /// @name Tracker
@@ -57,6 +62,7 @@ private:
             , pos_(pos) {}
 
         Loc loc() const { return {parser_.prev_.file, pos_, parser_.prev_.finis}; }
+        operator Loc() const { return loc(); }
         operator const Def*() const { return parser_.world().dbg({"", loc()}); }
         const Def* meta(const Def* m) const { return parser_.world().dbg({"", loc(), m}); }
         const Def* named(Sym sym) const { return parser_.world().dbg({sym.to_string(), loc()}); }
@@ -92,6 +98,13 @@ private:
     const Def* parse_lit();
     const Def* parse_var();
     const Def* parse_insert();
+    ///@}
+
+    /// @name ptrns
+    ///@{
+    std::unique_ptr<Ptrn> parse_ptrn(std::string_view ctxt);
+    std::unique_ptr<IdPtrn> parse_id_ptrn();
+    std::unique_ptr<TuplePtrn> parse_tuple_ptrn();
     ///@}
 
     /// @name decls
@@ -162,54 +175,21 @@ private:
     [[noreturn]] void err(std::string_view what, std::string_view ctxt) { err(what, ahead(), ctxt); }
     ///@}
 
-    /// @name Scope
-    ///@{
-    using Scope = SymMap<const Def*>;
-
-    void push() { scopes_.emplace_back(); }
-
-    void pop() {
-        assert(!scopes_.empty());
-        scopes_.pop_back();
-    }
-
-    const Def* find(Sym sym) const {
-        if (sym == anonymous_)
-            thorin::err<ScopeError>(sym.loc(), "the symbol '_' is special and never binds to anything", sym);
-
-        for (auto& scope : scopes_ | std::ranges::views::reverse)
-            if (auto i = scope.find(sym); i != scope.end()) return i->second;
-
-        thorin::err<ScopeError>(sym.loc(), "symbol '{}' not found", sym);
-    }
-
-    void insert(Sym sym, const Def* def) {
-        if (sym == anonymous_) return; // don't do anything with '_'
-
-        if (auto [i, ins] = scopes_.back().emplace(sym, def); !ins) {
-            auto curr = sym.loc();
-            auto prev = i->first.to_loc();
-            thorin::err<ScopeError>(curr, "symbol '{}' already declared in the current scope here: {}", sym, prev);
-        }
-    }
-    ///@}
-
     Parser(World&,
            std::string_view,
            std::istream&,
            ArrayRef<std::string>,
            const Normalizers*,
-           const std::deque<Parser::Scope>&,
+           const Binder&,
            const SymSet&);
 
     Lexer lexer_;
+    Binder binder_;
     Loc prev_;
     std::string dialect_;
     static constexpr size_t Max_Ahead = 2; ///< maximum lookahead
     std::array<Tok, Max_Ahead> ahead_;     ///< SLL look ahead
-    std::deque<Scope> scopes_;
     SymSet imported_;
-    Sym anonymous_;
     h::Bootstrapper bootstrapper_;
     std::vector<std::string> user_search_paths_;
     const Normalizers* normalizers_;

--- a/thorin/fe/parser.h
+++ b/thorin/fe/parser.h
@@ -62,7 +62,6 @@ private:
             , pos_(pos) {}
 
         Loc loc() const { return {parser_.prev_.file, pos_, parser_.prev_.finis}; }
-        operator Loc() const { return loc(); }
         operator const Def*() const { return parser_.world().dbg({"", loc()}); }
         const Def* meta(const Def* m) const { return parser_.world().dbg({"", loc(), m}); }
         const Def* named(Sym sym) const { return parser_.world().dbg({sym.to_string(), loc()}); }


### PR DESCRIPTION
This introduces patterns to Thorin's frontend. Originally, I intended not to introduce an AST layer but for patterns it makes sense as they don't duplicate anything that is already present within Thorin. Also, the Ptrn AST nodes are really lightweight.

Rn, it is only used within let expressions like so:
```
.let (x, y) = my_tuple;
```
You can also optionally annotate the type of an IdPtrn:
```
.let (x: T, y) = my_tuple;
```
But `T` is not used for anything right now. We can either use that later on to help type inference or we can remove this again.

There are also these var_lists which I believe we can remove in favor of proper patterns. And we somehow have to come up with a syntax that kind of blends patterns with dependent Sigmas.