### PR TITLE
bug fix: precedence with arrow and lam/cn

### DIFF
--- a/docs/langref.md
+++ b/docs/langref.md
@@ -186,17 +186,20 @@ An elided type of
 
 Expressions nesting is disambiguated according to the following precedence table (from strongest to weakest binding):
 
-| Operator      | Description                         | Associativity |
-|---------------|-------------------------------------|---------------|
-| L `:` e       | type ascription of a literal        | -             |
-| e `#` e       | extract                             | left-to-right |
-| e e           | application                         | left-to-right |
-| `Π` Sym `:` e | domain of a dependent function type | -             |
-| e `→` e       | function type                       | right-to-left |
+| Operator         | Description                         | Associativity |
+|------------------|-------------------------------------|---------------|
+| L `:` e          | type ascription of a literal        | -             |
+| e `#` e          | extract                             | left-to-right |
+| e e              | application                         | left-to-right |
+| `Π` Sym `:` e    | domain of a dependent function type | -             |
+| `.lam` Sym `:` e | nominal lambda declaration          | -             |
+| `.cn` Sym `:` e  | nominal continuation declaration    | -             |
+| e `→` e          | function type                       | right-to-left |
 
 Note that the domain of a dependent function type binds slightly stronger than `→`.
-This has the effect that, e.g., `Π T: * → T -> T` has the expected binding like this: (`Π T: *`) `→` (`T → T`).
+This has the effect that, e.g., `Π T: * → T → T` has the expected binding like this: (`Π T: *`) `→` (`T → T`).
 Otherwise, `→` would be consumed by the domain: `Π T:` (`* →` (`T → T`)) ↯.
+A similar situation occurs for `.lam`/`.cn` declaration.
 
 ## Scoping
 
@@ -229,10 +232,10 @@ These names take precedence over the usual scope.
 In the following example, `i` refers to the first element `i` of `X` and **not** to the `i` introduced via `.let`:
 ```
 .let i = 1_2;
-Π X: [i: .Nat, j: .Nat] -> f X#i;
+Π X: [i: .Nat, j: .Nat] → f X#i;
 ```
 Use parentheses to refer to the `.let`-bounded `i`:
 ```
 .let i = 1_2;
-Π X: [i: .Nat, j: .Nat] -> f X#(i);
+Π X: [i: .Nat, j: .Nat] → f X#(i);
 ```

--- a/lit/prec.thorin
+++ b/lit/prec.thorin
@@ -1,0 +1,5 @@
+// RUN: %thorin %s -o - | FileCheck %s
+
+.lam .extern f x: .Nat -> .Nat = x;
+
+// CHECK-DAG: .lam .extern f x_{{[0-9]+}}: .Nat → .Nat =

--- a/thorin/fe/parser.cpp
+++ b/thorin/fe/parser.cpp
@@ -727,7 +727,7 @@ void Parser::parse_nom_fun() {
 
     bool external = accept(Tok::Tag::K_extern).has_value();
     auto sym      = parse_sym("nominal lambda");
-    auto dom_p    = parse_ptrn(Tok::Tag::D_paren_l, "domain pattern of a lambda");
+    auto dom_p    = parse_ptrn(Tok::Tag::D_paren_l, "domain pattern of a lambda", Tok::Prec::Pi);
     auto dom_t    = dom_p->type(world());
     auto pi       = world().nom_pi(world().nom_infer_univ())->set_dom(dom_t);
     auto var_dbg  = world().dbg(dom_p->sym());

--- a/thorin/fe/tok.h
+++ b/thorin/fe/tok.h
@@ -84,7 +84,8 @@ constexpr auto Num_Keys = size_t(0) THORIN_KEY(CODE);
     /* left     prec,    right  */      \
     m(Nil,      Bot,     Nil     )      \
     m(Nil,      Nil,     Nil     )      \
-    m(Pi,       Arrow,   Arrow   )      \
+    m(Lam,      Arrow,   Arrow   )      \
+    m(Nil,      Lam,     Pi      )      \
     m(Nil,      Pi,      App     )      \
     m(App,      App,     Extract )      \
     m(Extract,  Extract, Lit     )      \


### PR DESCRIPTION
Adds another prec level so this one works as expected:
```
.lam .extern h x: .Nat -> .Nat = x;
```