### PR TITLE
Refactor/int

### DIFF
--- a/dialects/affine/affine.thorin
+++ b/dialects/affine/affine.thorin
@@ -23,7 +23,7 @@
 ///
 /// After termination of the loop `exit` is invoked.
 .ax %affine.For: Π [m: .Nat , n: .Nat , Ts: «n; *»] ->
-    .Cn [start: %Int m, stop: %Int m, step: %Int m, init: «i: n; Ts#i»,
-        body: .Cn [iter: %Int m, acc: «i: n; Ts#i», yield: .Cn [«i: n; Ts#i»]], 
+    .Cn [start: .Int m, stop: .Int m, step: .Int m, init: «i: n; Ts#i»,
+        body: .Cn [iter: .Int m, acc: «i: n; Ts#i», yield: .Cn [«i: n; Ts#i»]], 
         exit: .Cn [«i: n; Ts#i»]];
 

--- a/dialects/clos/clos.thorin
+++ b/dialects/clos/clos.thorin
@@ -8,10 +8,10 @@
 ///
 /// ## Operations related to longjmp
 ///
-.let BufPtr = %Int 8;
+.let BufPtr = .Int 8;
 .ax %clos.alloc_jmpbuf: [[], %mem.M] -> [%mem.M, BufPtr];
-.ax %clos.setjmp: [%mem.M, BufPtr] -> [%mem.M, BufPtr, %Int 4294967296];
-.ax %clos.longjmp: .Cn [%mem.M, BufPtr, %Int 4294967296];
+.ax %clos.setjmp: [%mem.M, BufPtr] -> [%mem.M, BufPtr, .Int 4294967296];
+.ax %clos.longjmp: .Cn [%mem.M, BufPtr, .Int 4294967296];
 ///
 /// ## Closure Annotations
 ///

--- a/dialects/clos/phase/lower_typed_clos.cpp
+++ b/dialects/clos/phase/lower_typed_clos.cpp
@@ -113,7 +113,7 @@ const Def* LowerTypedClos::rewrite(const Def* def) {
 
     if (auto c = isa_clos_lit(def)) {
         auto env      = rewrite(c.env());
-        auto mode     = (isa<Tag::Int>(env->type()) || isa<Tag::Ptr>(env->type())) ? Unbox : Box;
+        auto mode     = (env->type()->isa<Int>() || isa<Tag::Ptr>(env->type())) ? Unbox : Box;
         const Def* fn = make_stub(c.fnc_as_lam(), mode, true);
         if (env->type() == w.sigma()) {
             // Optimize empty env

--- a/dialects/core/be/ll/ll.cpp
+++ b/dialects/core/be/ll/ll.cpp
@@ -127,8 +127,8 @@ std::string Emitter::convert(const Def* type) {
 
     if (type->isa<Nat>()) {
         return types_[type] = "i64";
-    } else if (isa<Tag::Int>(type)) {
-        auto size = isa_sized_type(type);
+    } else if (auto int_t = type->isa<Int>()) {
+        auto size = int_t->size();
         if (size->isa<Top>()) return types_[type] = "i64";
         if (auto width = mod2width(as_lit(size))) {
             switch (*width) {
@@ -455,8 +455,8 @@ std::string Emitter::emit_bb(BB& bb, const Def* def) {
     if (auto lit = def->isa<Lit>()) {
         if (lit->type()->isa<Nat>()) {
             return std::to_string(lit->get<nat_t>());
-        } else if (isa<Tag::Int>(lit->type())) {
-            auto size = isa_sized_type(lit->type());
+        } else if (auto int_t = lit->type()->isa<Int>()) {
+            auto size = int_t->size();
             if (size->isa<Top>()) return std::to_string(lit->get<nat_t>());
             if (auto mod = mod2width(as_lit(size))) {
                 switch (*mod) {
@@ -712,9 +712,9 @@ std::string Emitter::emit_bb(BB& bb, const Def* def) {
         auto dst_t = convert(conv->type());
 
         auto size2width = [&](const Def* type) {
-            if (auto int_ = isa<Tag::Int>(type)) {
-                if (int_->arg()->isa<Top>()) return 64_u64;
-                if (auto width = mod2width(as_lit(int_->arg()))) return *width;
+            if (auto int_t = type->isa<Int>()) {
+                if (int_t->size()->isa<Top>()) return 64_u64;
+                if (auto width = mod2width(as_lit(int_t->size()))) return *width;
                 return 64_u64;
             }
             return as_lit(as<Tag::Real>(type)->arg());
@@ -746,9 +746,9 @@ std::string Emitter::emit_bb(BB& bb, const Def* def) {
         auto dst_t = convert(conv->type());
 
         auto size2width = [&](const Def* type) {
-            if (auto int_ = isa<Tag::Int>(type)) {
-                if (int_->arg()->isa<Top>()) return 64_u64;
-                if (auto width = mod2width(as_lit(int_->arg()))) return *width;
+            if (auto int_t = type->isa<Int>()) {
+                if (int_t->size()->isa<Top>()) return 64_u64;
+                if (auto width = mod2width(as_lit(int_t->size()))) return *width;
                 return 64_u64;
             }
             return as_lit(as<Tag::Real>(type)->arg());
@@ -790,9 +790,9 @@ std::string Emitter::emit_bb(BB& bb, const Def* def) {
 
         auto size2width = [&](const Def* type) {
             if (type->isa<Nat>()) return 64_u64;
-            if (auto int_ = isa<Tag::Int>(type)) {
-                if (int_->arg()->isa<Top>() || !int_->arg()->isa<Lit>()) return 64_u64;
-                if (auto width = mod2width(as_lit(int_->arg()))) return std::bit_ceil(*width);
+            if (auto int_t = type->isa<Int>()) {
+                if (int_t->size()->isa<Top>() || !int_t->size()->isa<Lit>()) return 64_u64;
+                if (auto width = mod2width(as_lit(int_t->size()))) return std::bit_ceil(*width);
                 return 64_u64;
             }
             return 0_u64;
@@ -823,9 +823,9 @@ std::string Emitter::emit_bb(BB& bb, const Def* def) {
 
         auto size2width = [&](const Def* type) {
             if (type->isa<Nat>()) return 64_u64;
-            if (auto int_ = isa<Tag::Int>(type)) {
-                if (int_->arg()->isa<Top>() || !int_->arg()->isa<Lit>()) return 64_u64;
-                if (auto width = mod2width(as_lit(int_->arg()))) return std::bit_ceil(*width);
+            if (auto int_t = type->isa<Int>()) {
+                if (int_t->size()->isa<Top>() || !int_t->size()->isa<Lit>()) return 64_u64;
+                if (auto width = mod2width(as_lit(int_t->size()))) return std::bit_ceil(*width);
                 return 64_u64;
             }
             return 0_u64;
@@ -853,8 +853,8 @@ std::string Emitter::emit_bb(BB& bb, const Def* def) {
         auto ll_idx = emit(idx);
         auto idx_t  = convert(idx->type());
 
-        if (auto int_t = as<Tag::Int>(idx->type())) {
-            auto size = isa_sized_type(int_t);
+        if (auto int_t = idx->type()->isa<Int>()) {
+            auto size = int_t->size();
             if (auto s = isa_lit(size); s && *s == 2) { // mod(2) = width(1)
                 ll_idx = bb.assign(name + ".8", "zext i1 {} to i8", ll_idx);
                 idx_t  = "i8";

--- a/dialects/core/core.h
+++ b/dialects/core/core.h
@@ -43,24 +43,24 @@ inline const Def* fn_bitcast(const Def* dst_t, const Def* src_t, const Def* dbg 
 ///@{
 inline const Def* op(bit2 o, const Def* a, const Def* b, const Def* dbg = {}) {
     World& w = a->world();
-    return w.app(fn(o, w.infer(a)), {a, b}, dbg);
+    return w.app(fn(o, w.iinfer(a)), {a, b}, dbg);
 }
 inline const Def* op(icmp o, const Def* a, const Def* b, const Def* dbg = {}) {
     World& w = a->world();
-    return w.app(fn(o, w.infer(a)), {a, b}, dbg);
+    return w.app(fn(o, w.iinfer(a)), {a, b}, dbg);
 }
 
 inline const Def* op(shr o, const Def* a, const Def* b, const Def* dbg = {}) {
     World& w = a->world();
-    return w.app(fn(o, w.infer(a)), {a, b}, dbg);
+    return w.app(fn(o, w.iinfer(a)), {a, b}, dbg);
 }
 inline const Def* op(wrap o, const Def* wmode, const Def* a, const Def* b, const Def* dbg = {}) {
     World& w = a->world();
-    return w.app(fn(o, wmode, w.infer(a)), {a, b}, dbg);
+    return w.app(fn(o, wmode, w.iinfer(a)), {a, b}, dbg);
 }
 inline const Def* op(div o, const Def* mem, const Def* a, const Def* b, const Def* dbg = {}) {
     World& w = mem->world();
-    return w.app(fn(o, w.infer(a)), {mem, a, b}, dbg);
+    return w.app(fn(o, w.iinfer(a)), {mem, a, b}, dbg);
 }
 
 template<class O>
@@ -85,18 +85,18 @@ inline const Def* op_bitcast(const Def* dst_type, const Def* src, const Def* dbg
 ///@{
 inline const Def* op_negate(const Def* a, const Def* dbg = {}) {
     World& w   = a->world();
-    auto width = as_lit(w.infer(a));
+    auto width = as_lit(w.iinfer(a));
     return op(bit2::_xor, w.lit_int(width, width - 1_u64), a, dbg);
 }
 // todo: real op
 // const Def* op_rminus(const Def* rmode, const Def* a, const Def* dbg = {}) {
 //     World& w   = rmode->world();
-//     auto width = as_lit(w.infer(a));
+//     auto width = as_lit(w.iinfer(a));
 //     return op(ROp::sub, rmode, w.lit_real(width, -0.0), a, dbg);
 // }
 inline const Def* op_wminus(const Def* wmode, const Def* a, const Def* dbg = {}) {
     World& w   = a->world();
-    auto width = as_lit(w.infer(a));
+    auto width = as_lit(w.iinfer(a));
     return op(wrap::sub, wmode, w.lit_int(width, 0), a, dbg);
 }
 // todo: real op

--- a/dialects/core/core.thorin
+++ b/dialects/core/core.thorin
@@ -8,9 +8,9 @@
 ///
 /// ## Types
 ///
-/// ### %core.Int
+/// ### %core.Real
 ///
-.ax %core.Int: .Nat -> *;
+.ax %core.Real: .Nat -> *;
 ///
 /// ## Operations
 ///
@@ -80,7 +80,7 @@
                xYgle,     xYglE,     xYgLe = sl, xYgLE = sle, xYGle = ug, xYGlE = uge, xYGLe,      xYGLE,
                Xygle,     XyglE,     XygLe = ul, XygLE = ule, XyGle = sg, XyGlE = sge, XyGLe,      XyGLE,
                XYgle,     XYglE,     XYgLe,      XYgLE,       XYGle,      XYGlE,       XYGLe = ne, XYGLE = t):
-    Π w: .Nat -> [%Int w, %Int w] -> .Bool , normalize_icmp;
+    Π w: .Nat -> [.Int w, .Int w] -> .Bool , normalize_icmp;
 ///
 /// ### %core.bit1
 ///
@@ -92,7 +92,7 @@
 /// | neg    | o | x | negate                       |
 /// | id     | x | o | identity                     |
 /// | t      | x | x | always true                  |
-.ax %core.bit1(f, neg, id, t): Π w: .Nat -> %Int w -> %Int w;
+.ax %core.bit1(f, neg, id, t): Π w: .Nat -> .Int w -> .Int w;
 ///
 /// ### %core.bit2
 ///
@@ -118,26 +118,26 @@
 /// | t      |  x |  x |  x |  x | always true                  |
 .ax %core.bit2( f,      nor,    nciff,  na,     niff,   nb,   _xor, nand,
                 _and,  nxor,    b,      iff,    a,      ciff, _or,  t):
-    Π w: .Nat -> [%Int w, %Int w] -> %Int w , normalize_bit2;
+    Π w: .Nat -> [.Int w, .Int w] -> .Int w , normalize_bit2;
 ///
 /// ### %core.shr
 ///
-.ax %core.shr(ashr, lshr): Π w: .Nat -> [%Int w, %Int w] -> %Int w, normalize_shr;
+.ax %core.shr(ashr, lshr): Π w: .Nat -> [.Int w, .Int w] -> .Int w, normalize_shr;
 ///
 /// ### %core.wrap
 ///
-.ax %core.wrap(add, sub, mul, shl): Π [m: .Nat, w: .Nat] -> [%Int w, %Int w] -> %Int w, normalize_wrap;
+.ax %core.wrap(add, sub, mul, shl): Π [m: .Nat, w: .Nat] -> [.Int w, .Int w] -> .Int w, normalize_wrap;
 ///
 /// ### %core.div
 ///
-.ax %core.div(sdiv, udiv, srem, urem): Π w: .Nat -> [%mem.M, %Int w, %Int w] -> [%mem.M, %Int w], normalize_div;
+.ax %core.div(sdiv, udiv, srem, urem): Π w: .Nat -> [%mem.M, .Int w, .Int w] -> [%mem.M, .Int w], normalize_div;
 ///
 /// ### %core.conv
 ///
-/// Bit width (and signedness) conversion for `%Int -> %Int` and `%Real -> %Real` as well as `%Real -> %Int` and `%Int -> %Real` conversions.
-.ax %core.conv(s2s, u2u): Π [dw: .Nat, sw: .Nat] -> %Int sw -> %Int dw, normalize_conv;
-.ax %core.conv(s2r, u2r): Π [dw: .Nat, sw: .Nat] -> %Int sw -> %Real dw, normalize_conv;
-.ax %core.conv(r2s, r2u): Π [dw: .Nat, sw: .Nat] -> %Real sw -> %Int dw, normalize_conv;
+/// Bit width (and signedness) conversion for `.Int -> .Int` and `%Real -> %Real` as well as `%Real -> .Int` and `.Int -> %Real` conversions.
+.ax %core.conv(s2s, u2u): Π [dw: .Nat, sw: .Nat] -> .Int sw -> .Int dw, normalize_conv;
+.ax %core.conv(s2r, u2r): Π [dw: .Nat, sw: .Nat] -> .Int sw -> %Real dw, normalize_conv;
+.ax %core.conv(r2s, r2u): Π [dw: .Nat, sw: .Nat] -> %Real sw -> .Int dw, normalize_conv;
 .ax %core.conv(r2r): Π [dw: .Nat, sw: .Nat] -> %Real sw -> %Real dw, normalize_conv;
 ///
 /// ### %core.bitcast

--- a/dialects/core/normalizers.cpp
+++ b/dialects/core/normalizers.cpp
@@ -565,8 +565,8 @@ static const Def* fold_conv(const Def* dst_type, const App* callee, const Def* s
             return world.lit(dst_type, as_lit(lit_src) % *lit_dw);
         }
 
-        if (isa<Tag::Int>(src->type())) *lit_sw = *mod2width(*lit_sw);
-        if (isa<Tag::Int>(dst_type)) *lit_dw = *mod2width(*lit_dw);
+        if (src->type()->isa<Int>()) *lit_sw = *mod2width(*lit_sw);
+        if (dst_type->isa<Int>()) *lit_dw = *mod2width(*lit_dw);
 
         Res res;
 #define CODE(sw, dw)                                                                                 \
@@ -613,7 +613,7 @@ const Def* normalize_bitcast(const Def* dst_type, const Def* callee, const Def* 
 
     if (auto lit = src->isa<Lit>()) {
         if (dst_type->isa<Nat>()) return world.lit(dst_type, lit->get(), dbg);
-        if (isa_sized_type(dst_type)) return world.lit(dst_type, lit->get(), dbg);
+        if (dst_type->isa<Int>()) return world.lit(dst_type, lit->get(), dbg);
     }
 
     return world.raw_app(callee, src, dbg);

--- a/dialects/mem/mem.thorin
+++ b/dialects/mem/mem.thorin
@@ -65,4 +65,4 @@
 ///
 /// Load effective address. 
 /// Performs address computation.
-.ax %mem.lea: Π [n: .Nat, Ts: «n; *», as: .Nat] -> Π [%mem.Ptr(«j: n; Ts#j», as), i: %Int n] -> %mem.Ptr(Ts#i, as), normalize_lea;
+.ax %mem.lea: Π [n: .Nat, Ts: «n; *», as: .Nat] -> Π [%mem.Ptr(«j: n; Ts#j», as), i: .Int n] -> %mem.Ptr(Ts#i, as), normalize_lea;

--- a/gtest/test.cpp
+++ b/gtest/test.cpp
@@ -43,7 +43,7 @@ TEST(World, simplify_one_tuple) {
     ASSERT_EQ(w.lit_ff(), w.tuple({w.lit_ff()})) << "constant fold (false) -> false";
 
     auto type = w.nom_sigma(w.type(), 2);
-    type->set({w.type_int(), w.type_int()});
+    type->set({w.type_nat(), w.type_nat()});
     ASSERT_EQ(type, w.sigma({type})) << "constant fold [nom] -> nom";
 
     auto v = w.tuple(type, {w.lit_int(42), w.lit_int(1337)});

--- a/lit/affine/dynamic_for.thorin
+++ b/lit/affine/dynamic_for.thorin
@@ -8,36 +8,36 @@
 .import mem;
 .import core;
 
-.cn atoi [%mem.M, %mem.Ptr («⊤:.Nat; %Int 256», 0:.Nat), .Cn [%mem.M, %Int 4294967296]];
+.cn atoi [%mem.M, %mem.Ptr («⊤:.Nat; .Int 256», 0:.Nat), .Cn [%mem.M, .Int 4294967296]];
 
-.cn .extern main [mem : %mem.M, argc : %Int 4294967296, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; %Int 256», 0:.Nat)», 0:.Nat), return : .Cn [%mem.M, %Int 4294967296]] = {
-    .cn for_body [i : %Int 4294967296, [acc_a : %Int 4294967296, acc_b : %Int 4294967296], continue : .Cn [%Int 4294967296, %Int 4294967296]] = {
-        .let a : %Int 4294967296 = %core.wrap.add (0:.Nat, 4294967296:.Nat) (i, acc_a);
-        .let b : %Int 4294967296 = %core.wrap.sub (0:.Nat, 4294967296:.Nat) (i, acc_b);
+.cn .extern main [mem : %mem.M, argc : .Int 4294967296, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .Int 256», 0:.Nat)», 0:.Nat), return : .Cn [%mem.M, .Int 4294967296]] = {
+    .cn for_body [i : .Int 4294967296, [acc_a : .Int 4294967296, acc_b : .Int 4294967296], continue : .Cn [.Int 4294967296, .Int 4294967296]] = {
+        .let a : .Int 4294967296 = %core.wrap.add (0:.Nat, 4294967296:.Nat) (i, acc_a);
+        .let b : .Int 4294967296 = %core.wrap.sub (0:.Nat, 4294967296:.Nat) (i, acc_b);
         continue (a, b)
     };
     
-    .cn atoi_cont_begin [mem : %mem.M, start : %Int 4294967296] = {
-        .let _19234: %mem.Ptr (%mem.Ptr («⊤:.Nat; %Int 256», 0:.Nat), 0:.Nat) = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; %Int 256», 0:.Nat)›, 0:.Nat) (argv, 2:(%Int 4294967296));
-        .let _19247: [%mem.M, %mem.Ptr («⊤:.Nat; %Int 256», 0:.Nat)] = %mem.load (%mem.Ptr («⊤:.Nat; %Int 256», 0:.Nat), 0:.Nat) (mem, _19234);
+    .cn atoi_cont_begin [mem : %mem.M, start : .Int 4294967296] = {
+        .let _19234: %mem.Ptr (%mem.Ptr («⊤:.Nat; .Int 256», 0:.Nat), 0:.Nat) = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .Int 256», 0:.Nat)›, 0:.Nat) (argv, 2:(.Int 4294967296));
+        .let _19247: [%mem.M, %mem.Ptr («⊤:.Nat; .Int 256», 0:.Nat)] = %mem.load (%mem.Ptr («⊤:.Nat; .Int 256», 0:.Nat), 0:.Nat) (mem, _19234);
 
-        .cn atoi_cont_end [mem : %mem.M, stop : %Int 4294967296] = {
-            .let _19318: %mem.Ptr (%mem.Ptr («⊤:.Nat; %Int 256», 0:.Nat), 0:.Nat) = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; %Int 256», 0:.Nat)›, 0:.Nat) (argv, 3:(%Int 4294967296));
-            .let _19331: [%mem.M, %mem.Ptr («⊤:.Nat; %Int 256», 0:.Nat)] = %mem.load (%mem.Ptr («⊤:.Nat; %Int 256», 0:.Nat), 0:.Nat) (mem, _19318);
-            .cn atoi_cont_step [mem : %mem.M, step : %Int 4294967296] = {
-                .cn for_exit [acc : [%Int 4294967296, %Int 4294967296]] = {
+        .cn atoi_cont_end [mem : %mem.M, stop : .Int 4294967296] = {
+            .let _19318: %mem.Ptr (%mem.Ptr («⊤:.Nat; .Int 256», 0:.Nat), 0:.Nat) = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .Int 256», 0:.Nat)›, 0:.Nat) (argv, 3:(.Int 4294967296));
+            .let _19331: [%mem.M, %mem.Ptr («⊤:.Nat; .Int 256», 0:.Nat)] = %mem.load (%mem.Ptr («⊤:.Nat; .Int 256», 0:.Nat), 0:.Nat) (mem, _19318);
+            .cn atoi_cont_step [mem : %mem.M, step : .Int 4294967296] = {
+                .cn for_exit [acc : [.Int 4294967296, .Int 4294967296]] = {
                     return (mem, acc#.ff)
                 };
 
-                %affine.For (4294967296:.Nat, 2:.Nat, (%Int 4294967296, %Int 4294967296)) (start, stop, step, (0:(%Int 4294967296), 5:(%Int 4294967296)), for_body, for_exit)
+                %affine.For (4294967296:.Nat, 2:.Nat, (.Int 4294967296, .Int 4294967296)) (start, stop, step, (0:(.Int 4294967296), 5:(.Int 4294967296)), for_body, for_exit)
             };
             atoi (_19331#.ff, _19331#.tt, atoi_cont_step)
         };
         atoi (_19247#.ff, _19247#.tt, atoi_cont_end)
     };
 
-    .let _19093: %mem.Ptr (%mem.Ptr («⊤:.Nat; %Int 256», 0:.Nat), 0:.Nat) = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; %Int 256», 0:.Nat)›, 0:.Nat) (argv, 1:(%Int 4294967296));
-    .let _19163: [%mem.M, %mem.Ptr («⊤:.Nat; %Int 256», 0:.Nat)] = %mem.load (%mem.Ptr («⊤:.Nat; %Int 256», 0:.Nat), 0:.Nat) (mem, _19093);
+    .let _19093: %mem.Ptr (%mem.Ptr («⊤:.Nat; .Int 256», 0:.Nat), 0:.Nat) = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .Int 256», 0:.Nat)›, 0:.Nat) (argv, 1:(.Int 4294967296));
+    .let _19163: [%mem.M, %mem.Ptr («⊤:.Nat; .Int 256», 0:.Nat)] = %mem.load (%mem.Ptr («⊤:.Nat; .Int 256», 0:.Nat), 0:.Nat) (mem, _19093);
     atoi (_19163#.ff, _19163#.tt, atoi_cont_begin)
 };
 

--- a/lit/affine/for_2acc.thorin
+++ b/lit/affine/for_2acc.thorin
@@ -8,17 +8,17 @@
 .import mem;
 .import core;
 
-.cn .extern main [mem : %mem.M, argc : %Int 4294967296, argv : %mem.Ptr (%mem.Ptr (%Int 4294967296, 0:.Nat), 0:.Nat), return : .Cn [%mem.M, %Int 4294967296]] = {
-    .cn for_exit [acc : [%Int 4294967296, %Int 4294967296]] = {
+.cn .extern main [mem : %mem.M, argc : .Int 4294967296, argv : %mem.Ptr (%mem.Ptr (.Int 4294967296, 0:.Nat), 0:.Nat), return : .Cn [%mem.M, .Int 4294967296]] = {
+    .cn for_exit [acc : [.Int 4294967296, .Int 4294967296]] = {
         return (mem, acc#.ff)
     };
 
-    .cn for_body [i : %Int 4294967296, acc : [%Int 4294967296, %Int 4294967296], continue : .Cn [[%Int 4294967296, %Int 4294967296]]] = {
-        .let a : %Int 4294967296 = %core.wrap.add (0:.Nat, 4294967296:.Nat) (i, acc#.ff);
-        .let b : %Int 4294967296 = %core.wrap.sub (0:.Nat, 4294967296:.Nat) (i, acc#.tt);
+    .cn for_body [i : .Int 4294967296, acc : [.Int 4294967296, .Int 4294967296], continue : .Cn [[.Int 4294967296, .Int 4294967296]]] = {
+        .let a : .Int 4294967296 = %core.wrap.add (0:.Nat, 4294967296:.Nat) (i, acc#.ff);
+        .let b : .Int 4294967296 = %core.wrap.sub (0:.Nat, 4294967296:.Nat) (i, acc#.tt);
         continue (a, b)
     };
-    %affine.For (4294967296, 2, (%Int 4294967296, %Int 4294967296)) (0:(%Int 4294967296), argc, 1:(%Int 4294967296), (0:(%Int 4294967296), 0:(%Int 4294967296)), for_body, for_exit)
+    %affine.For (4294967296, 2, (.Int 4294967296, .Int 4294967296)) (0:(.Int 4294967296), argc, 1:(.Int 4294967296), (0:(.Int 4294967296), 0:(.Int 4294967296)), for_body, for_exit)
 };
 
 // CHECK-NOT: affine.for

--- a/lit/affine/for_2acc_2types.thorin
+++ b/lit/affine/for_2acc_2types.thorin
@@ -8,17 +8,17 @@
 .import mem;
 .import affine;
 
-.cn .extern main [mem : %mem.M, argc : %Int 4294967296, argv : %mem.Ptr (%mem.Ptr (%Int 4294967296, 0:.Nat), 0:.Nat), return : .Cn [%mem.M, %Int 0]] = {
-    .cn for_exit [acc : [%Int 4294967296, %Int 0]] = {
+.cn .extern main [mem : %mem.M, argc : .Int 4294967296, argv : %mem.Ptr (%mem.Ptr (.Int 4294967296, 0:.Nat), 0:.Nat), return : .Cn [%mem.M, .Int 0]] = {
+    .cn for_exit [acc : [.Int 4294967296, .Int 0]] = {
         return (mem, acc#.tt)
     };
 
-    .cn for_body [i : %Int 4294967296, acc : [%Int 4294967296, %Int 0], continue : .Cn [[%Int 4294967296, %Int 0]]] = {
-        .let a : %Int 4294967296 = %core.wrap.add (0:.Nat, 4294967296:.Nat) (i, acc#.ff);
-        .let b : %Int 0 = %core.wrap.add (0:.Nat, 0:.Nat) (%core.conv.u2u (0, 4294967296) i, acc#.tt);
+    .cn for_body [i : .Int 4294967296, acc : [.Int 4294967296, .Int 0], continue : .Cn [[.Int 4294967296, .Int 0]]] = {
+        .let a : .Int 4294967296 = %core.wrap.add (0:.Nat, 4294967296:.Nat) (i, acc#.ff);
+        .let b : .Int 0 = %core.wrap.add (0:.Nat, 0:.Nat) (%core.conv.u2u (0, 4294967296) i, acc#.tt);
         continue (a, b)
     };
-    %affine.For (4294967296, 2, (%Int 4294967296, %Int 0)) (0:(%Int 4294967296), argc, 1:(%Int 4294967296), (0:(%Int 4294967296), 0:(%Int 0)), for_body, for_exit)
+    %affine.For (4294967296, 2, (.Int 4294967296, .Int 0)) (0:(.Int 4294967296), argc, 1:(.Int 4294967296), (0:(.Int 4294967296), 0:(.Int 0)), for_body, for_exit)
 };
 
 // CHECK-NOT: affine.for

--- a/lit/affine/for_2acc_real.thorin
+++ b/lit/affine/for_2acc_real.thorin
@@ -8,17 +8,17 @@
 .import mem;
 .import affine;
 
-.cn .extern main [mem : %mem.M, argc : %Int 4294967296, argv : %mem.Ptr (%mem.Ptr (%Int 4294967296, 0:.Nat), 0:.Nat), return : .Cn [%mem.M, %Int 0]] = {
-    .cn for_exit [acc : [%Int 4294967296, %Real 64]] = {
+.cn .extern main [mem : %mem.M, argc : .Int 4294967296, argv : %mem.Ptr (%mem.Ptr (.Int 4294967296, 0:.Nat), 0:.Nat), return : .Cn [%mem.M, .Int 0]] = {
+    .cn for_exit [acc : [.Int 4294967296, %Real 64]] = {
         return (mem, %core.conv.r2u (0, 64) acc#.tt)
     };
 
-    .cn for_body [i : %Int 4294967296, [acc_a : %Int 4294967296, acc_b : %Real 64], continue : .Cn [[%Int 4294967296, %Real 64]]] = {
-        .let a : %Int 4294967296 = %core.wrap.add (0:.Nat, 4294967296:.Nat) (i, acc_a);
+    .cn for_body [i : .Int 4294967296, [acc_a : .Int 4294967296, acc_b : %Real 64], continue : .Cn [[.Int 4294967296, %Real 64]]] = {
+        .let a : .Int 4294967296 = %core.wrap.add (0:.Nat, 4294967296:.Nat) (i, acc_a);
         .let b : %Real 64 = %core.conv.u2r (64, 0) (%core.wrap.add (0:.Nat, 0:.Nat) (%core.conv.u2u (0, 4294967296) i, %core.conv.r2u (0, 64) acc_b));
         continue (a, b)
     };
-    %affine.For (4294967296, 2, (%Int 4294967296, %Real 64)) (0:(%Int 4294967296), argc, 1:(%Int 4294967296), (0:(%Int 4294967296), 0:(%Real 64)), for_body, for_exit)
+    %affine.For (4294967296, 2, (.Int 4294967296, %Real 64)) (0:(.Int 4294967296), argc, 1:(.Int 4294967296), (0:(.Int 4294967296), 0:(%Real 64)), for_body, for_exit)
 };
 
 // CHECK-NOT: affine.for

--- a/lit/affine/for_over_mem.thorin
+++ b/lit/affine/for_over_mem.thorin
@@ -8,7 +8,7 @@
 .import mem;
 .import core;
 
-.let i32 = %Int 4294967296;
+.let i32 = .Int 4294967296;
 
 .cn .extern main [mem : %mem.M, argc : i32, argv : %mem.Ptr (%mem.Ptr (i32, 0:.Nat), 0:.Nat), return : .Cn [%mem.M, i32]] = {
     // .let arr_size = 16;

--- a/lit/affine/lower_for.thorin
+++ b/lit/affine/lower_for.thorin
@@ -8,23 +8,23 @@
 .import mem;
 .import core;
 
-.cn .extern main (mem : %mem.M, argc : %Int 4294967296, argv : %mem.Ptr (%mem.Ptr (%Int 256, 0), 0), return : .Cn [%mem.M, %Int 4294967296]) = {
-    .cn for_exit [acc : %Int 4294967296] = {
+.cn .extern main (mem : %mem.M, argc : .Int 4294967296, argv : %mem.Ptr (%mem.Ptr (.Int 256, 0), 0), return : .Cn [%mem.M, .Int 4294967296]) = {
+    .cn for_exit [acc : .Int 4294967296] = {
         return (mem, acc)
     };
 
-    .cn for_body [i : %Int 4294967296, acc : %Int 4294967296, continue : .Cn [%Int 4294967296]] = {
+    .cn for_body [i : .Int 4294967296, acc : .Int 4294967296, continue : .Cn [.Int 4294967296]] = {
         continue (%core.wrap.add (0, 4294967296) (i, acc))
     };
-    %affine.For (4294967296, 1, (%Int 4294967296)) (0:(%Int 4294967296), argc, 1:(%Int 4294967296), (0:(%Int 4294967296)), for_body, for_exit)
+    %affine.For (4294967296, 1, (.Int 4294967296)) (0:(.Int 4294967296), argc, 1:(.Int 4294967296), (0:(.Int 4294967296)), for_body, for_exit)
 };
 
-// CHECK-DAG: .cn .extern main _[[mainVar:[0-9_]+]]::[mem_[[memVar:[0-9_]+]]: %mem.M, argc_[[argcId:[0-9_]+]]: (%Int 4294967296), %mem.Ptr (%mem.Ptr ((%Int 256), 0), 0), return_[[returnId:[0-9_]+]]: .Cn [%mem.M, (%Int 4294967296)]] = {
+// CHECK-DAG: .cn .extern main _[[mainVar:[0-9_]+]]::[mem_[[memVar:[0-9_]+]]: %mem.M, argc_[[argcId:[0-9_]+]]: (.Int 4294967296), %mem.Ptr (%mem.Ptr ((.Int 256), 0), 0), return_[[returnId:[0-9_]+]]: .Cn [%mem.M, (.Int 4294967296)]] = {
 
-// CHECK-DAG: .cn return_[[returnId:[0-9_]+]] _[[returnVarId:[0-9_]+]]: [%mem.M, (%Int 4294967296)]
+// CHECK-DAG: .cn return_[[returnId:[0-9_]+]] _[[returnVarId:[0-9_]+]]: [%mem.M, (.Int 4294967296)]
 
-// CHECK-DAG: .cn for_[[forId:[0-9_]+]] _[[forVarId:[0-9_]+]]::[_[[forIntId:[0-9_]+]]: (%Int 4294967296), _[[forAccId:[0-9_]+]]: (%Int 4294967296)]
-// CHECK-DAG: _[[cmpId:[0-9_]+]]: (%Int 2) = %core.icmp.XygLe
+// CHECK-DAG: .cn for_[[forId:[0-9_]+]] _[[forVarId:[0-9_]+]]::[_[[forIntId:[0-9_]+]]: (.Int 4294967296), _[[forAccId:[0-9_]+]]: (.Int 4294967296)]
+// CHECK-DAG: _[[cmpId:[0-9_]+]]: (.Int 2) = %core.icmp.XygLe
 // CHECK-DAG: (_[[falseId:[0-9_]+]], for_body_[[bodyId:[0-9_]+]])#_[[cmpId]]
 
 // CHECK-DAG: .cn _{{[0-9]+}} []

--- a/lit/core/normalize_add.thorin
+++ b/lit/core/normalize_add.thorin
@@ -3,22 +3,22 @@
 
 .import core;
 
-.cn .extern add0 [i :%Int 256, return : .Cn %Int 256] = {
-    return (%core.wrap.add (0, 256) (i, 0 : (%Int 256)))
+.cn .extern add0 [i :.Int 256, return : .Cn .Int 256] = {
+    return (%core.wrap.add (0, 256) (i, 0 : (.Int 256)))
 };
 
-// CHECK-DAG: add0 _{{[0-9_]+}}::[i_[[valId:[0-9_]+]]: (%Int 256), return_[[retId:[0-9_]+]]: .Cn (%Int 256)]
+// CHECK-DAG: add0 _{{[0-9_]+}}::[i_[[valId:[0-9_]+]]: (.Int 256), return_[[retId:[0-9_]+]]: .Cn (.Int 256)]
 // CHECK-DAG: return_[[etaId:[0-9_]+]] i_[[valId]]
 
-// CHECK-DAG: return_[[etaId]] _[[etaVar:[0-9_]+]]: (%Int 256)
+// CHECK-DAG: return_[[etaId]] _[[etaVar:[0-9_]+]]: (.Int 256)
 // CHECK-DAG: return_[[retId]] _[[etaVar]]
 
-.cn .extern add_lit [return : .Cn %Int 256] = {
-    return (%core.wrap.add (0, 256) (6 : (%Int 256), 0 : (%Int 256)))
+.cn .extern add_lit [return : .Cn .Int 256] = {
+    return (%core.wrap.add (0, 256) (6 : (.Int 256), 0 : (.Int 256)))
 };
 
-// CHECK-DAG: add_lit _[[retId:[0-9_]+]]: .Cn (%Int 256)
-// CHECK-DAG: _[[etaId:[0-9_]+]] 6:(%Int 256)
+// CHECK-DAG: add_lit _[[retId:[0-9_]+]]: .Cn (.Int 256)
+// CHECK-DAG: _[[etaId:[0-9_]+]] 6:(.Int 256)
 
-// CHECK-DAG: _[[etaId]] _[[etaVar:[0-9_]+]]: (%Int 256)
+// CHECK-DAG: _[[etaId]] _[[etaVar:[0-9_]+]]: (.Int 256)
 // CHECK-DAG: _[[retId]] _[[etaVar]]

--- a/lit/core/normalize_and_ff.thorin
+++ b/lit/core/normalize_and_ff.thorin
@@ -3,12 +3,12 @@
 
 .import core;
 
-.cn .extern and_ff [i :%Int 2, return : .Cn %Int 2] = {
+.cn .extern and_ff [i :.Int 2, return : .Cn .Int 2] = {
     return (%core.bit2._and 2 (i, .ff))
 };
 
-// CHECK-DAG: .cn .extern and_ff _{{[0-9_]+}}::[(%Int 2), return_[[retId:[0-9_]+]]: .Cn (%Int 2)]
-// CHECK-DAG: return_[[etaId:[0-9_]+]] 0:(%Int 2)
+// CHECK-DAG: .cn .extern and_ff _{{[0-9_]+}}::[(.Int 2), return_[[retId:[0-9_]+]]: .Cn (.Int 2)]
+// CHECK-DAG: return_[[etaId:[0-9_]+]] 0:(.Int 2)
 
-// CHECK-DAG: .cn return_[[etaId]] _[[etaVar:[0-9_]+]]: (%Int 2)
+// CHECK-DAG: .cn return_[[etaId]] _[[etaVar:[0-9_]+]]: (.Int 2)
 // CHECK-DAG: return_[[retId]] _[[etaVar]]

--- a/lit/core/normalize_and_ff_tt.thorin
+++ b/lit/core/normalize_and_ff_tt.thorin
@@ -3,12 +3,12 @@
 
 .import core;
 
-.cn .extern and_lit_ff_tt [return : .Cn %Int 2] = {
+.cn .extern and_lit_ff_tt [return : .Cn .Int 2] = {
     return (%core.bit2._and 2 (.ff, .tt))
 };
 
-// CHECK-DAG: and_lit_ff_tt _[[retId_ff_tt:[0-9_]+]]: .Cn (%Int 2)
-// CHECK-DAG: _[[etaId_ff_tt:[0-9_]+]] 0:(%Int 2)
+// CHECK-DAG: and_lit_ff_tt _[[retId_ff_tt:[0-9_]+]]: .Cn (.Int 2)
+// CHECK-DAG: _[[etaId_ff_tt:[0-9_]+]] 0:(.Int 2)
 
-// CHECK-DAG: _[[etaId_ff_tt]] _[[etaVar_ff_tt:[0-9_]+]]: (%Int 2)
+// CHECK-DAG: _[[etaId_ff_tt]] _[[etaVar_ff_tt:[0-9_]+]]: (.Int 2)
 // CHECK-DAG: _[[retId_ff_tt]] _[[etaVar_ff_tt]]

--- a/lit/core/normalize_and_icmps.thorin
+++ b/lit/core/normalize_and_icmps.thorin
@@ -3,7 +3,7 @@
 
 .import core;
 
-.cn .extern and [a : %Int 2, b : %Int 2, return : .Cn %Int 2] = {
+.cn .extern and [a : .Int 2, b : .Int 2, return : .Cn .Int 2] = {
     return
     (%core.bit2._and 2
         (%core.icmp.uge 2
@@ -12,9 +12,9 @@
             (a, b)))
 };
 
-// CHECK-DAG: .cn .extern and _{{[0-9_]+}}::[a_[[aId:[0-9_]+]]: (%Int 2), b_[[bId:[0-9_]+]]: (%Int 2), return_[[retId:[0-9_]+]]: .Cn (%Int 2)]
-// CHECK-DAG: .let _[[cmpId:[0-9_]+]]: (%Int 2) = %core.icmp.xYGle 2 (a_[[aId]], b_[[bId]]);
+// CHECK-DAG: .cn .extern and _{{[0-9_]+}}::[a_[[aId:[0-9_]+]]: (.Int 2), b_[[bId:[0-9_]+]]: (.Int 2), return_[[retId:[0-9_]+]]: .Cn (.Int 2)]
+// CHECK-DAG: .let _[[cmpId:[0-9_]+]]: (.Int 2) = %core.icmp.xYGle 2 (a_[[aId]], b_[[bId]]);
 // CHECK-DAG: return_[[etaId:[0-9_]+]] _[[cmpId]]
 
-// CHECK-DAG: return_[[etaId]] _[[etaVar:[0-9_]+]]: (%Int 2)
+// CHECK-DAG: return_[[etaId]] _[[etaVar:[0-9_]+]]: (.Int 2)
 // CHECK-DAG: return_[[retId]] _[[etaVar]]

--- a/lit/core/normalize_and_icmps_lit.thorin
+++ b/lit/core/normalize_and_icmps_lit.thorin
@@ -3,7 +3,7 @@
 
 .import core;
 
-.cn .extern and_lit [return : .Cn %Int 2] = {
+.cn .extern and_lit [return : .Cn .Int 2] = {
     return
     (%core.bit2._and 2
         (%core.icmp.uge 2
@@ -12,8 +12,8 @@
             (.tt, .ff)))
 };
 
-// CHECK-DAG: and_lit _[[retId:[0-9_]+]]: .Cn (%Int 2)
-// CHECK-DAG: _[[etaId:[0-9_]+]] 1:(%Int 2)
+// CHECK-DAG: and_lit _[[retId:[0-9_]+]]: .Cn (.Int 2)
+// CHECK-DAG: _[[etaId:[0-9_]+]] 1:(.Int 2)
 
-// CHECK-DAG: _[[etaId]] _[[etaVar:[0-9_]+]]: (%Int 2)
+// CHECK-DAG: _[[etaId]] _[[etaVar:[0-9_]+]]: (.Int 2)
 // CHECK-DAG: _[[retId]] _[[etaVar]]

--- a/lit/core/normalize_and_tree.thorin
+++ b/lit/core/normalize_and_tree.thorin
@@ -3,7 +3,7 @@
 
 .import core;
 
-.cn .extern and_lit [return : .Cn %Int 2] = {
+.cn .extern and_lit [return : .Cn .Int 2] = {
     return
     (%core.bit2._and 2
         (%core.bit2._and 2
@@ -14,9 +14,9 @@
              %core.bit2._and 2 (.tt, .ff))))
 };
 
-// CHECK-DAG: .cn .extern and_lit _[[retId:[0-9_]+]]: .Cn (%Int 2) = {
-// CHECK-DAG: _[[etaId:[0-9_]+]] 0:(%Int 2)
+// CHECK-DAG: .cn .extern and_lit _[[retId:[0-9_]+]]: .Cn (.Int 2) = {
+// CHECK-DAG: _[[etaId:[0-9_]+]] 0:(.Int 2)
 
-// CHECK-DAG: .cn _[[etaId]] _[[etaVar:[0-9_]+]]: (%Int 2) = {
+// CHECK-DAG: .cn _[[etaId]] _[[etaVar:[0-9_]+]]: (.Int 2) = {
 // CHECK-DAG: _[[retId]] _[[etaVar]]
 

--- a/lit/core/normalize_and_tt.thorin
+++ b/lit/core/normalize_and_tt.thorin
@@ -3,12 +3,12 @@
 
 .import core;
 
-.cn .extern and_tt [i :%Int 2, return : .Cn %Int 2] = {
+.cn .extern and_tt [i :.Int 2, return : .Cn .Int 2] = {
     return (%core.bit2._and 2 (i, .tt))
 };
 
-// CHECK-DAG: and_tt _{{[0-9_]+}}::[i_[[valId_tt:[0-9_]+]]: (%Int 2), return_[[retId_tt:[0-9_]+]]: .Cn (%Int 2)] = {
+// CHECK-DAG: and_tt _{{[0-9_]+}}::[i_[[valId_tt:[0-9_]+]]: (.Int 2), return_[[retId_tt:[0-9_]+]]: .Cn (.Int 2)] = {
 // CHECK-DAG: return_[[etaId_tt:[0-9_]+]] i_[[valId_tt]]
 
-// CHECK-DAG: return_[[etaId_tt]] _[[etaVar_tt:[0-9_]+]]: (%Int 2) = {
+// CHECK-DAG: return_[[etaId_tt]] _[[etaVar_tt:[0-9_]+]]: (.Int 2) = {
 // CHECK-DAG: return_[[retId_tt]] _[[etaVar_tt]]

--- a/lit/core/normalize_and_tt_tt.thorin
+++ b/lit/core/normalize_and_tt_tt.thorin
@@ -3,12 +3,12 @@
 
 .import core;
 
-.cn .extern and_lit_tt_tt [return : .Cn %Int 2] = {
+.cn .extern and_lit_tt_tt [return : .Cn .Int 2] = {
     return (%core.bit2._and 2 (.tt, .tt))
 };
 
-// CHECK-DAG: .cn .extern and_lit_tt_tt _[[retId:[0-9_]+]]: .Cn (%Int 2) = {
-// CHECK-DAG: _[[etaId:[0-9_]+]] 1:(%Int 2)
+// CHECK-DAG: .cn .extern and_lit_tt_tt _[[retId:[0-9_]+]]: .Cn (.Int 2) = {
+// CHECK-DAG: _[[etaId:[0-9_]+]] 1:(.Int 2)
 
-// CHECK-DAG: .cn _[[etaId]] _[[etaVar:[0-9_]+]]: (%Int 2) = {
+// CHECK-DAG: .cn _[[etaId]] _[[etaVar:[0-9_]+]]: (.Int 2) = {
 // CHECK-DAG: _[[retId]] _[[etaVar]]

--- a/lit/core/normalize_bitcast.thorin
+++ b/lit/core/normalize_bitcast.thorin
@@ -4,13 +4,13 @@
 
 .import core;
 
-.cn .extern bitcast_bitcast [i : %mem.Ptr (%Int 256, 0), return : .Cn %Int 4294967296] = {
-    return (%core.bitcast (%Int 4294967296, .Nat) (%core.bitcast (.Nat, %mem.Ptr (%Int 256, 0)) i))
+.cn .extern bitcast_bitcast [i : %mem.Ptr (.Int 256, 0), return : .Cn .Int 4294967296] = {
+    return (%core.bitcast (.Int 4294967296, .Nat) (%core.bitcast (.Nat, %mem.Ptr (.Int 256, 0)) i))
 };
 
-// CHECK-DAG: bitcast_bitcast _{{[0-9_]+}}::[i_[[valId:[0-9_]+]]: %mem.Ptr ((%Int 256), 0), return_[[retId:[0-9_]+]]: .Cn (%Int 4294967296)] = {
-// CHECK-DAG: .let _[[castedId:[0-9_]+]]: (%Int 4294967296) = %core.bitcast ((%Int 4294967296), %mem.Ptr ((%Int 256), 0)) i_[[valId]];
+// CHECK-DAG: bitcast_bitcast _{{[0-9_]+}}::[i_[[valId:[0-9_]+]]: %mem.Ptr ((.Int 256), 0), return_[[retId:[0-9_]+]]: .Cn (.Int 4294967296)] = {
+// CHECK-DAG: .let _[[castedId:[0-9_]+]]: (.Int 4294967296) = %core.bitcast ((.Int 4294967296), %mem.Ptr ((.Int 256), 0)) i_[[valId]];
 // CHECK-DAG: return_[[etaId:[0-9_]+]] _[[castedId]]
 
-// CHECK-DAG: return_[[etaId]] _[[etaVar:[0-9_]+]]: (%Int 4294967296) = {
+// CHECK-DAG: return_[[etaId]] _[[etaVar:[0-9_]+]]: (.Int 4294967296) = {
 // CHECK-DAG: return_[[retId]] _[[etaVar]]

--- a/lit/core/normalize_icmp.thorin
+++ b/lit/core/normalize_icmp.thorin
@@ -3,7 +3,7 @@
 
 .import core;
 
-.cn .extern icmp_lit [return : .Cn %Int 2] = {
+.cn .extern icmp_lit [return : .Cn .Int 2] = {
     return
     (%core.icmp.e 2
         (%core.icmp.uge 2
@@ -12,8 +12,8 @@
             (.tt, .ff)))
 };
 
-// CHECK-DAG: icmp_lit _[[retId:[0-9_]+]]: .Cn (%Int 2) = {
-// CHECK-DAG: _[[etaId:[0-9_]+]] 1:(%Int 2)
+// CHECK-DAG: icmp_lit _[[retId:[0-9_]+]]: .Cn (.Int 2) = {
+// CHECK-DAG: _[[etaId:[0-9_]+]] 1:(.Int 2)
 
-// CHECK-DAG: _[[etaId]] _[[etaVar:[0-9_]+]]: (%Int 2) = {
+// CHECK-DAG: _[[etaId]] _[[etaVar:[0-9_]+]]: (.Int 2) = {
 // CHECK-DAG: _[[retId]] _[[etaVar]]

--- a/lit/core/ret_add.thorin
+++ b/lit/core/ret_add.thorin
@@ -7,27 +7,27 @@
 .import core;
 .import mem;
 
-.cn atoi [%mem.M, %mem.Ptr («⊤:.Nat; %Int 256», 0), .Cn [%mem.M, %Int 4294967296]];
+.cn atoi [%mem.M, %mem.Ptr («⊤:.Nat; .Int 256», 0), .Cn [%mem.M, .Int 4294967296]];
 
-.cn .extern main [mem : %mem.M, argc : %Int 4294967296, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; %Int 256», 0)», 0:.Nat), return : .Cn [%mem.M, %Int 4294967296]] = {
-    .cn atoi_cont_a [mem : %mem.M, a : %Int 4294967296] = {
-        .cn atoi_cont_b [mem : %mem.M, b : %Int 4294967296] = {
+.cn .extern main [mem : %mem.M, argc : .Int 4294967296, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .Int 256», 0)», 0:.Nat), return : .Cn [%mem.M, .Int 4294967296]] = {
+    .cn atoi_cont_a [mem : %mem.M, a : .Int 4294967296] = {
+        .cn atoi_cont_b [mem : %mem.M, b : .Int 4294967296] = {
                 return (mem, %core.wrap.add (0, 4294967296) (a, b))
         };
 
-        .let argv_ptr_b = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; %Int 256», 0)›, 0) (argv, 2:(%Int 4294967296));
-        .let argv_load_b = %mem.load (%mem.Ptr («⊤:.Nat; %Int 256», 0), 0) (mem, argv_ptr_b);
+        .let argv_ptr_b = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .Int 256», 0)›, 0) (argv, 2:(.Int 4294967296));
+        .let argv_load_b = %mem.load (%mem.Ptr («⊤:.Nat; .Int 256», 0), 0) (mem, argv_ptr_b);
         atoi (argv_load_b#.ff, argv_load_b#.tt, atoi_cont_b)
     };
 
-    .let argv_ptr_a = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; %Int 256», 0)›, 0) (argv, 1:(%Int 4294967296));
-    .let argv_load_a = %mem.load (%mem.Ptr («⊤:.Nat; %Int 256», 0), 0) (mem, argv_ptr_a);
+    .let argv_ptr_a = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .Int 256», 0)›, 0) (argv, 1:(.Int 4294967296));
+    .let argv_load_a = %mem.load (%mem.Ptr («⊤:.Nat; .Int 256», 0), 0) (mem, argv_ptr_a);
     atoi (argv_load_a#.ff, argv_load_a#.tt, atoi_cont_a)
 };
 
-// CHECK-DAG: main _{{[0-9_]+}}::[mem_[[memId:[0-9_]+]]: %mem.M, (%Int 4294967296), argv_{{[0-9]+}}: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (%Int 256)», 0)», 0), return_[[returnId:[0-9_]+]]: .Cn [%mem.M, (%Int 4294967296)]] = {
+// CHECK-DAG: main _{{[0-9_]+}}::[mem_[[memId:[0-9_]+]]: %mem.M, (.Int 4294967296), argv_{{[0-9]+}}: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (.Int 256)», 0)», 0), return_[[returnId:[0-9_]+]]: .Cn [%mem.M, (.Int 4294967296)]] = {
 
-// CHECK-DAG: atoi_cont_a_[[aContId:[0-9_]+]] _{{[0-9_]+}}::[mem_{{[0-9]+}}: %mem.M, a_[[aId:[0-9_]+]]: (%Int 4294967296)]
+// CHECK-DAG: atoi_cont_a_[[aContId:[0-9_]+]] _{{[0-9_]+}}::[mem_{{[0-9]+}}: %mem.M, a_[[aId:[0-9_]+]]: (.Int 4294967296)]
 
-// CHECK-DAG: atoi_cont_b_[[bContId:[0-9_]+]] _{{[0-9_]+}}::[mem_{{[0-9]+}}: %mem.M, b_[[bId:[0-9_]+]]: (%Int 4294967296)]
+// CHECK-DAG: atoi_cont_b_[[bContId:[0-9_]+]] _{{[0-9_]+}}::[mem_{{[0-9]+}}: %mem.M, b_[[bId:[0-9_]+]]: (.Int 4294967296)]
 // CHECK-DAG: %core.wrap.add (0, 4294967296) (a_[[aId]], b_[[bId]])

--- a/lit/core/ret_and.thorin
+++ b/lit/core/ret_and.thorin
@@ -7,27 +7,27 @@
 .import core;
 .import mem;
 
-.cn atoi [%mem.M, %mem.Ptr («⊤:.Nat; %Int 256», 0), .Cn [%mem.M, %Int 4294967296]];
+.cn atoi [%mem.M, %mem.Ptr («⊤:.Nat; .Int 256», 0), .Cn [%mem.M, .Int 4294967296]];
 
-.cn .extern main [mem : %mem.M, argc : %Int 4294967296, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; %Int 256», 0)», 0), return : .Cn [%mem.M, %Int 4294967296]] = {
-    .cn atoi_cont_a [mem : %mem.M, a : %Int 4294967296] = {
-        .cn atoi_cont_b [mem : %mem.M, b : %Int 4294967296] = {
+.cn .extern main [mem : %mem.M, argc : .Int 4294967296, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .Int 256», 0)», 0), return : .Cn [%mem.M, .Int 4294967296]] = {
+    .cn atoi_cont_a [mem : %mem.M, a : .Int 4294967296] = {
+        .cn atoi_cont_b [mem : %mem.M, b : .Int 4294967296] = {
                 return (mem, %core.bit2._and (4294967296) (a, b))
         };
 
-        .let argv_ptr_b = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; %Int 256», 0)›, 0) (argv, 2:(%Int 4294967296));
-        .let argv_load_b = %mem.load (%mem.Ptr («⊤:.Nat; %Int 256», 0), 0) (mem, argv_ptr_b);
+        .let argv_ptr_b = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .Int 256», 0)›, 0) (argv, 2:(.Int 4294967296));
+        .let argv_load_b = %mem.load (%mem.Ptr («⊤:.Nat; .Int 256», 0), 0) (mem, argv_ptr_b);
         atoi (argv_load_b#.ff, argv_load_b#.tt, atoi_cont_b)
     };
 
-    .let argv_ptr_a = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; %Int 256», 0)›, 0) (argv, 1:(%Int 4294967296));
-    .let argv_load_a = %mem.load (%mem.Ptr («⊤:.Nat; %Int 256», 0), 0) (mem, argv_ptr_a);
+    .let argv_ptr_a = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .Int 256», 0)›, 0) (argv, 1:(.Int 4294967296));
+    .let argv_load_a = %mem.load (%mem.Ptr («⊤:.Nat; .Int 256», 0), 0) (mem, argv_ptr_a);
     atoi (argv_load_a#.ff, argv_load_a#.tt, atoi_cont_a)
 };
 
-// CHECK-DAG: main _{{[0-9_]+}}::[mem_[[memId:[0-9_]+]]: %mem.M, (%Int 4294967296), argv_{{[0-9]+}}: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (%Int 256)», 0)», 0), return_[[returnId:[0-9_]+]]: .Cn [%mem.M, (%Int 4294967296)]] = {
+// CHECK-DAG: main _{{[0-9_]+}}::[mem_[[memId:[0-9_]+]]: %mem.M, (.Int 4294967296), argv_{{[0-9]+}}: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (.Int 256)», 0)», 0), return_[[returnId:[0-9_]+]]: .Cn [%mem.M, (.Int 4294967296)]] = {
 
-// CHECK-DAG: atoi_cont_a_[[aContId:[0-9_]+]] _{{[0-9_]+}}::[mem_{{[0-9]+}}: %mem.M, a_[[aId:[0-9_]+]]: (%Int 4294967296)]
+// CHECK-DAG: atoi_cont_a_[[aContId:[0-9_]+]] _{{[0-9_]+}}::[mem_{{[0-9]+}}: %mem.M, a_[[aId:[0-9_]+]]: (.Int 4294967296)]
 
-// CHECK-DAG: atoi_cont_b_[[bContId:[0-9_]+]] _{{[0-9_]+}}::[mem_{{[0-9]+}}: %mem.M, b_[[bId:[0-9_]+]]: (%Int 4294967296)]
+// CHECK-DAG: atoi_cont_b_[[bContId:[0-9_]+]] _{{[0-9_]+}}::[mem_{{[0-9]+}}: %mem.M, b_[[bId:[0-9_]+]]: (.Int 4294967296)]
 // CHECK-DAG: %core.bit2._and 4294967296 (a_[[aId]], b_[[bId]])

--- a/lit/core/ret_lshr.thorin
+++ b/lit/core/ret_lshr.thorin
@@ -7,27 +7,27 @@
 .import core;
 .import mem;
 
-.cn atoi [%mem.M, %mem.Ptr («⊤:.Nat; %Int 256», 0), .Cn [%mem.M, %Int 4294967296]];
+.cn atoi [%mem.M, %mem.Ptr («⊤:.Nat; .Int 256», 0), .Cn [%mem.M, .Int 4294967296]];
 
-.cn .extern main [mem : %mem.M, argc : %Int 4294967296, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; %Int 256», 0)», 0), return : .Cn [%mem.M, %Int 4294967296]] = {
-    .cn atoi_cont_a [mem : %mem.M, a : %Int 4294967296] = {
-        .cn atoi_cont_b [mem : %mem.M, b : %Int 4294967296] = {
+.cn .extern main [mem : %mem.M, argc : .Int 4294967296, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .Int 256», 0)», 0), return : .Cn [%mem.M, .Int 4294967296]] = {
+    .cn atoi_cont_a [mem : %mem.M, a : .Int 4294967296] = {
+        .cn atoi_cont_b [mem : %mem.M, b : .Int 4294967296] = {
                 return (mem, %core.shr.lshr 4294967296 (a, b))
         };
 
-        .let argv_ptr_b = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; %Int 256», 0)›, 0) (argv, 2:(%Int 4294967296));
-        .let argv_load_b = %mem.load (%mem.Ptr («⊤:.Nat; %Int 256», 0), 0) (mem, argv_ptr_b);
+        .let argv_ptr_b = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .Int 256», 0)›, 0) (argv, 2:(.Int 4294967296));
+        .let argv_load_b = %mem.load (%mem.Ptr («⊤:.Nat; .Int 256», 0), 0) (mem, argv_ptr_b);
         atoi (argv_load_b#.ff, argv_load_b#.tt, atoi_cont_b)
     };
 
-    .let argv_ptr_a = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; %Int 256», 0)›, 0) (argv, 1:(%Int 4294967296));
-    .let argv_load_a = %mem.load (%mem.Ptr («⊤:.Nat; %Int 256», 0), 0) (mem, argv_ptr_a);
+    .let argv_ptr_a = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .Int 256», 0)›, 0) (argv, 1:(.Int 4294967296));
+    .let argv_load_a = %mem.load (%mem.Ptr («⊤:.Nat; .Int 256», 0), 0) (mem, argv_ptr_a);
     atoi (argv_load_a#.ff, argv_load_a#.tt, atoi_cont_a)
 };
 
-// CHECK-DAG: main _{{[0-9_]+}}::[mem_[[memId:[0-9_]+]]: %mem.M, (%Int 4294967296), argv_{{[0-9]+}}: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (%Int 256)», 0)», 0), return_[[returnId:[0-9_]+]]: .Cn [%mem.M, (%Int 4294967296)]] = {
+// CHECK-DAG: main _{{[0-9_]+}}::[mem_[[memId:[0-9_]+]]: %mem.M, (.Int 4294967296), argv_{{[0-9]+}}: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (.Int 256)», 0)», 0), return_[[returnId:[0-9_]+]]: .Cn [%mem.M, (.Int 4294967296)]] = {
 
-// CHECK-DAG: atoi_cont_a_[[aContId:[0-9_]+]] _{{[0-9_]+}}::[mem_{{[0-9]+}}: %mem.M, a_[[aId:[0-9_]+]]: (%Int 4294967296)]
+// CHECK-DAG: atoi_cont_a_[[aContId:[0-9_]+]] _{{[0-9_]+}}::[mem_{{[0-9]+}}: %mem.M, a_[[aId:[0-9_]+]]: (.Int 4294967296)]
 
-// CHECK-DAG: atoi_cont_b_[[bContId:[0-9_]+]] _{{[0-9_]+}}::[mem_{{[0-9]+}}: %mem.M, b_[[bId:[0-9_]+]]: (%Int 4294967296)]
+// CHECK-DAG: atoi_cont_b_[[bContId:[0-9_]+]] _{{[0-9_]+}}::[mem_{{[0-9]+}}: %mem.M, b_[[bId:[0-9_]+]]: (.Int 4294967296)]
 // CHECK-DAG: %core.shr.lshr 4294967296 (a_[[aId]], b_[[bId]])

--- a/lit/debug/debug.thorin
+++ b/lit/debug/debug.thorin
@@ -6,14 +6,14 @@
 .import debug;
 .import mem;
 
-.let I32 = %Int 4294967296;
-.cn .extern main [mem : %mem.M, argc : I32, argv : %mem.Ptr (%mem.Ptr (%Int 256, 0), 0), return : .Cn [%mem.M, I32]] = {
+.let I32 = .Int 4294967296;
+.cn .extern main [mem : %mem.M, argc : I32, argv : %mem.Ptr (%mem.Ptr (.Int 256, 0), 0), return : .Cn [%mem.M, I32]] = {
     .let c = %debug.dbg I32 (42:I32);
     return (mem, c)
 };
 
-// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[memId:[_0-9]*]]: %mem.M, (%Int 4294967296), %mem.Ptr (%mem.Ptr ((%Int 256), 0), 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (%Int 4294967296)]] = {
-// CHECK-DAG: return_[[returnEtaId:[_0-9]*]] (mem_[[memId]], 42:(%Int 4294967296))
+// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[memId:[_0-9]*]]: %mem.M, (.Int 4294967296), %mem.Ptr (%mem.Ptr ((.Int 256), 0), 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (.Int 4294967296)]] = {
+// CHECK-DAG: return_[[returnEtaId:[_0-9]*]] (mem_[[memId]], 42:(.Int 4294967296))
 
-// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (%Int 4294967296)] = {
+// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Int 4294967296)] = {
 // CHECK-DAG: return_[[returnId]] _[[returnEtaVarId]]

--- a/lit/debug/debug_perm.thorin
+++ b/lit/debug/debug_perm.thorin
@@ -6,14 +6,14 @@
 .import debug;
 .import mem;
 
-.let I32 = %Int 4294967296;
-.cn .extern main [mem : %mem.M, argc : I32, argv : %mem.Ptr (%mem.Ptr (%Int 256, 0), 0), return : .Cn [%mem.M, I32]] = {
+.let I32 = .Int 4294967296;
+.cn .extern main [mem : %mem.M, argc : I32, argv : %mem.Ptr (%mem.Ptr (.Int 256, 0), 0), return : .Cn [%mem.M, I32]] = {
     .let c = %debug.dbg_perm I32 (42:I32);
     return (mem, c)
 };
 
-// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[memId:[_0-9]*]]: %mem.M, (%Int 4294967296), %mem.Ptr (%mem.Ptr ((%Int 256), 0), 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (%Int 4294967296)]] = {
-// CHECK-DAG: return_[[returnEtaId:[_0-9]*]] (mem_[[memId]], 42:(%Int 4294967296))
+// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[memId:[_0-9]*]]: %mem.M, (.Int 4294967296), %mem.Ptr (%mem.Ptr ((.Int 256), 0), 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (.Int 4294967296)]] = {
+// CHECK-DAG: return_[[returnEtaId:[_0-9]*]] (mem_[[memId]], 42:(.Int 4294967296))
 
-// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (%Int 4294967296)] = {
+// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Int 4294967296)] = {
 // CHECK-DAG: return_[[returnId]] _[[returnEtaVarId]]

--- a/lit/direct/ds2cps.thorin
+++ b/lit/direct/ds2cps.thorin
@@ -7,19 +7,19 @@
 .import direct;
 .import mem;
 
-.let I32 = %Int 4294967296;
+.let I32 = .Int 4294967296;
 
 .lam f [a:I32] -> I32 = {
     %Wrap_add (0, 4294967296) (2:I32, a)
 };
 
-.cn .extern main [mem : %mem.M, argc : I32, argv : %mem.Ptr (%mem.Ptr (%Int 256, 0), 0), return : .Cn [%mem.M, I32]] = {
+.cn .extern main [mem : %mem.M, argc : I32, argv : %mem.Ptr (%mem.Ptr (.Int 256, 0), 0), return : .Cn [%mem.M, I32]] = {
     .let c = f (40:I32);
     return (mem, c)
 };
 
-// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[memId:[_0-9]*]]: %mem.M, (%Int 4294967296), %mem.Ptr (%mem.Ptr ((%Int 256), 0), 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (%Int 4294967296)]] = {
-// CHECK-DAG: return_[[returnEtaId:[_0-9]*]] (mem_[[memId]], 42:(%Int 4294967296))
+// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[memId:[_0-9]*]]: %mem.M, (.Int 4294967296), %mem.Ptr (%mem.Ptr ((.Int 256), 0), 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (.Int 4294967296)]] = {
+// CHECK-DAG: return_[[returnEtaId:[_0-9]*]] (mem_[[memId]], 42:(.Int 4294967296))
 
-// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (%Int 4294967296)] = {
+// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Int 4294967296)] = {
 // CHECK-DAG: return_[[returnId]] _[[returnEtaVarId]]

--- a/lit/direct/ds2cps_ax_cps2ds.thorin
+++ b/lit/direct/ds2cps_ax_cps2ds.thorin
@@ -6,21 +6,21 @@
 .import direct;
 .import mem;
 
-.let I32 = %Int 4294967296;
+.let I32 = .Int 4294967296;
 
 .cn f [a:I32, return: .Cn I32] = {
     .let b = %Wrap_add (0, 4294967296) (2:I32, a);
     return b
 };
 
-.cn .extern main [mem : %mem.M, argc : I32, argv : %mem.Ptr (%mem.Ptr (%Int 256, 0), 0), return : .Cn [%mem.M, I32]] = {
+.cn .extern main [mem : %mem.M, argc : I32, argv : %mem.Ptr (%mem.Ptr (.Int 256, 0), 0), return : .Cn [%mem.M, I32]] = {
     .let g = %direct.cps2ds (I32,I32) f;
     .let c = g (40:I32);
     return (mem, c)
 };
 
-// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[memId:[_0-9]+]]: %mem.M, (%Int 4294967296), %mem.Ptr (%mem.Ptr ((%Int 256), 0), 0), return_[[returnId:[_0-9]+]]: .Cn [%mem.M, (%Int 4294967296)]] = {
-// CHECK-DAG: return_[[returnEtaId:[_0-9]+]] (mem_[[memId]], 42:(%Int 4294967296))
+// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[memId:[_0-9]+]]: %mem.M, (.Int 4294967296), %mem.Ptr (%mem.Ptr ((.Int 256), 0), 0), return_[[returnId:[_0-9]+]]: .Cn [%mem.M, (.Int 4294967296)]] = {
+// CHECK-DAG: return_[[returnEtaId:[_0-9]+]] (mem_[[memId]], 42:(.Int 4294967296))
 
-// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (%Int 4294967296)] = {
+// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Int 4294967296)] = {
 // CHECK-DAG: return_[[returnId]] _[[returnEtaVarId]]

--- a/lit/direct/ds2cps_cps_only.thorin
+++ b/lit/direct/ds2cps_cps_only.thorin
@@ -6,19 +6,19 @@
 .import direct;
 .import mem;
 
-.let I32 = %Int 4294967296;
+.let I32 = .Int 4294967296;
 
 .cn h [mem : %mem.M, a : I32, return : .Cn [%mem.M, I32]] = {
     .let c = a;
     return (mem, c)
 };
 
-.cn .extern main [mem : %mem.M, argc : I32, argv : %mem.Ptr (%mem.Ptr (%Int 256, 0), 0), return : .Cn [%mem.M, I32]] = {
+.cn .extern main [mem : %mem.M, argc : I32, argv : %mem.Ptr (%mem.Ptr (.Int 256, 0), 0), return : .Cn [%mem.M, I32]] = {
     h (mem, 40:I32, return)
 };
 
-// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[memId:[_0-9]*]]: %mem.M, (%Int 4294967296), %mem.Ptr (%mem.Ptr ((%Int 256), 0), 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (%Int 4294967296)]] = {
-// CHECK-DAG: return_[[returnEtaId:[_0-9]*]] (mem_[[memId]], 40:(%Int 4294967296))
+// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[memId:[_0-9]*]]: %mem.M, (.Int 4294967296), %mem.Ptr (%mem.Ptr ((.Int 256), 0), 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (.Int 4294967296)]] = {
+// CHECK-DAG: return_[[returnEtaId:[_0-9]*]] (mem_[[memId]], 40:(.Int 4294967296))
 
-// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (%Int 4294967296)] = {
+// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Int 4294967296)] = {
 // CHECK-DAG: return_[[returnId]] _[[returnEtaVarId]]

--- a/lit/direct/ds2cps_mixed.thorin
+++ b/lit/direct/ds2cps_mixed.thorin
@@ -6,7 +6,7 @@
 .import direct;
 .import mem;
 
-.let I32 = %Int 4294967296;
+.let I32 = .Int 4294967296;
 
 .lam f [a:I32] -> I32 = {
     %Wrap_add (0, 4294967296) (2:I32, a)
@@ -17,12 +17,12 @@
     return (mem, c)
 };
 
-.cn .extern main [mem : %mem.M, argc : I32, argv : %mem.Ptr (%mem.Ptr (%Int 256, 0), 0), return : .Cn [%mem.M, I32]] = {
+.cn .extern main [mem : %mem.M, argc : I32, argv : %mem.Ptr (%mem.Ptr (.Int 256, 0), 0), return : .Cn [%mem.M, I32]] = {
     h (mem, 40:I32, return)
 };
 
-// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[memId:[_0-9]*]]: %mem.M, (%Int 4294967296), %mem.Ptr (%mem.Ptr ((%Int 256), 0), 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (%Int 4294967296)]] = {
-// CHECK-DAG: return_[[returnEtaId:[_0-9]*]] (mem_[[memId]], 42:(%Int 4294967296))
+// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[memId:[_0-9]*]]: %mem.M, (.Int 4294967296), %mem.Ptr (%mem.Ptr ((.Int 256), 0), 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (.Int 4294967296)]] = {
+// CHECK-DAG: return_[[returnEtaId:[_0-9]*]] (mem_[[memId]], 42:(.Int 4294967296))
 
-// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (%Int 4294967296)] = {
+// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Int 4294967296)] = {
 // CHECK-DAG: return_[[returnId]] _[[returnEtaVarId]]

--- a/lit/direct/ds2cps_mixed2.thorin
+++ b/lit/direct/ds2cps_mixed2.thorin
@@ -6,7 +6,7 @@
 .import direct;
 .import mem;
 
-.let I32 = %Int 4294967296;
+.let I32 = .Int 4294967296;
 
 .lam f [a:I32] -> I32 = {
     %Wrap_add (0, 4294967296) (2:I32, a)
@@ -22,12 +22,12 @@
     h (mem, b, return)
 };
 
-.cn .extern main [mem : %mem.M, argc : I32, argv : %mem.Ptr (%mem.Ptr (%Int 256, 0), 0), return : .Cn [%mem.M, I32]] = {
+.cn .extern main [mem : %mem.M, argc : I32, argv : %mem.Ptr (%mem.Ptr (.Int 256, 0), 0), return : .Cn [%mem.M, I32]] = {
     g (mem, 40:I32, return)
 };
 
-// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[memId:[_0-9]*]]: %mem.M, (%Int 4294967296), %mem.Ptr (%mem.Ptr ((%Int 256), 0), 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (%Int 4294967296)]] = {
-// CHECK-DAG: return_[[returnEtaId:[_0-9]*]] (mem_[[memId]], 45:(%Int 4294967296))
+// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[memId:[_0-9]*]]: %mem.M, (.Int 4294967296), %mem.Ptr (%mem.Ptr ((.Int 256), 0), 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (.Int 4294967296)]] = {
+// CHECK-DAG: return_[[returnEtaId:[_0-9]*]] (mem_[[memId]], 45:(.Int 4294967296))
 
-// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (%Int 4294967296)] = {
+// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Int 4294967296)] = {
 // CHECK-DAG: return_[[returnId]] _[[returnEtaVarId]]

--- a/lit/direct/ds2cps_mixed_tuple.thorin
+++ b/lit/direct/ds2cps_mixed_tuple.thorin
@@ -6,7 +6,7 @@
 .import direct;
 .import mem;
 
-.let I32 = %Int 4294967296;
+.let I32 = .Int 4294967296;
 
 .lam f [a:I32] -> [I32, I32] = {
     (%Wrap_add (0, 4294967296) (2:I32, a), %Wrap_add (0, 4294967296) (3:I32, a))
@@ -14,15 +14,15 @@
 
 .cn h [mem : %mem.M, a : I32, return : .Cn [%mem.M, I32]] = {
     .let c = f a;
-    return (mem, %Wrap_add (0, 4294967296) (c#0:(%Int 2), c#1:(%Int 2)))
+    return (mem, %Wrap_add (0, 4294967296) (c#0:(.Int 2), c#1:(.Int 2)))
 };
 
-.cn .extern main [mem : %mem.M, argc : I32, argv : %mem.Ptr (%mem.Ptr (%Int 256, 0), 0), return : .Cn [%mem.M, I32]] = {
+.cn .extern main [mem : %mem.M, argc : I32, argv : %mem.Ptr (%mem.Ptr (.Int 256, 0), 0), return : .Cn [%mem.M, I32]] = {
     h (mem, 40:I32, return)
 };
 
-// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[memId:[_0-9]*]]: %mem.M, (%Int 4294967296), %mem.Ptr (%mem.Ptr ((%Int 256), 0), 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (%Int 4294967296)]] = {
-// CHECK-DAG: return_[[returnEtaId:[_0-9]*]] (mem_[[memId]], 85:(%Int 4294967296))
+// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[memId:[_0-9]*]]: %mem.M, (.Int 4294967296), %mem.Ptr (%mem.Ptr ((.Int 256), 0), 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (.Int 4294967296)]] = {
+// CHECK-DAG: return_[[returnEtaId:[_0-9]*]] (mem_[[memId]], 85:(.Int 4294967296))
 
-// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (%Int 4294967296)] = {
+// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Int 4294967296)] = {
 // CHECK-DAG: return_[[returnId]] _[[returnEtaVarId]]

--- a/lit/main_loop.thorin
+++ b/lit/main_loop.thorin
@@ -7,36 +7,36 @@
 .import core;
 .import mem;
 
-.cn .extern main(mem: %mem.M, argc: %Int 4294967296, argv: %mem.Ptr (%mem.Ptr (%Int 256, 0), 0), return: .Cn [%mem.M, %Int 4294967296]) = {
-    .cn loop(mem: %mem.M, i: %Int 4294967296, acc: %Int 4294967296) = {
-        .let cond: (%Int 2) = %core.icmp.ul 4294967296 (i, argc);
+.cn .extern main(mem: %mem.M, argc: .Int 4294967296, argv: %mem.Ptr (%mem.Ptr (.Int 256, 0), 0), return: .Cn [%mem.M, .Int 4294967296]) = {
+    .cn loop(mem: %mem.M, i: .Int 4294967296, acc: .Int 4294967296) = {
+        .let cond: (.Int 2) = %core.icmp.ul 4294967296 (i, argc);
 
         .cn exit m: %mem.M = return (m, acc);
 
         .cn body m: %mem.M = {
-            .let inc: %Int 4294967296 = %Wrap_add (0, 4294967296) (1:(%Int 4294967296), i);
-            .let acci: %Int 4294967296 = %Wrap_add (0, 4294967296) (i, acc);
+            .let inc: .Int 4294967296 = %Wrap_add (0, 4294967296) (1:(.Int 4294967296), i);
+            .let acci: .Int 4294967296 = %Wrap_add (0, 4294967296) (i, acc);
             loop (m, inc, acci)
         };
         (exit, body)#cond mem
     };
-    loop (mem, 0:(%Int 4294967296), 0:(%Int 4294967296))
+    loop (mem, 0:(.Int 4294967296), 0:(.Int 4294967296))
 };
 
-// CHECK-DAG: .cn .extern main _[[mainVarId:[0-9_]+]]::[mem_[[memId:[0-9_]+]]: %mem.M, argc_[[argcId:[0-9_]+]]: (%Int 4294967296), %mem.Ptr (%mem.Ptr ((%Int 256), 0), 0), return_[[returnId:[0-9_]+]]: .Cn [%mem.M, (%Int 4294967296)]] = {
-// CHECK-DAG: loop_[[loopId:[0-9_]+]] (mem_[[memId]], 0:(%Int 4294967296), 0:(%Int 4294967296))
+// CHECK-DAG: .cn .extern main _[[mainVarId:[0-9_]+]]::[mem_[[memId:[0-9_]+]]: %mem.M, argc_[[argcId:[0-9_]+]]: (.Int 4294967296), %mem.Ptr (%mem.Ptr ((.Int 256), 0), 0), return_[[returnId:[0-9_]+]]: .Cn [%mem.M, (.Int 4294967296)]] = {
+// CHECK-DAG: loop_[[loopId:[0-9_]+]] (mem_[[memId]], 0:(.Int 4294967296), 0:(.Int 4294967296))
 
-// CHECK-DAG: .cn return_[[returnEtaId:[0-9_]+]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (%Int 4294967296)] = {
+// CHECK-DAG: .cn return_[[returnEtaId:[0-9_]+]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Int 4294967296)] = {
 // CHECK-DAG: return_[[returnId]] _[[returnEtaVarId]]
 
-// CHECK-DAG: .cn loop_[[loopId]] _{{[0-9_]+}}::[mem_[[loopMemId:[0-9_]+]]: %mem.M, i_[[iterId:[0-9_]+]]: (%Int 4294967296), acc_[[accId:[0-9_]+]]: (%Int 4294967296)] = {
-// CHECK-DAG:   _[[condId:[0-9_]+]]: (%Int 2) = %core.icmp.XygLe 4294967296 (i_[[iterId]], argc_[[argcId]]);
+// CHECK-DAG: .cn loop_[[loopId]] _{{[0-9_]+}}::[mem_[[loopMemId:[0-9_]+]]: %mem.M, i_[[iterId:[0-9_]+]]: (.Int 4294967296), acc_[[accId:[0-9_]+]]: (.Int 4294967296)] = {
+// CHECK-DAG:   _[[condId:[0-9_]+]]: (.Int 2) = %core.icmp.XygLe 4294967296 (i_[[iterId]], argc_[[argcId]]);
 // CHECK-DAG: (exit_[[exitId:[0-9_]+]], body_[[bodyId:[0-9_]+]])#_[[condId]] mem_[[loopMemId]]
 
 // CHECK-DAG: .cn exit_[[exitId]] m_[[mExitVarId:[0-9_]+]]: %mem.M = {
 // CHECK-DAG: return_[[returnEtaId]] (m_[[mExitVarId]], acc_[[accId]])
 
 // CHECK-DAG: .cn body_[[bodyId]] m_[[mBodyVarId:[0-9_]+]]: %mem.M = {
-// CHECK-DAG:   _[[addIterId:[0-9_]+]]: (%Int 4294967296) = %Wrap_add (0, 4294967296) (1:(%Int 4294967296), i_[[iterId]]);
-// CHECK-DAG:   _[[addAccId:[0-9_]+]]: (%Int 4294967296) = %Wrap_add (0, 4294967296) (acc_[[accId]], i_[[iterId]]);
+// CHECK-DAG:   _[[addIterId:[0-9_]+]]: (.Int 4294967296) = %Wrap_add (0, 4294967296) (1:(.Int 4294967296), i_[[iterId]]);
+// CHECK-DAG:   _[[addAccId:[0-9_]+]]: (.Int 4294967296) = %Wrap_add (0, 4294967296) (acc_[[accId]], i_[[iterId]]);
 // CHECK-DAG: loop_[[loopId]] (m_[[mBodyVarId]], _[[addIterId]], _[[addAccId]])

--- a/lit/mem/alloc_load_store.thorin
+++ b/lit/mem/alloc_load_store.thorin
@@ -7,21 +7,21 @@
 
 .import mem;
 
-.let i32 = %Int 4294967296;
-.cn .extern main(mem: %mem.M, argc: i32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; %Int 256», 0)», 0), return: .Cn [%mem.M, i32]) = {
+.let i32 = .Int 4294967296;
+.cn .extern main(mem: %mem.M, argc: i32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .Int 256», 0)», 0), return: .Cn [%mem.M, i32]) = {
     .let Tas = (i32, 0);
     .let allocd = %mem.alloc Tas mem;
-    .let store = %mem.store Tas (allocd#0:(%Int 2), allocd#1:(%Int 2), argc);
-    .let load = %mem.load Tas (store, allocd#1:(%Int 2));
+    .let store = %mem.store Tas (allocd#0:(.Int 2), allocd#1:(.Int 2), argc);
+    .let load = %mem.load Tas (store, allocd#1:(.Int 2));
     // todo: free :)
     return load
 };
 
-// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[mainMemId:[_0-9]*]]: %mem.M, argc_[[argcId:[0-9_]+]]: (%Int 4294967296), %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (%Int 256)», 0)», 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (%Int 4294967296)]] = {
-// CHECK-DAG: _[[appMSlotId:[0-9_]+]]: [%mem.M, %mem.Ptr ((%Int 4294967296), 0)] = %mem.malloc ((%Int 4294967296), 0) (mem_[[mainMemId]], 4);
-// CHECK-DAG: _[[appStoreId:[0-9_]+]]: %mem.M = %mem.store ((%Int 4294967296), 0) (_[[appMSlotId]]#0:(%Int 2), _[[appMSlotId]]#1:(%Int 2), argc_[[argcId]]);
-// CHECK-DAG: _[[appLoadId:[0-9_]+]]: [%mem.M, (%Int 4294967296)] = %mem.load ((%Int 4294967296), 0) (_[[appStoreId]], _[[appMSlotId]]#1:(%Int 2));
+// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[mainMemId:[_0-9]*]]: %mem.M, argc_[[argcId:[0-9_]+]]: (.Int 4294967296), %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (.Int 256)», 0)», 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (.Int 4294967296)]] = {
+// CHECK-DAG: _[[appMSlotId:[0-9_]+]]: [%mem.M, %mem.Ptr ((.Int 4294967296), 0)] = %mem.malloc ((.Int 4294967296), 0) (mem_[[mainMemId]], 4);
+// CHECK-DAG: _[[appStoreId:[0-9_]+]]: %mem.M = %mem.store ((.Int 4294967296), 0) (_[[appMSlotId]]#0:(.Int 2), _[[appMSlotId]]#1:(.Int 2), argc_[[argcId]]);
+// CHECK-DAG: _[[appLoadId:[0-9_]+]]: [%mem.M, (.Int 4294967296)] = %mem.load ((.Int 4294967296), 0) (_[[appStoreId]], _[[appMSlotId]]#1:(.Int 2));
 // CHECK-DAG: return_[[returnEtaId:[0-9_]+]] _[[appLoadId]]
 
-// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (%Int 4294967296)] = {
+// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Int 4294967296)] = {
 // CHECK-DAG: return_[[returnId]] _[[returnEtaVarId]]

--- a/lit/mem/malloc_load_store.thorin
+++ b/lit/mem/malloc_load_store.thorin
@@ -7,21 +7,21 @@
 
 .import mem;
 
-.let i32 = %Int 4294967296;
-.cn .extern main(mem: %mem.M, argc: i32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; %Int 256», 0)», 0), return: .Cn [%mem.M, i32]) = {
+.let i32 = .Int 4294967296;
+.cn .extern main(mem: %mem.M, argc: i32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .Int 256», 0)», 0), return: .Cn [%mem.M, i32]) = {
     .let Tas = (i32, 0);
     .let allocd = %mem.malloc Tas (mem, 4);
-    .let store = %mem.store Tas (allocd#0:(%Int 2), allocd#1:(%Int 2), argc);
-    .let load = %mem.load Tas (store, allocd#1:(%Int 2));
+    .let store = %mem.store Tas (allocd#0:(.Int 2), allocd#1:(.Int 2), argc);
+    .let load = %mem.load Tas (store, allocd#1:(.Int 2));
     // todo: free :)
     return load
 };
 
-// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[mainMemId:[_0-9]*]]: %mem.M, argc_[[argcId:[0-9_]+]]: (%Int 4294967296), %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (%Int 256)», 0)», 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (%Int 4294967296)]] = {
-// CHECK-DAG: _[[appMSlotId:[0-9_]+]]: [%mem.M, %mem.Ptr ((%Int 4294967296), 0)] = %mem.malloc ((%Int 4294967296), 0) (mem_[[mainMemId]], 4);
-// CHECK-DAG: _[[appStoreId:[0-9_]+]]: %mem.M = %mem.store ((%Int 4294967296), 0) (_[[appMSlotId]]#0:(%Int 2), _[[appMSlotId]]#1:(%Int 2), argc_[[argcId]]);
-// CHECK-DAG: _[[appLoadId:[0-9_]+]]: [%mem.M, (%Int 4294967296)] = %mem.load ((%Int 4294967296), 0) (_[[appStoreId]], _[[appMSlotId]]#1:(%Int 2));
+// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[mainMemId:[_0-9]*]]: %mem.M, argc_[[argcId:[0-9_]+]]: (.Int 4294967296), %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (.Int 256)», 0)», 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (.Int 4294967296)]] = {
+// CHECK-DAG: _[[appMSlotId:[0-9_]+]]: [%mem.M, %mem.Ptr ((.Int 4294967296), 0)] = %mem.malloc ((.Int 4294967296), 0) (mem_[[mainMemId]], 4);
+// CHECK-DAG: _[[appStoreId:[0-9_]+]]: %mem.M = %mem.store ((.Int 4294967296), 0) (_[[appMSlotId]]#0:(.Int 2), _[[appMSlotId]]#1:(.Int 2), argc_[[argcId]]);
+// CHECK-DAG: _[[appLoadId:[0-9_]+]]: [%mem.M, (.Int 4294967296)] = %mem.load ((.Int 4294967296), 0) (_[[appStoreId]], _[[appMSlotId]]#1:(.Int 2));
 // CHECK-DAG: return_[[returnEtaId:[0-9_]+]] _[[appLoadId]]
 
-// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (%Int 4294967296)] = {
+// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Int 4294967296)] = {
 // CHECK-DAG: return_[[returnId]] _[[returnEtaVarId]]

--- a/lit/mem/mslot_load_store.thorin
+++ b/lit/mem/mslot_load_store.thorin
@@ -7,20 +7,20 @@
 
 .import mem;
 
-.let i32 = %Int 4294967296;
-.cn .extern main(mem: %mem.M, argc: i32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; %Int 256», 0)», 0), return: .Cn [%mem.M, i32]) = {
+.let i32 = .Int 4294967296;
+.cn .extern main(mem: %mem.M, argc: i32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .Int 256», 0)», 0), return: .Cn [%mem.M, i32]) = {
     .let Tas = (i32, 0);
     .let slot = %mem.mslot Tas (mem, 4, 0);
-    .let store = %mem.store Tas (slot#0:(%Int 2), slot#1:(%Int 2), argc);
-    .let load = %mem.load Tas (store, slot#1:(%Int 2));
+    .let store = %mem.store Tas (slot#0:(.Int 2), slot#1:(.Int 2), argc);
+    .let load = %mem.load Tas (store, slot#1:(.Int 2));
     return load
 };
 
-// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[mainMemId:[_0-9]*]]: %mem.M, argc_[[argcId:[0-9_]+]]: (%Int 4294967296), %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (%Int 256)», 0)», 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (%Int 4294967296)]] = {
-// CHECK-DAG: _[[appMSlotId:[0-9_]+]]: [%mem.M, %mem.Ptr ((%Int 4294967296), 0)] = %mem.mslot ((%Int 4294967296), 0) (mem_[[mainMemId]], 4, 0);
-// CHECK-DAG: _[[appStoreId:[0-9_]+]]: %mem.M = %mem.store ((%Int 4294967296), 0) (_[[appMSlotId]]#0:(%Int 2), _[[appMSlotId]]#1:(%Int 2), argc_[[argcId]]);
-// CHECK-DAG: _[[appLoadId:[0-9_]+]]: [%mem.M, (%Int 4294967296)] = %mem.load ((%Int 4294967296), 0) (_[[appStoreId]], _[[appMSlotId]]#1:(%Int 2));
+// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[mainMemId:[_0-9]*]]: %mem.M, argc_[[argcId:[0-9_]+]]: (.Int 4294967296), %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (.Int 256)», 0)», 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (.Int 4294967296)]] = {
+// CHECK-DAG: _[[appMSlotId:[0-9_]+]]: [%mem.M, %mem.Ptr ((.Int 4294967296), 0)] = %mem.mslot ((.Int 4294967296), 0) (mem_[[mainMemId]], 4, 0);
+// CHECK-DAG: _[[appStoreId:[0-9_]+]]: %mem.M = %mem.store ((.Int 4294967296), 0) (_[[appMSlotId]]#0:(.Int 2), _[[appMSlotId]]#1:(.Int 2), argc_[[argcId]]);
+// CHECK-DAG: _[[appLoadId:[0-9_]+]]: [%mem.M, (.Int 4294967296)] = %mem.load ((.Int 4294967296), 0) (_[[appStoreId]], _[[appMSlotId]]#1:(.Int 2));
 // CHECK-DAG: return_[[returnEtaId:[0-9_]+]] _[[appLoadId]]
 
-// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (%Int 4294967296)] = {
+// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Int 4294967296)] = {
 // CHECK-DAG: return_[[returnId]] _[[returnEtaVarId]]

--- a/lit/mem/slot_load_store.thorin
+++ b/lit/mem/slot_load_store.thorin
@@ -7,17 +7,17 @@
 
 .import mem;
 
-.let i32 = %Int 4294967296;
-.cn .extern main(mem: %mem.M, argc: i32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; %Int 256», 0)», 0), return: .Cn [%mem.M, i32]) = {
+.let i32 = .Int 4294967296;
+.cn .extern main(mem: %mem.M, argc: i32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .Int 256», 0)», 0), return: .Cn [%mem.M, i32]) = {
     .let Tas = (i32, 0);
     .let slot = %mem.slot Tas (mem, 0);
-    .let store = %mem.store Tas (slot#0:(%Int 2), slot#1:(%Int 2), argc);
-    .let load = %mem.load Tas (store, slot#1:(%Int 2));
+    .let store = %mem.store Tas (slot#0:(.Int 2), slot#1:(.Int 2), argc);
+    .let load = %mem.load Tas (store, slot#1:(.Int 2));
     return load
 };
 
-// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[mainMemId:[_0-9]*]]: %mem.M, argc_[[argcId:[0-9_]+]]: (%Int 4294967296), %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (%Int 256)», 0)», 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (%Int 4294967296)]] = {
+// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[mainMemId:[_0-9]*]]: %mem.M, argc_[[argcId:[0-9_]+]]: (.Int 4294967296), %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (.Int 256)», 0)», 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (.Int 4294967296)]] = {
 // CHECK-DAG: return_[[returnEtaId:[0-9_]+]] (mem_[[mainMemId]], argc_[[argcId]])
 
-// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (%Int 4294967296)] = {
+// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Int 4294967296)] = {
 // CHECK-DAG: return_[[returnId]] _[[returnEtaVarId]]

--- a/lit/parse_output_parse.thorin
+++ b/lit/parse_output_parse.thorin
@@ -7,15 +7,15 @@
 
 .import mem;
 
-.cn .extern main [mem : %mem.M, argc : %Int 4294967296, argv : %mem.Ptr (%mem.Ptr (%Int 256, 0), 0), return : .Cn [%mem.M, %Int 4294967296]] = {
+.cn .extern main [mem : %mem.M, argc : .Int 4294967296, argv : %mem.Ptr (%mem.Ptr (.Int 256, 0), 0), return : .Cn [%mem.M, .Int 4294967296]] = {
     .cn single_arg_parse_test mem: %mem.M = {
             return (mem, argc)
     };
     single_arg_parse_test mem
 };
 
-// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[memId:[_0-9]*]]: %mem.M, argc_[[argcId:[0-9_]+]]: (%Int 4294967296), %mem.Ptr (%mem.Ptr ((%Int 256), 0), 0), return_[[returnId:[_0-9]+]]: .Cn [%mem.M, (%Int 4294967296)]] = {
+// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[memId:[_0-9]*]]: %mem.M, argc_[[argcId:[0-9_]+]]: (.Int 4294967296), %mem.Ptr (%mem.Ptr ((.Int 256), 0), 0), return_[[returnId:[_0-9]+]]: .Cn [%mem.M, (.Int 4294967296)]] = {
 // CHECK-DAG: return_[[returnEtaId:[0-9_]+]] (mem_[[memId]], argc_[[argcId]])
 
-// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (%Int 4294967296)] = {
+// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Int 4294967296)] = {
 // CHECK-DAG: return_[[returnId]] _[[returnEtaVarId]]

--- a/lit/restructre_free_var.thorin
+++ b/lit/restructre_free_var.thorin
@@ -28,7 +28,7 @@
     ] ->
     %matrix.Mat (n,S,T);
 
-.let I32 = %Int 4294967296;
+.let I32 = .Int 4294967296;
 .let test = %matrix.mapReduce 
     (2,(4,3),I32,
         2,

--- a/lit/ret_argc.thorin
+++ b/lit/ret_argc.thorin
@@ -7,12 +7,12 @@
 
 .import mem;
 
-.let i8  = %Int 256;
-.let i32 = %Int 4294967296;
+.let i8  = .Int 256;
+.let i32 = .Int 4294967296;
 .cn .extern main(mem: %mem.M, argc: i32, argv: %mem.Ptr (%mem.Ptr (i8, 0), 0), return: .Cn [%mem.M, i32]) = return (mem, argc);
 
-// CHECK-DAG: .cn .extern main _[[mainVarId:[0-9_]+]]::[mem_[[memId:[0-9_]+]]: %mem.M, argc_[[argcId:[0-9_]+]]: (%Int 4294967296), %mem.Ptr (%mem.Ptr ((%Int 256), 0), 0), return_[[returnId:[0-9_]+]]: .Cn [%mem.M, (%Int 4294967296)]] = {
+// CHECK-DAG: .cn .extern main _[[mainVarId:[0-9_]+]]::[mem_[[memId:[0-9_]+]]: %mem.M, argc_[[argcId:[0-9_]+]]: (.Int 4294967296), %mem.Ptr (%mem.Ptr ((.Int 256), 0), 0), return_[[returnId:[0-9_]+]]: .Cn [%mem.M, (.Int 4294967296)]] = {
 // CHECK-DAG: return_[[returnEtaId:[0-9_]+]] (mem_[[memId]], argc_[[argcId]])
 
-// CHECK-DAG: .cn return_[[returnEtaId:[0-9_]+]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (%Int 4294967296)] = {
+// CHECK-DAG: .cn return_[[returnEtaId:[0-9_]+]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Int 4294967296)] = {
 // CHECK-DAG: return_[[returnId]] _[[returnEtaVarId]]

--- a/lit/type_error/domain.thorin
+++ b/lit/type_error/domain.thorin
@@ -1,6 +1,6 @@
 // RUN: ! %thorin %s 2>&1 | FileCheck %s 
 
-.let I32 = %Int  4294967296;
+.let I32 = .Int  4294967296;
 .let R32 = %Real 32;
 .ax %foo.bar: .Cn [I32, R32];
 .let err = %foo.bar(23:R32, 42:I32);

--- a/thorin/axiom.h
+++ b/thorin/axiom.h
@@ -156,13 +156,6 @@ Match<Tag2Enum<t>, Tag2Def<t>> as(Tag2Enum<t> f, const Def* d) {
     return {std::get<0>(Axiom::get(d)), d->as<App>()};
 }
 
-/// Checks whether @p type is an Tag::Int or a Tag::Real and returns its mod or width, respectively.
-inline const Def* isa_sized_type(const Def* type) {
-    if (auto int_ = isa<Tag::Int>(type)) return int_->arg();
-    if (auto real = isa<Tag::Real>(type)) return real->arg();
-    return nullptr;
-}
-
 constexpr uint64_t width2mod(uint64_t n) {
     assert(n != 0);
     return n == 64 ? 0 : (1_u64 << n);

--- a/thorin/def.cpp
+++ b/thorin/def.cpp
@@ -64,6 +64,9 @@ Def::Def(node_t node, const Def* type, size_t num_ops, flags_t flags, const Def*
 Nat::Nat(World& world)
     : Def(Node, world.type(), Defs{}, 0, nullptr) {}
 
+Int::Int(World& world, const Def* size)
+    : Def(Node, world.type(), Defs{size}, 0, nullptr) {}
+
 // clang-format off
 
 /*
@@ -75,6 +78,7 @@ const Def* App      ::rebuild(World& w, const Def*  , Defs o, const Def* dbg) co
 const Def* Arr      ::rebuild(World& w, const Def*  , Defs o, const Def* dbg) const { return w.arr(o[0], o[1], dbg); }
 const Def* Extract  ::rebuild(World& w, const Def*  , Defs o, const Def* dbg) const { return w.extract(o[0], o[1], dbg); }
 const Def* Insert   ::rebuild(World& w, const Def*  , Defs o, const Def* dbg) const { return w.insert(o[0], o[1], o[2], dbg); }
+const Def* Int      ::rebuild(World& w, const Def*  , Defs o, const Def*    ) const { return w.type_int(o[0]); }
 const Def* Lam      ::rebuild(World& w, const Def* t, Defs o, const Def* dbg) const { return w.lam(t->as<Pi>(), o[0], o[1], dbg); }
 const Def* Lit      ::rebuild(World& w, const Def* t, Defs  , const Def* dbg) const { return w.lit(t, get(), dbg); }
 const Def* Nat      ::rebuild(World& w, const Def*  , Defs  , const Def*    ) const { return w.type_nat(); }
@@ -386,7 +390,6 @@ const Def* Def::proj(nat_t a, nat_t i, const Def* dbg) const {
         return op(i);
     } else if (auto arr = isa<Arr>()) {
         if (arr->arity()->isa<Top>()) return arr->body();
-        if (!w.type_int()) return arr->op(i); // hack for alpha equiv check of sigma (dbg of %Int..)
         return arr->reduce(w.lit_int(as_lit(arr->arity()), i));
     } else if (auto pack = isa<Pack>()) {
         if (pack->arity()->isa<Top>()) return pack->body();

--- a/thorin/def.h
+++ b/thorin/def.h
@@ -550,6 +550,22 @@ public:
     friend class World;
 };
 
+class Int : public Def {
+private:
+    Int(World&, const Def* size);
+
+public:
+    const Def* size() const { return op(0); }
+
+    /// @name virtual methods
+    ///@{
+    const Def* rebuild(World&, const Def*, Defs, const Def*) const override;
+    ///@}
+
+    static constexpr auto Node = Node::Int;
+    friend class World;
+};
+
 class Proxy : public Def {
 private:
     Proxy(const Def* type, Defs ops, u32 pass, u32 tag, const Def* dbg)

--- a/thorin/dump.cpp
+++ b/thorin/dump.cpp
@@ -120,7 +120,7 @@ std::ostream& operator<<(std::ostream& os, Inline u) {
         return print(os, "{}{}", name[0] == '%' ? "" : "%", name);
     } else if (auto lit = u->isa<Lit>()) {
         if (lit->type()->isa<Nat>()) return print(os, "{}", lit->get());
-        if (auto real = thorin::isa<Tag::Real>(lit->type())) {
+        if (auto real = isa<Tag::Real>(lit->type())) {
             switch (as_lit(real->arg())) {
                 case 16: return print(os, "{}:(%Real 16)", lit->get<r16>());
                 case 32: return print(os, "{}:(%Real 32)", lit->get<r32>());
@@ -141,12 +141,11 @@ std::ostream& operator<<(std::ostream& os, Inline u) {
         return print(os, "Π {} → {}", pi->dom(), pi->codom());
     } else if (auto lam = u->isa<Lam>()) {
         return print(os, "{}, {}", lam->filter(), lam->body());
+    } else if (auto int_ = u->isa<Int>()) {
+        return print(os, "(.Int {})", int_->size());
+    } else if (auto real = isa<Tag::Real>(*u)) {
+        return print(os, "(%Real {})", real->arg());
     } else if (auto app = u->isa<App>()) {
-        if (auto size = isa_sized_type(app)) {
-            if (auto real = thorin::isa<Tag::Real>(app)) return print(os, "(%Real {})", size);
-            if (auto _int = thorin::isa<Tag::Int>(app)) return print(os, "(%Int {})", size);
-            unreachable();
-        }
         return print(os, "{} {}", LPrec(app->callee(), app), RPrec(app, app->arg()));
     } else if (auto sigma = u->isa<Sigma>()) {
         if (auto nom = sigma->isa_nom<Sigma>(); nom && nom->var()) {

--- a/thorin/fe/parser.cpp
+++ b/thorin/fe/parser.cpp
@@ -255,6 +255,7 @@ const Def* Parser::parse_primary_expr(std::string_view ctxt) {
         case Tok::Tag::D_brckt_l: return parse_sigma();
         case Tok::Tag::D_paren_l: return parse_tuple();
         case Tok::Tag::K_Cn:      return parse_Cn();
+        case Tok::Tag::K_Int:     return parse_int();
         case Tok::Tag::K_Type:    return parse_type();
         case Tok::Tag::K_Univ:    lex(); return world().univ();
         case Tok::Tag::K_Bool:    lex(); return world().type_bool();
@@ -278,8 +279,6 @@ const Def* Parser::parse_primary_expr(std::string_view ctxt) {
             // HACK hard-coded some built-in axioms
             auto tok = lex();
             auto s = tok.sym().to_string();
-            // if (s == "%Mem")      return world().ax();
-            if (s == "%Int"     ) return world().type_int();
             if (s == "%Real"    ) return world().type_real();
             if (s == "%Wrap_add") return world().ax(Wrap::add);
             if (s == "%Wrap_sub") return world().ax(Wrap::sub);
@@ -391,6 +390,13 @@ const Def* Parser::parse_type() {
     auto [l, r] = Tok::prec(Tok::Prec::App);
     auto level  = parse_expr("type level", r);
     return world().type(level, track);
+}
+
+const Def* Parser::parse_int() {
+    eat(Tok::Tag::K_Int);
+    auto [l, r] = Tok::prec(Tok::Prec::App);
+    auto size  = parse_expr("size of .Int", r);
+    return world().type_int(size);
 }
 
 const Def* Parser::parse_pi() {

--- a/thorin/fe/parser.cpp
+++ b/thorin/fe/parser.cpp
@@ -395,7 +395,7 @@ const Def* Parser::parse_type() {
 const Def* Parser::parse_int() {
     eat(Tok::Tag::K_Int);
     auto [l, r] = Tok::prec(Tok::Prec::App);
-    auto size  = parse_expr("size of .Int", r);
+    auto size   = parse_expr("size of .Int", r);
     return world().type_int(size);
 }
 

--- a/thorin/fe/parser.h
+++ b/thorin/fe/parser.h
@@ -91,6 +91,7 @@ private:
     const Def* parse_block();
     const Def* parse_sigma();
     const Def* parse_tuple();
+    const Def* parse_int();
     const Def* parse_type();
     const Def* parse_pi();
     const Def* parse_lam();

--- a/thorin/fe/tok.h
+++ b/thorin/fe/tok.h
@@ -16,6 +16,7 @@ namespace thorin::fe {
     m(K_let,    ".let"   )             \
     m(K_Bool,   ".Bool"  )             \
     m(K_Nat,    ".Nat"   )             \
+    m(K_Int,    ".Int"   )             \
     m(K_extern, ".extern")             \
     m(K_Arr,    ".Arr"   )             \
     m(K_Sigma,  ".Sigma" )             \

--- a/thorin/normalize.cpp
+++ b/thorin/normalize.cpp
@@ -637,9 +637,9 @@ const Def* normalize_Trait(const Def*, const Def* callee, const Def* type, const
         return world.lit_nat(8);
     } else if (type->isa<Pi>()) {
         return world.lit_nat(8); // Gets lowered to function ptr
-    } else if (auto int_ = isa<Tag::Int>(type)) {
+    } else if (auto int_ = type->isa<Int>()) {
         if (int_->type()->isa<Top>()) return world.lit_nat(8);
-        if (auto w = isa_lit(int_->arg())) {
+        if (auto w = isa_lit(int_->size())) {
             if (*w == 0) return world.lit_nat(8);
             if (*w <= 0x0000'0000'0000'0100_u64) return world.lit_nat(1);
             if (*w <= 0x0000'0000'0001'0000_u64) return world.lit_nat(2);
@@ -713,8 +713,8 @@ static const Def* fold_Conv(const Def* dst_type, const App* callee, const Def* s
             return world.lit(dst_type, as_lit(lit_src) % *lit_dw);
         }
 
-        if (isa<Tag::Int>(src->type())) *lit_sw = *mod2width(*lit_sw);
-        if (isa<Tag::Int>(dst_type)) *lit_dw = *mod2width(*lit_dw);
+        if (src->type()->isa<Int>()) *lit_sw = *mod2width(*lit_sw);
+        if (dst_type->isa<Int>()) *lit_dw = *mod2width(*lit_dw);
 
         Res res;
 #define CODE(sw, dw)                                                                                 \
@@ -778,7 +778,8 @@ const Def* normalize_bitcast(const Def* dst_type, const Def* callee, const Def* 
 
     if (auto lit = src->isa<Lit>()) {
         if (dst_type->isa<Nat>()) return world.lit(dst_type, lit->get(), dbg);
-        if (isa_sized_type(dst_type)) return world.lit(dst_type, lit->get(), dbg);
+        if (dst_type->isa<Int>()) return world.lit(dst_type, lit->get(), dbg);
+        if (isa<Tag::Real>(dst_type)) return world.lit(dst_type, lit->get(), dbg);
     }
 
     return world.raw_app(callee, src, dbg);

--- a/thorin/normalize.h
+++ b/thorin/normalize.h
@@ -109,8 +109,10 @@ static const Def* fold(World& world, const Def* type, const App* callee, const D
             nsw            = mode & WMode::nsw;
             nuw            = mode & WMode::nuw;
             width          = w;
+        } else if (auto int_t = a->type()->isa<Int>()) {
+            width = as_lit(int_t->size());
         } else {
-            width = as_lit(a->type()->as<App>()->arg());
+            width = as_lit(as<Tag::Real>(a)->arg());
         }
 
         if (is_int<Op>()) width = *mod2width(width);

--- a/thorin/tables.h
+++ b/thorin/tables.h
@@ -25,14 +25,14 @@ using sub_t     = u8;
     m(Proxy, proxy)                                                           \
     m(Axiom, axiom)                                                           \
     m(Lit, lit)                                                               \
-    m(Nat, nat)                                                               \
+    m(Nat, nat)         m(Int, int)                                           \
     m(Var, var)                                                               \
     m(Infer, infer)                                                           \
     m(Global, global)                                                         \
     m(Singleton, singleton)
 
 #define THORIN_TAG(m)                                                      \
-    m(Mem, mem) m(Int, int) m(Real, real) m(Ptr, ptr)                      \
+    m(Mem, mem) m(Real, real) m(Ptr, ptr)                                  \
     m(Bit, bit) m(Shr, shr) m(Wrap, wrap) m(ROp, rop)                      \
     m(ICmp, icmp) m(RCmp, rcmp)                                            \
     m(Trait, trait) m(Conv, conv) m(PE, pe) m(Acc, acc)                    \

--- a/thorin/world.cpp
+++ b/thorin/world.cpp
@@ -309,10 +309,9 @@ const Def* World::extract(const Def* d, const Def* index, const Def* dbg) {
     }
 
     auto index_t = index->type()->as<Int>();
-    auto type = d->unfold_type();
+    auto type    = d->unfold_type();
     if (err()) {
-        if (!checker().equiv(type->arity(), index_t->size(), dbg))
-            err()->index_out_of_range(type->arity(), index, dbg);
+        if (!checker().equiv(type->arity(), index_t->size(), dbg)) err()->index_out_of_range(type->arity(), index, dbg);
     }
 
     // nom sigmas can be 1-tuples
@@ -353,11 +352,10 @@ const Def* World::extract(const Def* d, const Def* index, const Def* dbg) {
 }
 
 const Def* World::insert(const Def* d, const Def* index, const Def* val, const Def* dbg) {
-    auto type = d->unfold_type();
+    auto type    = d->unfold_type();
     auto index_t = index->type()->as<Int>();
 
-    if (err() && !checker().equiv(type->arity(), index_t, dbg))
-        err()->index_out_of_range(type->arity(), index, dbg);
+    if (err() && !checker().equiv(type->arity(), index_t, dbg)) err()->index_out_of_range(type->arity(), index, dbg);
 
     if (auto size = isa_lit(index_t->size()); size && *size == 1)
         return tuple(d, {val}, dbg); // d could be nom - that's why the tuple ctor is needed

--- a/thorin/world.h
+++ b/thorin/world.h
@@ -482,7 +482,9 @@ public:
     /// @name op - these guys build the final function application for the various operations
     ///@{
     const Def* op(Bit o, const Def* a, const Def* b, const Def* dbg = {}) { return app(fn(o, iinfer(a)), {a, b}, dbg); }
-    const Def* op(ICmp o, const Def* a, const Def* b, const Def* dbg = {}) { return app(fn(o, iinfer(a)), {a, b}, dbg); }
+    const Def* op(ICmp o, const Def* a, const Def* b, const Def* dbg = {}) {
+        return app(fn(o, iinfer(a)), {a, b}, dbg);
+    }
     const Def* op(RCmp o, const Def* rmode, const Def* a, const Def* b, const Def* dbg = {}) {
         return app(fn(o, rmode, rinfer(a)), {a, b}, dbg);
     }

--- a/thorin/world.h
+++ b/thorin/world.h
@@ -419,14 +419,13 @@ public:
     /// @name types
     ///@{
     const Nat* type_nat() { return data_.type_nat_; }
-    const Axiom* type_int() { return data_.type_int_; }
+    const Int* type_int(const Def* size) { return unify<Int>(1, *this, size); }
+    const Int* type_int(nat_t size) { return type_int(lit_nat(size)); }
+    const Int* type_int_width(nat_t width) { return type_int(lit_nat(width2mod(width))); }
+    const Int* type_bool() { return data_.type_bool_; }
     const Axiom* type_real() { return data_.type_real_; }
-    const App* type_bool() { return data_.type_bool_; }
-    const Def* type_int_width(nat_t width) { return type_int(lit_nat(width2mod(width))); }
-    const Def* type_int(nat_t mod) { return type_int(lit_nat(mod)); }
-    const Def* type_real(nat_t width) { return type_real(lit_nat(width)); }
-    const Def* type_int(const Def* mod) { return app(type_int(), mod); }
     const Def* type_real(const Def* width) { return app(type_real(), width); }
+    const Def* type_real(nat_t width) { return type_real(lit_nat(width)); }
     ///@}
 
     /// @name bulitin axioms
@@ -482,17 +481,17 @@ public:
 
     /// @name op - these guys build the final function application for the various operations
     ///@{
-    const Def* op(Bit o, const Def* a, const Def* b, const Def* dbg = {}) { return app(fn(o, infer(a)), {a, b}, dbg); }
-    const Def* op(ICmp o, const Def* a, const Def* b, const Def* dbg = {}) { return app(fn(o, infer(a)), {a, b}, dbg); }
+    const Def* op(Bit o, const Def* a, const Def* b, const Def* dbg = {}) { return app(fn(o, iinfer(a)), {a, b}, dbg); }
+    const Def* op(ICmp o, const Def* a, const Def* b, const Def* dbg = {}) { return app(fn(o, iinfer(a)), {a, b}, dbg); }
     const Def* op(RCmp o, const Def* rmode, const Def* a, const Def* b, const Def* dbg = {}) {
-        return app(fn(o, rmode, infer(a)), {a, b}, dbg);
+        return app(fn(o, rmode, rinfer(a)), {a, b}, dbg);
     }
     const Def* op(ROp o, const Def* rmode, const Def* a, const Def* b, const Def* dbg = {}) {
-        return app(fn(o, rmode, infer(a)), {a, b}, dbg);
+        return app(fn(o, rmode, rinfer(a)), {a, b}, dbg);
     }
-    const Def* op(Shr o, const Def* a, const Def* b, const Def* dbg = {}) { return app(fn(o, infer(a)), {a, b}, dbg); }
+    const Def* op(Shr o, const Def* a, const Def* b, const Def* dbg = {}) { return app(fn(o, iinfer(a)), {a, b}, dbg); }
     const Def* op(Wrap o, const Def* wmode, const Def* a, const Def* b, const Def* dbg = {}) {
-        return app(fn(o, wmode, infer(a)), {a, b}, dbg);
+        return app(fn(o, wmode, iinfer(a)), {a, b}, dbg);
     }
     template<class O>
     const Def* op(O o, nat_t mode, const Def* a, const Def* b, const Def* dbg = {}) {
@@ -517,15 +516,15 @@ public:
     /// @name wrappers for unary operations
     ///@{
     const Def* op_negate(const Def* a, const Def* dbg = {}) {
-        auto w = as_lit(infer(a));
+        auto w = as_lit(iinfer(a));
         return op(Bit::_xor, lit_int(w, w - 1_u64), a, dbg);
     }
     const Def* op_rminus(const Def* rmode, const Def* a, const Def* dbg = {}) {
-        auto w = as_lit(infer(a));
+        auto w = as_lit(rinfer(a));
         return op(ROp::sub, rmode, lit_real(w, -0.0), a, dbg);
     }
     const Def* op_wminus(const Def* wmode, const Def* a, const Def* dbg = {}) {
-        auto w = as_lit(infer(a));
+        auto w = as_lit(iinfer(a));
         return op(Wrap::sub, wmode, lit_int(w, 0), a, dbg);
     }
     const Def* op_rminus(nat_t rmode, const Def* a, const Def* dbg = {}) { return op_rminus(lit_nat(rmode), a, dbg); }
@@ -544,7 +543,8 @@ public:
         meta     = meta ? meta : bot(type_bot());
         return tuple({sym.str(), loc, meta});
     }
-    const Def* infer(const Def* def) { return isa_sized_type(def->type()); }
+    const Def* iinfer(const Def* def) { return def->type()->as<Int>()->size(); }
+    const Def* rinfer(const Def* def) { return as<Tag::Real>(def->type())->arg(); }
     ///@}
 
     /// @name dumping/logging
@@ -696,7 +696,7 @@ private:
         const Type* type_0_;
         const Type* type_1_;
         const Bot* type_bot_;
-        const App* type_bool_;
+        const Int* type_bool_;
         const Top* top_nat_;
         const Sigma* sigma_;
         const Tuple* tuple_;
@@ -723,7 +723,6 @@ private:
         const Lit* lit_univ_1_;
         const Axiom* atomic_;
         const Axiom* bitcast_;
-        const Axiom* type_int_;
         const Axiom* type_real_;
         const Axiom* zip_;
         Lam* exit_;


### PR DESCRIPTION
This patch replaces the axiom `%Int` with a builtin `.Int`. 

`Int` is so deeply geared into Thorin that it doesn't really make sense to have it as an "optional" axiom. What is more, we sometimes get weird bootstrapping problems because of this.

* FE syntax changes from `%Int` to `.Int` (as already discussed: we cannot really make `%Int` part of a dialect)
* removed `isa_sized_type` in favor of `isa<Tag::Real>(def)` or `def->isa<Int>()` 