### PR TITLE
refactor world logging stuff

### DIFF
--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -100,8 +100,8 @@ int main(int argc, char** argv) {
             throw std::invalid_argument("error: unknown option " + input);
 
         World world;
-        world.set_log_ostream(&std::cerr);
-        world.set_log_level((LogLevel)verbose);
+        world.log.ostream = &std::cerr;
+        world.log.level   = (Log::Level)verbose;
 #if THORIN_ENABLE_CHECKS
         for (auto b : breakpoints) world.breakpoint(b);
 #endif
@@ -112,8 +112,7 @@ int main(int argc, char** argv) {
             return EXIT_FAILURE;
         }
 
-        for (const auto& dialect : dialects)
-            Parser::import_module(world, dialect.name(), dialect_paths, &normalizers);
+        for (const auto& dialect : dialects) Parser::import_module(world, dialect.name(), dialect_paths, &normalizers);
 
         Parser parser(world, input, ifs, dialect_paths, &normalizers, os[Md]);
         parser.parse_module();

--- a/dialects/core/be/ll/ll.cpp
+++ b/dialects/core/be/ll/ll.cpp
@@ -919,7 +919,7 @@ std::string CodeGen::emit_bb(BB& bb, const Def* def) {
         return globals_[global] = name;
     }
 
-    assert(false && "not yet implemented");
+    unreachable(); // not yet implemented
 }
 
 void emit(World& world, std::ostream& ostream) {

--- a/thorin/CMakeLists.txt
+++ b/thorin/CMakeLists.txt
@@ -88,6 +88,8 @@ add_library(libthorin
     util/hash.h
     util/indexmap.h
     util/indexset.h
+    util/log.cpp
+    util/log.h
     util/print.cpp
     util/print.h
     util/sys.cpp

--- a/thorin/be/emitter.h
+++ b/thorin/be/emitter.h
@@ -86,7 +86,7 @@ protected:
 
         child().finalize(scope);
         locals_.clear();
-        assert(lam2bb_.size() == old_size && "really make sure we didn't triger a rehash");
+        assert_unused(lam2bb_.size() == old_size && "really make sure we didn't triger a rehash");
     }
 
     World& world_;

--- a/thorin/pass/pass.h
+++ b/thorin/pass/pass.h
@@ -87,7 +87,7 @@ public:
     }
     const Proxy* as_proxy(const Def* def, u32 tag = 0) {
         auto proxy = def->as<Proxy>();
-        assert(proxy->pass() == index() && proxy->tag() == tag);
+        assert_unused(proxy->pass() == index() && proxy->tag() == tag);
         return proxy;
     }
     ///@}

--- a/thorin/stream.cpp
+++ b/thorin/stream.cpp
@@ -196,8 +196,7 @@ void RecStreamer::run(const DepNode* node) {
             if (def->isa<Arr>()) return ".Arr";
             if (def->isa<Pack>()) return ".pack";
             if (def->isa<Pi>()) return ".Pi";
-
-            assert(false && "unknown nominal");
+            unreachable();
         };
 
         auto nom_op0 = [&](const Def* def) -> std::ostream& {
@@ -206,8 +205,7 @@ void RecStreamer::run(const DepNode* node) {
             if (auto arr = def->isa<Arr>()) return print(os, ", {}", arr->shape());
             if (auto pack = def->isa<Pack>()) return print(os, ", {}", pack->shape());
             if (auto pi = def->isa<Pi>()) return print(os, ", {}", pi->dom());
-
-            assert(false && "unknown nominal");
+            unreachable();
         };
 
         if (nom->is_set()) {

--- a/thorin/stream.cpp
+++ b/thorin/stream.cpp
@@ -317,7 +317,7 @@ std::ostream& World::stream(RecStreamer& rec, const DepNode* n) const {
 }
 
 void World::debug_stream() const {
-    if (max_level() == LogLevel::Debug) log_stream() << *this;
+    if (log.level == Log::Level::Debug) *log.ostream << *this;
 }
 
 void World::dump() const { std::cout << *this; }

--- a/thorin/util/assert.h
+++ b/thorin/util/assert.h
@@ -4,8 +4,6 @@
 
 namespace thorin {
 
-// TODO output s in Debug build
-
 // see https://stackoverflow.com/a/65258501
 #ifdef __GNUC__ // GCC 4.8+, Clang, Intel and other compilers compatible with GCC (-std=c++0x or above)
 [[noreturn]] inline __attribute__((always_inline)) void unreachable() {

--- a/thorin/util/log.cpp
+++ b/thorin/util/log.cpp
@@ -1,0 +1,51 @@
+#include "thorin/util/log.h"
+
+namespace thorin {
+
+// clang-format off
+std::string_view Log::level2acro(Level level) {
+    switch (level) {
+        case Level::Debug:   return "D";
+        case Level::Verbose: return "V";
+        case Level::Info:    return "I";
+        case Level::Warn:    return "W";
+        case Level::Error:   return "E";
+        default: unreachable();
+    }
+}
+
+Log::Level Log::str2level(std::string_view s) {
+    if (false) {}
+    else if (s == "debug"  ) return Level::Debug;
+    else if (s == "verbose") return Level::Verbose;
+    else if (s == "info"   ) return Level::Info;
+    else if (s == "warn"   ) return Level::Warn;
+    else if (s == "error"  ) return Level::Error;
+    else throw std::invalid_argument("invalid log level");
+}
+
+int Log::level2color(Level level) {
+    switch (level) {
+        case Level::Debug:   return 4;
+        case Level::Verbose: return 4;
+        case Level::Info:    return 2;
+        case Level::Warn:    return 3;
+        case Level::Error:   return 1;
+        default: unreachable();
+    }
+}
+// clang-format on
+
+#ifdef THORIN_COLOR_TERM
+std::string Log::colorize(std::string_view str, int color) {
+    if (isatty(fileno(stdout))) {
+        const char c = '0' + color;
+        return "\033[1;3" + (c + ('m' + std::string(str))) + "\033[0m";
+    }
+    return std::string(str);
+}
+#else
+std::string Log::colorize(std::string_view str, int) { return std::string(str); }
+#endif
+
+} // namespace thorin

--- a/thorin/util/log.h
+++ b/thorin/util/log.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "thorin/debug.h"
+
+#include "thorin/util/print.h"
+
+namespace thorin {
+
+struct Log {
+    enum class Level { Error, Warn, Info, Verbose, Debug };
+
+    template<class... Args>
+    void log(Level curr, Loc loc, const char* fmt, Args&&... args) {
+        if (ostream && int(curr) <= int(level)) {
+            std::ostringstream oss;
+            oss << loc;
+            print(*ostream, "{}:{}: ", colorize(level2acro(curr), level2color(curr)), colorize(oss.str(), 7));
+            print(*ostream, fmt, std::forward<Args&&>(args)...) << std::endl;
+        }
+    }
+
+    template<class... Args>
+    [[noreturn]] void error(Loc loc, const char* fmt, Args&&... args) {
+        log(Level::Error, loc, fmt, std::forward<Args&&>(args)...);
+        std::abort();
+    }
+
+    static std::string_view level2acro(Level);
+    static Level str2level(std::string_view);
+    static int level2color(Level level);
+    static std::string colorize(std::string_view str, int color);
+
+    std::ostream* ostream = nullptr;
+    Level level           = Level::Error; ///< **Maximum** log Level.
+};
+
+} // namespace thorin

--- a/thorin/util/log.h
+++ b/thorin/util/log.h
@@ -20,12 +20,6 @@ struct Log {
     }
     void log() {} ///< Dummy for Debug build.
 
-    template<class... Args>
-    [[noreturn]] void error(Loc loc, const char* fmt, Args&&... args) {
-        log(Level::Error, loc, fmt, std::forward<Args&&>(args)...);
-        std::abort();
-    }
-
     static std::string_view level2acro(Level);
     static Level str2level(std::string_view);
     static int level2color(Level level);

--- a/thorin/util/log.h
+++ b/thorin/util/log.h
@@ -18,6 +18,7 @@ struct Log {
             print(*ostream, fmt, std::forward<Args&&>(args)...) << std::endl;
         }
     }
+    void log() {} ///< Dummy for Debug build.
 
     template<class... Args>
     [[noreturn]] void error(Loc loc, const char* fmt, Args&&... args) {
@@ -33,5 +34,17 @@ struct Log {
     std::ostream* ostream = nullptr;
     Level level           = Level::Error; ///< **Maximum** log Level.
 };
+
+// clang-format off
+#define ELOG(...) log.log(thorin::Log::Level::Error,   thorin::Loc(__FILE__, {__LINE__, thorin::u32(-1)}, {__LINE__, thorin::u32(-1)}), __VA_ARGS__)
+#define WLOG(...) log.log(thorin::Log::Level::Warn,    thorin::Loc(__FILE__, {__LINE__, thorin::u32(-1)}, {__LINE__, thorin::u32(-1)}), __VA_ARGS__)
+#define ILOG(...) log.log(thorin::Log::Level::Info,    thorin::Loc(__FILE__, {__LINE__, thorin::u32(-1)}, {__LINE__, thorin::u32(-1)}), __VA_ARGS__)
+#define VLOG(...) log.log(thorin::Log::Level::Verbose, thorin::Loc(__FILE__, {__LINE__, thorin::u32(-1)}, {__LINE__, thorin::u32(-1)}), __VA_ARGS__)
+#ifndef NDEBUG
+#define DLOG(...) log.log(thorin::Log::Level::Debug,   thorin::Loc(__FILE__, {__LINE__, thorin::u32(-1)}, {__LINE__, thorin::u32(-1)}), __VA_ARGS__)
+#else
+#define DLOG(...) log.log()
+#endif
+// clang-format on
 
 } // namespace thorin

--- a/thorin/world.cpp
+++ b/thorin/world.cpp
@@ -577,56 +577,6 @@ void World::visit(VisitFn f) const {
     }
 }
 
-/*
- * logging
- */
-
-// clang-format off
-std::string_view World::level2acro(LogLevel level) {
-    switch (level) {
-        case LogLevel::Debug:   return "D";
-        case LogLevel::Verbose: return "V";
-        case LogLevel::Info:    return "I";
-        case LogLevel::Warn:    return "W";
-        case LogLevel::Error:   return "E";
-        default: unreachable();
-    }
-}
-
-LogLevel World::str2level(std::string_view s) {
-    if (false) {}
-    else if (s == "debug"  ) return LogLevel::Debug;
-    else if (s == "verbose") return LogLevel::Verbose;
-    else if (s == "info"   ) return LogLevel::Info;
-    else if (s == "warn"   ) return LogLevel::Warn;
-    else if (s == "error"  ) return LogLevel::Error;
-    else throw std::invalid_argument("invalid log level");
-}
-
-int World::level2color(LogLevel level) {
-    switch (level) {
-        case LogLevel::Debug:   return 4;
-        case LogLevel::Verbose: return 4;
-        case LogLevel::Info:    return 2;
-        case LogLevel::Warn:    return 3;
-        case LogLevel::Error:   return 1;
-        default: unreachable();
-    }
-}
-// clang-format on
-
-#ifdef THORIN_COLOR_TERM
-std::string World::colorize(std::string_view str, int color) {
-    if (isatty(fileno(stdout))) {
-        const char c = '0' + color;
-        return "\033[1;3" + (c + ('m' + std::string(str))) + "\033[0m";
-    }
-    return std::string(str);
-}
-#else
-std::string World::colorize(std::string_view str, int) { return std::string(str); }
-#endif
-
 void World::set_error_handler(std::unique_ptr<ErrorHandler>&& err) { err_ = std::move(err); }
 
 /*

--- a/thorin/world.cpp
+++ b/thorin/world.cpp
@@ -522,7 +522,7 @@ const Def* World::test(const Def* value, const Def* probe, const Def* match, con
         // TODO proper error msg
         assert(m_pi && c_pi);
         auto a = isa_lit(m_pi->dom()->arity());
-        assert(a && *a == 2);
+        assert_unused(a && *a == 2);
         assert(checker_->equiv(m_pi->dom(2, 0_s), c_pi->dom(), nullptr));
     }
 

--- a/thorin/world.h
+++ b/thorin/world.h
@@ -698,16 +698,4 @@ private:
 
 std::ostream& operator<<(std::ostream&, const World&);
 
-// clang-format off
-#define ELOG(...) log.log(thorin::Log::Level::Error,   thorin::Loc(__FILE__, {__LINE__, thorin::u32(-1)}, {__LINE__, thorin::u32(-1)}), __VA_ARGS__)
-#define WLOG(...) log.log(thorin::Log::Level::Warn,    thorin::Loc(__FILE__, {__LINE__, thorin::u32(-1)}, {__LINE__, thorin::u32(-1)}), __VA_ARGS__)
-#define ILOG(...) log.log(thorin::Log::Level::Info,    thorin::Loc(__FILE__, {__LINE__, thorin::u32(-1)}, {__LINE__, thorin::u32(-1)}), __VA_ARGS__)
-#define VLOG(...) log.log(thorin::Log::Level::Verbose, thorin::Loc(__FILE__, {__LINE__, thorin::u32(-1)}, {__LINE__, thorin::u32(-1)}), __VA_ARGS__)
-#ifndef NDEBUG
-#define DLOG(...) log.log(thorin::Log::Level::Debug,   thorin::Loc(__FILE__, {__LINE__, thorin::u32(-1)}, {__LINE__, thorin::u32(-1)}), __VA_ARGS__)
-#else
-#define DLOG(...)
-#endif
-// clang-format on
-
 } // namespace thorin


### PR DESCRIPTION
This puts logging stuff into it's own class and simply makes Log::level
and Log::ostream public and removes getters/setters.