### PR TITLE
Refactor affine.For.

### DIFF
--- a/dialects/affine/affine.thorin
+++ b/dialects/affine/affine.thorin
@@ -17,12 +17,13 @@
 /// This operation ranges from (including) `start` to (excluding) `stop` using `step` as stride.
 /// In addition, this loop manages `n` loop accumulators whose initial values `init` must be given.
 /// Each iteration the given `body` is invoked which receives 
-/// * the current `%mem.M`, 
+/// * the current iteration index, and
 /// * the current values of the loop accumulators `acc`, and
 /// * a `yield` continuation to prematurely continue with the next iteration.
 ///
 /// After termination of the loop `exit` is invoked.
 .ax %affine.For: Π [m: .Nat , n: .Nat , Ts: «n; *»] ->
-    .Cn [mem: %mem.M, start: %Int m, stop: %Int m, step: %Int m, init: «i: n; Ts#i»,
-        body: .Cn [%mem.M , %Int m, acc: «i: n; Ts#i», yield: .Cn [%mem.M , «i: n; Ts#i»]], 
-        exit: .Cn [%mem.M , «i: n; Ts#i»]];
+    .Cn [start: %Int m, stop: %Int m, step: %Int m, init: «i: n; Ts#i»,
+        body: .Cn [iter: %Int m, acc: «i: n; Ts#i», yield: .Cn [«i: n; Ts#i»]], 
+        exit: .Cn [«i: n; Ts#i»]];
+

--- a/dialects/affine/passes/lower_for.cpp
+++ b/dialects/affine/passes/lower_for.cpp
@@ -3,6 +3,7 @@
 #include <thorin/lam.h>
 
 #include "dialects/affine/affine.h"
+#include "dialects/mem/mem.h"
 
 namespace thorin::affine {
 
@@ -13,41 +14,43 @@ const Def* LowerFor::rewrite(const Def* def) {
         auto& w = world();
         w.DLOG("rewriting for axiom: {} within {}", for_ax, curr_nom());
 
-        auto for_pi  = for_ax->callee_type();
-        auto for_lam = w.nom_lam(for_pi, w.dbg("for"));
+        auto for_pi = for_ax->callee_type();
+        DefArray for_dom{for_pi->num_doms() - 2, [&](size_t i) { return for_pi->dom(i); }};
+        auto for_lam = w.nom_lam(w.cn(for_dom), w.dbg("for"));
 
-        auto org_body  = for_ax->arg(for_ax->num_args() - 2);
-        auto body_type = org_body->type()->as<Pi>();
+        auto body = for_ax->arg(for_ax->num_args() - 2, w.dbg("body"));
+        auto brk  = for_ax->arg(for_ax->num_args() - 1, w.dbg("break"));
+
+        auto body_type = body->type()->as<Pi>();
         auto yield_pi  = body_type->doms().back()->as<Pi>();
         auto yield_lam = w.nom_lam(yield_pi, w.dbg("yield"));
 
         { // construct yield
-            auto [mem, iter, end, step, acc, body, brk] =
-                for_lam->vars<7>({w.dbg("mem"), w.dbg("begin"), w.dbg("end"), w.dbg("step"), w.dbg("acc"),
-                                  w.dbg("body"), w.dbg("break")});
-            auto [yield_mem, yield_acc] = yield_lam->vars<2>();
+            auto [iter, end, step, acc] = for_lam->vars<4>({w.dbg("begin"), w.dbg("end"), w.dbg("step"), w.dbg("acc")});
+            auto yield_acc              = yield_lam->var();
 
-            auto add = w.op(Wrap::add, w.lit_nat_0(), iter, step);
-            yield_lam->app(false, for_lam, {yield_mem, add, end, step, yield_acc, body, brk});
+            auto add = core::op(core::wrap::add, w.lit_nat_0(), iter, step);
+            yield_lam->app(false, for_lam, {add, end, step, yield_acc});
         }
         { // construct for
-            auto [mem, iter, end, step, acc, body, brk] = for_lam->vars<7>();
+            auto [iter, end, step, acc] = for_lam->vars<4>();
 
-            // continue
-            auto if_then_cn = w.cn(mem->type());
-            auto if_then    = w.nom_lam(if_then_cn, nullptr);
-            if_then->app(false, body, {if_then->var(0, w.dbg("mem")), iter, acc, yield_lam});
+            // reduce the body to remove the cn parameter
+            auto nom_body = body->as_nom<Lam>();
+            auto new_body = nom_body->stub(w, w.cn(w.sigma()), body->dbg());
+            new_body->set(nom_body->reduce(w.tuple({iter, acc, yield_lam})));
 
             // break
-            auto if_else_cn = w.cn(mem->type());
+            auto if_else_cn = w.cn(w.sigma());
             auto if_else    = w.nom_lam(if_else_cn, nullptr);
-            if_else->app(false, brk, {if_else->var(0, w.dbg("mem")), acc});
+            if_else->app(false, brk, acc);
 
-            auto cmp = w.op(ICmp::ul, iter, end);
-            for_lam->branch(false, cmp, if_then, if_else, mem);
+            auto cmp = core::op(core::icmp::ul, iter, end);
+            for_lam->branch(false, cmp, new_body, if_else, w.tuple());
         }
 
-        return rewritten_[def] = w.app(for_lam, for_ax->arg(), for_ax->dbg());
+        DefArray for_args{for_ax->num_args() - 2, [&](size_t i) { return for_ax->arg(i); }};
+        return rewritten_[def] = w.app(for_lam, for_args, for_ax->dbg());
     }
 
     return def;

--- a/dialects/affine/passes/lower_for.h
+++ b/dialects/affine/passes/lower_for.h
@@ -6,7 +6,6 @@
 namespace thorin::affine {
 
 /// Lowers the for axiom to actual control flow in CPS style
-/// Requires CopyProp to cleanup afterwards.
 class LowerFor : public RWPass<Lam> {
 public:
     LowerFor(PassMan& man)

--- a/dialects/core/be/ll/ll.cpp
+++ b/dialects/core/be/ll/ll.cpp
@@ -785,7 +785,26 @@ std::string CodeGen::emit_bb(BB& bb, const Def* def) {
         if (src_type_ptr)                 return bb.assign(name, "ptrtoint {} {} to {}", src_t, src, dst_t);
         if (dst_type_ptr)                 return bb.assign(name, "inttoptr {} {} to {}", src_t, src, dst_t);
         // clang-format on
-        return bb.assign(name, "bitcast {} {} to {}", src_t, src, dst_t);
+
+        auto size2width = [&](const Def* type) {
+            if (type->isa<Nat>()) return 64_u64;
+            if (auto int_ = isa<Tag::Int>(type)) {
+                if (int_->arg()->isa<Top>() || !int_->arg()->isa<Lit>()) return 64_u64;
+                if (auto width = mod2width(as_lit(int_->arg()))) return std::bit_ceil(*width);
+                return 64_u64;
+            }
+            return 0_u64;
+        };
+
+        auto src_size = size2width(bitcast->arg()->type());
+        auto dst_size = size2width(bitcast->type());
+
+        op = "bitcast";
+        if (src_size && dst_size) {
+            if (src_size == dst_size) return src;
+            op = (src_size < dst_size) ? "zext" : "trunc";
+        }
+        return bb.assign(name, "{} {} {} to {}", op, src_t, src, dst_t);
     } else if (auto bitcast = match<core::bitcast>(def)) {
         auto dst_type_ptr = match<mem::Ptr>(bitcast->type());
         auto src_type_ptr = match<mem::Ptr>(bitcast->arg()->type());
@@ -799,7 +818,26 @@ std::string CodeGen::emit_bb(BB& bb, const Def* def) {
         if (src_type_ptr)                 return bb.assign(name, "ptrtoint {} {} to {}", src_t, src, dst_t);
         if (dst_type_ptr)                 return bb.assign(name, "inttoptr {} {} to {}", src_t, src, dst_t);
         // clang-format on
-        return bb.assign(name, "bitcast {} {} to {}", src_t, src, dst_t);
+
+        auto size2width = [&](const Def* type) {
+            if (type->isa<Nat>()) return 64_u64;
+            if (auto int_ = isa<Tag::Int>(type)) {
+                if (int_->arg()->isa<Top>() || !int_->arg()->isa<Lit>()) return 64_u64;
+                if (auto width = mod2width(as_lit(int_->arg()))) return std::bit_ceil(*width);
+                return 64_u64;
+            }
+            return 0_u64;
+        };
+
+        auto src_size = size2width(bitcast->arg()->type());
+        auto dst_size = size2width(bitcast->type());
+
+        op = "bitcast";
+        if (src_size && dst_size) {
+            if (src_size == dst_size) return src;
+            op = (src_size < dst_size) ? "zext" : "trunc";
+        }
+        return bb.assign(name, "{} {} {} to {}", op, src_t, src, dst_t);
     } else if (auto lea = match<mem::lea>(def)) {
         auto [ptr, idx] = lea->args<2>();
         auto ll_ptr     = emit(ptr);

--- a/lit/affine/dynamic_for.thorin
+++ b/lit/affine/dynamic_for.thorin
@@ -6,18 +6,15 @@
 
 .import affine;
 .import mem;
+.import core;
 
 .cn atoi [%mem.M, %mem.Ptr («⊤:.Nat; %Int 256», 0:.Nat), .Cn [%mem.M, %Int 4294967296]];
 
 .cn .extern main [mem : %mem.M, argc : %Int 4294967296, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; %Int 256», 0:.Nat)», 0:.Nat), return : .Cn [%mem.M, %Int 4294967296]] = {
-    .cn for_exit [mem : %mem.M , acc : [%Int 4294967296, %Int 4294967296]] = {
-        return (mem, acc#.ff)
-    };
-
-    .cn for_body [mem : %mem.M , i : %Int 4294967296, acc : [%Int 4294967296, %Int 4294967296], continue : .Cn [%mem.M , [%Int 4294967296, %Int 4294967296]]] = {
-        .let a : %Int 4294967296 = %Wrap_add (0:.Nat, 4294967296:.Nat) (i, acc#.ff);
-        .let b : %Int 4294967296 = %Wrap_sub (0:.Nat, 4294967296:.Nat) (i, acc#.tt);
-        continue (mem, (a, b))
+    .cn for_body [i : %Int 4294967296, [acc_a : %Int 4294967296, acc_b : %Int 4294967296], continue : .Cn [%Int 4294967296, %Int 4294967296]] = {
+        .let a : %Int 4294967296 = %core.wrap.add (0:.Nat, 4294967296:.Nat) (i, acc_a);
+        .let b : %Int 4294967296 = %core.wrap.sub (0:.Nat, 4294967296:.Nat) (i, acc_b);
+        continue (a, b)
     };
     
     .cn atoi_cont_begin [mem : %mem.M, start : %Int 4294967296] = {
@@ -28,7 +25,11 @@
             .let _19318: %mem.Ptr (%mem.Ptr («⊤:.Nat; %Int 256», 0:.Nat), 0:.Nat) = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; %Int 256», 0:.Nat)›, 0:.Nat) (argv, 3:(%Int 4294967296));
             .let _19331: [%mem.M, %mem.Ptr («⊤:.Nat; %Int 256», 0:.Nat)] = %mem.load (%mem.Ptr («⊤:.Nat; %Int 256», 0:.Nat), 0:.Nat) (mem, _19318);
             .cn atoi_cont_step [mem : %mem.M, step : %Int 4294967296] = {
-                %affine.For (4294967296:.Nat, 2:.Nat, (%Int 4294967296, %Int 4294967296)) (mem, start, stop, step, (0:(%Int 4294967296), 5:(%Int 4294967296)), for_body, for_exit)
+                .cn for_exit [acc : [%Int 4294967296, %Int 4294967296]] = {
+                    return (mem, acc#.ff)
+                };
+
+                %affine.For (4294967296:.Nat, 2:.Nat, (%Int 4294967296, %Int 4294967296)) (start, stop, step, (0:(%Int 4294967296), 5:(%Int 4294967296)), for_body, for_exit)
             };
             atoi (_19331#.ff, _19331#.tt, atoi_cont_step)
         };

--- a/lit/affine/for_2acc.thorin
+++ b/lit/affine/for_2acc.thorin
@@ -6,18 +6,19 @@
 
 .import affine;
 .import mem;
+.import core;
 
 .cn .extern main [mem : %mem.M, argc : %Int 4294967296, argv : %mem.Ptr (%mem.Ptr (%Int 4294967296, 0:.Nat), 0:.Nat), return : .Cn [%mem.M, %Int 4294967296]] = {
-    .cn for_exit [mem : %mem.M , acc : [%Int 4294967296, %Int 4294967296]] = {
+    .cn for_exit [acc : [%Int 4294967296, %Int 4294967296]] = {
         return (mem, acc#.ff)
     };
 
-    .cn for_body [mem : %mem.M , i : %Int 4294967296, acc : [%Int 4294967296, %Int 4294967296], continue : .Cn [%mem.M , [%Int 4294967296, %Int 4294967296]]] = {
-        .let a : %Int 4294967296 = %Wrap_add (0:.Nat, 4294967296:.Nat) (i, acc#.ff);
-        .let b : %Int 4294967296 = %Wrap_sub (0:.Nat, 4294967296:.Nat) (i, acc#.tt);
-        continue (mem, (a, b))
+    .cn for_body [i : %Int 4294967296, acc : [%Int 4294967296, %Int 4294967296], continue : .Cn [[%Int 4294967296, %Int 4294967296]]] = {
+        .let a : %Int 4294967296 = %core.wrap.add (0:.Nat, 4294967296:.Nat) (i, acc#.ff);
+        .let b : %Int 4294967296 = %core.wrap.sub (0:.Nat, 4294967296:.Nat) (i, acc#.tt);
+        continue (a, b)
     };
-    %affine.For (4294967296, 2, (%Int 4294967296, %Int 4294967296)) (mem, 0:(%Int 4294967296), argc, 1:(%Int 4294967296), (0:(%Int 4294967296), 0:(%Int 4294967296)), for_body, for_exit)
+    %affine.For (4294967296, 2, (%Int 4294967296, %Int 4294967296)) (0:(%Int 4294967296), argc, 1:(%Int 4294967296), (0:(%Int 4294967296), 0:(%Int 4294967296)), for_body, for_exit)
 };
 
 // CHECK-NOT: affine.for

--- a/lit/affine/for_2acc_2types.thorin
+++ b/lit/affine/for_2acc_2types.thorin
@@ -9,16 +9,16 @@
 .import affine;
 
 .cn .extern main [mem : %mem.M, argc : %Int 4294967296, argv : %mem.Ptr (%mem.Ptr (%Int 4294967296, 0:.Nat), 0:.Nat), return : .Cn [%mem.M, %Int 0]] = {
-    .cn for_exit [mem : %mem.M , acc : [%Int 4294967296, %Int 0]] = {
+    .cn for_exit [acc : [%Int 4294967296, %Int 0]] = {
         return (mem, acc#.tt)
     };
 
-    .cn for_body [mem : %mem.M , i : %Int 4294967296, acc : [%Int 4294967296, %Int 0], continue : .Cn [%mem.M , [%Int 4294967296, %Int 0]]] = {
+    .cn for_body [i : %Int 4294967296, acc : [%Int 4294967296, %Int 0], continue : .Cn [[%Int 4294967296, %Int 0]]] = {
         .let a : %Int 4294967296 = %core.wrap.add (0:.Nat, 4294967296:.Nat) (i, acc#.ff);
         .let b : %Int 0 = %core.wrap.add (0:.Nat, 0:.Nat) (%core.conv.u2u (0, 4294967296) i, acc#.tt);
-        continue (mem, (a, b))
+        continue (a, b)
     };
-    %affine.For (4294967296, 2, (%Int 4294967296, %Int 0)) (mem, 0:(%Int 4294967296), argc, 1:(%Int 4294967296), (0:(%Int 4294967296), 0:(%Int 0)), for_body, for_exit)
+    %affine.For (4294967296, 2, (%Int 4294967296, %Int 0)) (0:(%Int 4294967296), argc, 1:(%Int 4294967296), (0:(%Int 4294967296), 0:(%Int 0)), for_body, for_exit)
 };
 
 // CHECK-NOT: affine.for

--- a/lit/affine/for_2acc_real.thorin
+++ b/lit/affine/for_2acc_real.thorin
@@ -9,16 +9,16 @@
 .import affine;
 
 .cn .extern main [mem : %mem.M, argc : %Int 4294967296, argv : %mem.Ptr (%mem.Ptr (%Int 4294967296, 0:.Nat), 0:.Nat), return : .Cn [%mem.M, %Int 0]] = {
-    .cn for_exit [mem : %mem.M , acc : [%Int 4294967296, %Real 64]] = {
+    .cn for_exit [acc : [%Int 4294967296, %Real 64]] = {
         return (mem, %core.conv.r2u (0, 64) acc#.tt)
     };
 
-    .cn for_body [mem : %mem.M , i : %Int 4294967296, acc : [%Int 4294967296, %Real 64], continue : .Cn [%mem.M , [%Int 4294967296, %Real 64]]] = {
-        .let a : %Int 4294967296 = %core.wrap.add (0:.Nat, 4294967296:.Nat) (i, acc#.ff);
-        .let b : %Real 64 = %core.conv.u2r (64, 0) (%core.wrap.add (0:.Nat, 0:.Nat) (%core.conv.u2u (0, 4294967296) i, %core.conv.r2u (0, 64) acc#.tt));
-        continue (mem, (a, b))
+    .cn for_body [i : %Int 4294967296, [acc_a : %Int 4294967296, acc_b : %Real 64], continue : .Cn [[%Int 4294967296, %Real 64]]] = {
+        .let a : %Int 4294967296 = %core.wrap.add (0:.Nat, 4294967296:.Nat) (i, acc_a);
+        .let b : %Real 64 = %core.conv.u2r (64, 0) (%core.wrap.add (0:.Nat, 0:.Nat) (%core.conv.u2u (0, 4294967296) i, %core.conv.r2u (0, 64) acc_b));
+        continue (a, b)
     };
-    %affine.For (4294967296, 2, (%Int 4294967296, %Real 64)) (mem, 0:(%Int 4294967296), argc, 1:(%Int 4294967296), (0:(%Int 4294967296), 0:(%Real 64)), for_body, for_exit)
+    %affine.For (4294967296, 2, (%Int 4294967296, %Real 64)) (0:(%Int 4294967296), argc, 1:(%Int 4294967296), (0:(%Int 4294967296), 0:(%Real 64)), for_body, for_exit)
 };
 
 // CHECK-NOT: affine.for

--- a/lit/affine/for_over_mem.thorin
+++ b/lit/affine/for_over_mem.thorin
@@ -1,0 +1,32 @@
+// RUN: rm -f %t.ll ; \
+// RUN: %thorin -d affine %s --output-ll %t.ll --output-thorin - | FileCheck %s
+// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %t 0 1 2 3 ; test $? -eq 1
+// RUN: %t 0 1 2 3 4 5 6 7 ; test $? -eq 15
+
+.import affine;
+.import mem;
+.import core;
+
+.let i32 = %Int 4294967296;
+
+.cn .extern main [mem : %mem.M, argc : i32, argv : %mem.Ptr (%mem.Ptr (i32, 0:.Nat), 0:.Nat), return : .Cn [%mem.M, i32]] = {
+    // .let arr_size = 16;
+    .let arr_size = ⊤:.Nat;
+    .let (alloc_mem, ptr) = %mem.alloc (<<%core.bitcast (.Nat, i32) argc; i32>>, 0) (mem);
+    .cn for_exit acc : [mem : %mem.M, i32, i32] = {
+        .let lea = %mem.lea (arr_size, <arr_size; i32>, 0) (ptr, %core.conv.u2u (arr_size, 4294967296) (%core.wrap.sub (0, 4294967296) (argc, 4:i32)));
+        .let (load_mem, val) = %mem.load (i32, 0) (mem, lea);
+        return (load_mem, val)
+    };
+    .cn for_body [i : i32, [mem : %mem.M, acc_a : i32, acc_b : i32], continue : .Cn [%mem.M, i32, i32]] = {
+        .let a : i32 = %core.wrap.add (0:.Nat, 4294967296:.Nat) (i, acc_a);
+        .let b : i32 = %core.wrap.sub (0:.Nat, 4294967296:.Nat) (i, acc_b);
+        .let lea = %mem.lea (arr_size, <arr_size; i32>, 0) (ptr, %core.conv.u2u (arr_size, 4294967296) i);
+        .let store_mem = %mem.store (i32, 0) (mem, lea, a);
+        continue (store_mem, a, b)
+    };
+    %affine.For (4294967296, 3, (%mem.M, i32, i32)) (0:(i32), argc, 1:(i32), (alloc_mem, 0:(i32), 0:(i32)), for_body, for_exit)
+};
+
+// CHECK-NOT: affine.For

--- a/lit/affine/lower_for.thorin
+++ b/lit/affine/lower_for.thorin
@@ -6,41 +6,38 @@
 
 .import affine;
 .import mem;
+.import core;
 
 .cn .extern main (mem : %mem.M, argc : %Int 4294967296, argv : %mem.Ptr (%mem.Ptr (%Int 256, 0:.Nat), 0:.Nat), return : .Cn [%mem.M, %Int 4294967296]) = {
-    .cn for_exit [mem : %mem.M , acc : %Int 4294967296] = {
+    .cn for_exit [acc : %Int 4294967296] = {
         return (mem, acc)
     };
 
-    .cn for_body [mem : %mem.M , i : %Int 4294967296, acc : %Int 4294967296, continue : .Cn [%mem.M , %Int 4294967296]] = {
-        continue (mem, %Wrap_add (0:.Nat, 4294967296:.Nat) (i, acc))
+    .cn for_body [i : %Int 4294967296, acc : %Int 4294967296, continue : .Cn [%Int 4294967296]] = {
+        continue (%core.wrap.add (0:.Nat, 4294967296:.Nat) (i, acc))
     };
-    %affine.For (4294967296, 1, (%Int 4294967296)) (mem, 0:(%Int 4294967296), argc, 1:(%Int 4294967296), (0:(%Int 4294967296)), for_body, for_exit)
+    %affine.For (4294967296, 1, (%Int 4294967296)) (0:(%Int 4294967296), argc, 1:(%Int 4294967296), (0:(%Int 4294967296)), for_body, for_exit)
 };
 
 // CHECK-DAG: .cn .extern main _[[mainVar:[0-9_]+]]::[mem_[[memVar:[0-9_]+]]: %mem.M, argc_[[argcId:[0-9_]+]]: (%Int 4294967296), %mem.Ptr (%mem.Ptr ((%Int 256), 0:.Nat), 0:.Nat), return_[[returnId:[0-9_]+]]: .Cn [%mem.M, (%Int 4294967296)]] = {
 
 // CHECK-DAG: .cn return_[[returnId:[0-9_]+]] _[[returnVarId:[0-9_]+]]: [%mem.M, (%Int 4294967296)]
 
-// CHECK-DAG: .cn for_[[forId:[0-9_]+]] _[[forVarId:[0-9_]+]]::[_[[forMemId:[0-9_]+]]: %mem.M, _[[forIntId:[0-9_]+]]: (%Int 4294967296), _[[forAccId:[0-9_]+]]: (%Int 4294967296)]
-// CHECK-DAG: _[[cmpId:[0-9_]+]]: (%Int 2) = %ICmp_ul
-// CHECK-DAG: _[[appId:[0-9_]+]]: ⊥:★ = (_[[falseId:[0-9_]+]], _[[trueId:[0-9_]+]])#_[[cmpId]]
+// CHECK-DAG: .cn for_[[forId:[0-9_]+]] _[[forVarId:[0-9_]+]]::[_[[forIntId:[0-9_]+]]: (%Int 4294967296), _[[forAccId:[0-9_]+]]: (%Int 4294967296)]
+// CHECK-DAG: _[[cmpId:[0-9_]+]]: (%Int 2) = %core.icmp.XygLe
+// CHECK-DAG: _[[appId:[0-9_]+]]: ⊥:★ = (_[[falseId:[0-9_]+]], for_body_[[bodyId:[0-9_]+]])#_[[cmpId]]
 // CHECK-DAG: _[[appId]]
 
-// CHECK-DAG: .cn _{{[0-9]+}} _[[exitVarId:[0-9_]+]]: %mem.M
-// CHECK-DAG: _[[appIdExit:[0-9_]+]]: ⊥:★ = return_[[returnId]] (_[[exitVarId]], _{{[0-9]+}});
+// CHECK-DAG: .cn _{{[0-9]+}} []
+// CHECK-DAG: _[[appIdExit:[0-9_]+]]: ⊥:★ = return_[[returnId]] (mem_[[memVar]], _{{[0-9]+}});
 // CHECK-DAG: _[[appIdExit]]
 
 
-// CHECK-DAG: .cn for_body_[[forBodyId:[0-9_]+]] _{{[0-9]+}}: %mem.M
-// CHECK-DAG: = %Wrap_add
-// CHECK-DAG: = %Wrap_add
+// CHECK-DAG: .cn for_body_[[bodyId]] []
+// CHECK-DAG: = %core.wrap.add
+// CHECK-DAG: = %core.wrap.add
 // CHECK-DAG: _[[appIdFor:[0-9_]+]]: ⊥:★ = for_[[forId]]
 // CHECK-DAG: _[[appIdFor]]
-
-// CHECK-DAG: .cn _{{[0-9]+}} _{{[0-9]+}}: %mem.M
-// CHECK-DAG: _[[appIdBody:[0-9_]+]]: ⊥:★ = for_body_[[forBodyId]]
-// CHECK-DAG: _[[appIdBody]]
 
 // CHECK-DAG: for_[[forId]]
 // CHECK-NOT: %affine.For


### PR DESCRIPTION
Remove mem parameter from affine.For and its body / break cns. If a mem parameter is required, it can be propagated through the accumulator.
While at it, also removed the hard dependency on CopyProp & LamSpec by directly reducing the continuations into the lamdas.

cc  @NeuralCoder3 