### PR TITLE
parse filter

### DIFF
--- a/thorin/fe/parser.cpp
+++ b/thorin/fe/parser.cpp
@@ -755,8 +755,14 @@ void Parser::parse_nom_fun() {
     dom_p->bind(scopes_, lam_var);
 
     if (accept(Tok::Tag::T_assign)) {
-        auto body = parse_expr("body of a lambda");
-        lam->set(false, body);
+        const Def* filter = world().lit_bool(false);
+        auto body         = parse_expr("filter/body of a lambda");
+        if (ahead().tag() == Tok::Tag::T_comma) {
+            eat(Tok::Tag::T_comma);
+            filter = body;
+            body   = parse_expr("body of a lambda");
+        }
+        lam->set(filter, body);
     }
     expect(Tok::Tag::T_semicolon, "end of lambda");
 


### PR DESCRIPTION
A simple addition to the parser 
for parsing filters.

A nominal function now first parses 
an expression after `=` and checks if a `,` follows.
If this is the case, the parsed expression is used as filter
and the body is parsed. 
Otherwise, the parsed expression is used as body.

This way (as opposed to moving the filter into the body),
the filter is near the lambda definition and separated from the body.