### PR TITLE
Refactor/int2idx

### DIFF
--- a/dialects/affine/affine.h
+++ b/dialects/affine/affine.h
@@ -9,7 +9,7 @@ namespace thorin::affine {
 /// Returns the affine_for axiom applied with \a params.
 /// See documentation for %affine.For axiom in @ref affine.
 inline const Def* fn_for(World& w, Defs params) {
-    return w.app(w.ax<affine::For>(), {w.lit_nat(width2mod(32)), w.lit_nat(params.size()), w.tuple(params)});
+    return w.app(w.ax<affine::For>(), {w.lit_nat(bitwidth2size(32)), w.lit_nat(params.size()), w.tuple(params)});
 }
 
 /// Returns a fully applied affine_for axiom.

--- a/dialects/affine/affine.thorin
+++ b/dialects/affine/affine.thorin
@@ -23,7 +23,7 @@
 ///
 /// After termination of the loop `exit` is invoked.
 .ax %affine.For: Π [m: .Nat , n: .Nat , Ts: «n; *»] ->
-    .Cn [start: .Int m, stop: .Int m, step: .Int m, init: «i: n; Ts#i»,
-        body: .Cn [iter: .Int m, acc: «i: n; Ts#i», yield: .Cn [«i: n; Ts#i»]], 
+    .Cn [start: .Idx m, stop: .Idx m, step: .Idx m, init: «i: n; Ts#i»,
+        body: .Cn [iter: .Idx m, acc: «i: n; Ts#i», yield: .Cn [«i: n; Ts#i»]], 
         exit: .Cn [«i: n; Ts#i»]];
 

--- a/dialects/clos/clos.thorin
+++ b/dialects/clos/clos.thorin
@@ -8,10 +8,10 @@
 ///
 /// ## Operations related to longjmp
 ///
-.let BufPtr = .Int 8;
+.let BufPtr = .Idx 8;
 .ax %clos.alloc_jmpbuf: [[], %mem.M] -> [%mem.M, BufPtr];
-.ax %clos.setjmp: [%mem.M, BufPtr] -> [%mem.M, BufPtr, .Int 4294967296];
-.ax %clos.longjmp: .Cn [%mem.M, BufPtr, .Int 4294967296];
+.ax %clos.setjmp: [%mem.M, BufPtr] -> [%mem.M, BufPtr, .Idx 4294967296];
+.ax %clos.longjmp: .Cn [%mem.M, BufPtr, .Idx 4294967296];
 ///
 /// ## Closure Annotations
 ///

--- a/dialects/clos/pass/rw/clos2sjlj.cpp
+++ b/dialects/clos/pass/rw/clos2sjlj.cpp
@@ -157,7 +157,7 @@ void Clos2SJLJ::enter() {
     auto m0 = body->arg(0);
     assert(m0->type() == mem::type_mem(w));
     auto [m1, tag] = op_setjmp(m0, cur_jbuf_)->projs<2>();
-    tag            = op(core::conv::s2s, w.type_int(branches.size()), tag);
+    tag            = op(core::conv::s2s, w.type_idx(branches.size()), tag);
     auto branch    = w.extract(w.tuple(branches), tag);
     curr_nom()->set_body(clos_apply(branch, m1));
 }
@@ -167,7 +167,7 @@ const Def* Clos2SJLJ::rewrite(const Def* def) {
         auto& w     = world();
         auto [i, _] = lam2tag_[c.fnc_as_lam()];
         auto tlam   = get_throw(c.fnc_as_lam()->dom());
-        return clos_pack(w.tuple({cur_jbuf_, cur_rbuf_, w.lit_int(i)}), tlam, c.type());
+        return clos_pack(w.tuple({cur_jbuf_, cur_rbuf_, w.lit_idx(i)}), tlam, c.type());
     }
     return def;
 }

--- a/dialects/clos/pass/rw/clos2sjlj.h
+++ b/dialects/clos/pass/rw/clos2sjlj.h
@@ -20,10 +20,10 @@ public:
     const Def* rewrite(const Def*) override;
 
 private:
-    const Def* void_ptr() { return mem::type_ptr(world().type_int_width(8)); }
+    const Def* void_ptr() { return mem::type_ptr(world().type_int_(8)); }
     const Def* jb_type() { return void_ptr(); }
     const Def* rb_type() { return mem::type_ptr(void_ptr()); }
-    const Def* tag_type() { return world().type_int_width(32); }
+    const Def* tag_type() { return world().type_int_(32); }
 
     Lam* get_throw(const Def* res_type);
     Lam* get_lpad(Lam* lam, const Def* rb);

--- a/dialects/clos/phase/lower_typed_clos.cpp
+++ b/dialects/clos/phase/lower_typed_clos.cpp
@@ -113,7 +113,7 @@ const Def* LowerTypedClos::rewrite(const Def* def) {
 
     if (auto c = isa_clos_lit(def)) {
         auto env      = rewrite(c.env());
-        auto mode     = (env->type()->isa<Int>() || isa<Tag::Ptr>(env->type())) ? Unbox : Box;
+        auto mode     = (env->type()->isa<Idx>() || isa<Tag::Ptr>(env->type())) ? Unbox : Box;
         const Def* fn = make_stub(c.fnc_as_lam(), mode, true);
         if (env->type() == w.sigma()) {
             // Optimize empty env

--- a/dialects/core/core.h
+++ b/dialects/core/core.h
@@ -70,7 +70,7 @@ const Def* op(O o, nat_t mode, const Def* a, const Def* b, const Def* dbg = {}) 
 }
 
 inline const Def* get_size(const Def* type) {
-    if (auto int_t = type->isa<Int>()) return int_t->size();
+    if (auto idx = type->isa<Idx>()) return idx->size();
     if (auto real = isa<Tag::Real>(type)) return real->arg();
     unreachable();
 }
@@ -92,7 +92,7 @@ inline const Def* op_bitcast(const Def* dst_type, const Def* src, const Def* dbg
 inline const Def* op_negate(const Def* a, const Def* dbg = {}) {
     World& w   = a->world();
     auto width = as_lit(w.iinfer(a));
-    return op(bit2::_xor, w.lit_int(width, width - 1_u64), a, dbg);
+    return op(bit2::_xor, w.lit_idx(width, width - 1_u64), a, dbg);
 }
 // todo: real op
 // const Def* op_rminus(const Def* rmode, const Def* a, const Def* dbg = {}) {
@@ -103,7 +103,7 @@ inline const Def* op_negate(const Def* a, const Def* dbg = {}) {
 inline const Def* op_wminus(const Def* wmode, const Def* a, const Def* dbg = {}) {
     World& w   = a->world();
     auto width = as_lit(w.iinfer(a));
-    return op(wrap::sub, wmode, w.lit_int(width, 0), a, dbg);
+    return op(wrap::sub, wmode, w.lit_idx(width, 0), a, dbg);
 }
 // todo: real op
 // const Def* op_rminus(nat_t rmode, const Def* a, const Def* dbg = {}) { return op_rminus(lit_nat(rmode), a, dbg); }
@@ -117,11 +117,11 @@ inline const Def* op_wminus(nat_t wmode, const Def* a, const Def* dbg = {}) {
 ///@{
 inline const Def* extract_unsafe(const Def* d, const Def* i, const Def* dbg = {}) {
     World& w = d->world();
-    return w.extract(d, op(conv::u2u, w.type_int(as_lit(d->unfold_type()->arity())), i, dbg), dbg);
+    return w.extract(d, op(conv::u2u, w.type_idx(as_lit(d->unfold_type()->arity())), i, dbg), dbg);
 }
 inline const Def* extract_unsafe(const Def* d, u64 i, const Def* dbg = {}) {
     World& w = d->world();
-    return extract_unsafe(d, w.lit_int(0_u64, i), dbg);
+    return extract_unsafe(d, w.lit_idx(0_u64, i), dbg);
 }
 ///@}
 
@@ -129,11 +129,11 @@ inline const Def* extract_unsafe(const Def* d, u64 i, const Def* dbg = {}) {
 ///@{
 inline const Def* insert_unsafe(const Def* d, const Def* i, const Def* val, const Def* dbg = {}) {
     World& w = d->world();
-    return w.insert(d, op(conv::u2u, w.type_int(as_lit(d->unfold_type()->arity())), i), val, dbg);
+    return w.insert(d, op(conv::u2u, w.type_idx(as_lit(d->unfold_type()->arity())), i), val, dbg);
 }
 inline const Def* insert_unsafe(const Def* d, u64 i, const Def* val, const Def* dbg = {}) {
     World& w = d->world();
-    return insert_unsafe(d, w.lit_int(0_u64, i), val, dbg);
+    return insert_unsafe(d, w.lit_idx(0_u64, i), val, dbg);
 }
 ///@}
 

--- a/dialects/core/core.thorin
+++ b/dialects/core/core.thorin
@@ -16,7 +16,7 @@
 ///
 /// ### %core.icmp
 ///
-/// Integer comparison is made of 5 disjoint relations:
+/// Idxeger comparison is made of 5 disjoint relations:
 ///     * `X`: first operand plus, second minus
 ///     * `Y`: first operand minus, second plus
 ///     * `G`: greater with same sign
@@ -80,7 +80,7 @@
                xYgle,     xYglE,     xYgLe = sl, xYgLE = sle, xYGle = ug, xYGlE = uge, xYGLe,      xYGLE,
                Xygle,     XyglE,     XygLe = ul, XygLE = ule, XyGle = sg, XyGlE = sge, XyGLe,      XyGLE,
                XYgle,     XYglE,     XYgLe,      XYgLE,       XYGle,      XYGlE,       XYGLe = ne, XYGLE = t):
-    Π w: .Nat -> [.Int w, .Int w] -> .Bool , normalize_icmp;
+    Π w: .Nat -> [.Idx w, .Idx w] -> .Bool , normalize_icmp;
 ///
 /// ### %core.bit1
 ///
@@ -92,7 +92,7 @@
 /// | neg    | o | x | negate                       |
 /// | id     | x | o | identity                     |
 /// | t      | x | x | always true                  |
-.ax %core.bit1(f, neg, id, t): Π w: .Nat -> .Int w -> .Int w;
+.ax %core.bit1(f, neg, id, t): Π w: .Nat -> .Idx w -> .Idx w;
 ///
 /// ### %core.bit2
 ///
@@ -118,26 +118,26 @@
 /// | t      |  x |  x |  x |  x | always true                  |
 .ax %core.bit2( f,      nor,    nciff,  na,     niff,   nb,   _xor, nand,
                 _and,  nxor,    b,      iff,    a,      ciff, _or,  t):
-    Π w: .Nat -> [.Int w, .Int w] -> .Int w , normalize_bit2;
+    Π w: .Nat -> [.Idx w, .Idx w] -> .Idx w , normalize_bit2;
 ///
 /// ### %core.shr
 ///
-.ax %core.shr(ashr, lshr): Π w: .Nat -> [.Int w, .Int w] -> .Int w, normalize_shr;
+.ax %core.shr(ashr, lshr): Π w: .Nat -> [.Idx w, .Idx w] -> .Idx w, normalize_shr;
 ///
 /// ### %core.wrap
 ///
-.ax %core.wrap(add, sub, mul, shl): Π [m: .Nat, w: .Nat] -> [.Int w, .Int w] -> .Int w, normalize_wrap;
+.ax %core.wrap(add, sub, mul, shl): Π [m: .Nat, w: .Nat] -> [.Idx w, .Idx w] -> .Idx w, normalize_wrap;
 ///
 /// ### %core.div
 ///
-.ax %core.div(sdiv, udiv, srem, urem): Π w: .Nat -> [%mem.M, .Int w, .Int w] -> [%mem.M, .Int w], normalize_div;
+.ax %core.div(sdiv, udiv, srem, urem): Π w: .Nat -> [%mem.M, .Idx w, .Idx w] -> [%mem.M, .Idx w], normalize_div;
 ///
 /// ### %core.conv
 ///
-/// Bit width (and signedness) conversion for `.Int -> .Int` and `%Real -> %Real` as well as `%Real -> .Int` and `.Int -> %Real` conversions.
-.ax %core.conv(s2s, u2u): Π [dw: .Nat, sw: .Nat] -> .Int sw -> .Int dw, normalize_conv;
-.ax %core.conv(s2r, u2r): Π [dw: .Nat, sw: .Nat] -> .Int sw -> %Real dw, normalize_conv;
-.ax %core.conv(r2s, r2u): Π [dw: .Nat, sw: .Nat] -> %Real sw -> .Int dw, normalize_conv;
+/// Bit width (and signedness) conversion for `.Idx -> .Idx` and `%Real -> %Real` as well as `%Real -> .Idx` and `.Idx -> %Real` conversions.
+.ax %core.conv(s2s, u2u): Π [dw: .Nat, sw: .Nat] -> .Idx sw -> .Idx dw, normalize_conv;
+.ax %core.conv(s2r, u2r): Π [dw: .Nat, sw: .Nat] -> .Idx sw -> %Real dw, normalize_conv;
+.ax %core.conv(r2s, r2u): Π [dw: .Nat, sw: .Nat] -> %Real sw -> .Idx dw, normalize_conv;
 .ax %core.conv(r2r): Π [dw: .Nat, sw: .Nat] -> %Real sw -> %Real dw, normalize_conv;
 ///
 /// ### %core.bitcast

--- a/dialects/core/core.thorin
+++ b/dialects/core/core.thorin
@@ -16,7 +16,7 @@
 ///
 /// ### %core.icmp
 ///
-/// Idxeger comparison is made of 5 disjoint relations:
+/// Integer comparison is made of 5 disjoint relations:
 ///     * `X`: first operand plus, second minus
 ///     * `Y`: first operand minus, second plus
 ///     * `G`: greater with same sign

--- a/dialects/mem/mem.h
+++ b/dialects/mem/mem.h
@@ -57,13 +57,13 @@ inline const Def* op_lea(const Def* ptr, const Def* index, const Def* dbg = {}) 
 
 inline const Def* op_lea_unsafe(const Def* ptr, const Def* i, const Def* dbg = {}) {
     World& w      = ptr->world();
-    auto safe_int = w.type_int(match<mem::Ptr, false>(ptr->type())->arg(0)->arity());
+    auto safe_int = w.type_idx(match<mem::Ptr, false>(ptr->type())->arg(0)->arity());
     return op_lea(ptr, core::op(core::conv::u2u, safe_int, i), dbg);
 }
 
 inline const Def* op_lea_unsafe(const Def* ptr, u64 i, const Def* dbg = {}) {
     World& w = ptr->world();
-    return op_lea_unsafe(ptr, w.lit_int(i), dbg);
+    return op_lea_unsafe(ptr, w.lit_idx(i), dbg);
 }
 
 inline const Def* op_load(const Def* mem, const Def* ptr, const Def* dbg = {}) {

--- a/dialects/mem/mem.thorin
+++ b/dialects/mem/mem.thorin
@@ -65,4 +65,4 @@
 ///
 /// Load effective address. 
 /// Performs address computation.
-.ax %mem.lea: Π [n: .Nat, Ts: «n; *», as: .Nat] -> Π [%mem.Ptr(«j: n; Ts#j», as), i: .Int n] -> %mem.Ptr(Ts#i, as), normalize_lea;
+.ax %mem.lea: Π [n: .Nat, Ts: «n; *», as: .Nat] -> Π [%mem.Ptr(«j: n; Ts#j», as), i: .Idx n] -> %mem.Ptr(Ts#i, as), normalize_lea;

--- a/docs/langref.md
+++ b/docs/langref.md
@@ -47,8 +47,8 @@ In addition the following keywords are *terminals*:
 | `.module`   | starts a module           |
 | `.import`   | imports a dialect         |
 | `.Nat`      | thorin::Nat               |
-| `.Int`      | thorin::Int               |
-| `.Bool`     | alias for `.Int 2`        |
+| `.Idx`      | thorin::Idx               |
+| `.Bool`     | alias for `.Idx 2`        |
 | `.ff`       | alias for `0₂`            |
 | `.tt`       | alias for `1₂`            |
 | `.Type`     | thorin::Type              |
@@ -78,8 +78,8 @@ The following *terminals* comprise more complicated patterns that are specified 
 | L        | sign? 0x hex+ pP sign dec+           | [floating-point hexadecimal](https://en.cppreference.com/w/cpp/language/floating_literal) literal |
 | L        | sign? 0x hex+ `.` hex\* pP sign dec+ | [floating-point hexadecimal](https://en.cppreference.com/w/cpp/language/floating_literal) literal |
 | L        | sign? 0x hex\* `.` hex+ pP sign dec+ | [floating-point hexadecimal](https://en.cppreference.com/w/cpp/language/floating_literal) literal |
-| I        | dec+ sub+                            | integer literal of type `:Int mod`                                                                |
-| I        | dec+ `_` dec+                        | integer literal of type `:Int mod`                                                                |
+| I        | dec+ sub+                            | index literal of type `.Idx sub`                                                                  |
+| I        | dec+ `_` dec+                        | index literal of type `.Idx sub`                                                                  |
 
 The previous table resorts to the following definitions as shorthand:
 
@@ -167,12 +167,12 @@ For this reason there is no rule `b -> s (p, ..., p)`.
 | e           | `*`                                                                           |            | alias for `.Type (0:.Univ)`         | thorin::Type    |
 | e           | `□`                                                                           |            | alias for `.Type (1:.Univ)`         | thorin::Type    |
 | e           | `.Nat`                                                                        |            | natural number                      | thorin::Nat     |
-| e           | `.Int` e                                                                      |            | integer of size e                   | thorin::Int     |
-| e           | `.Bool`                                                                       |            | alias for `.Int 2`                  | thorin::Int     |
+| e           | `.Idx` e                                                                      |            | index of size e                     | thorin::Idx     |
+| e           | `.Bool`                                                                       |            | alias for `.Idx 2`                  | thorin::Idx     |
 | e           | `{` e `}`                                                                     | ✓          | block                               | -               |
 | e           | L `:` e<sub>type</sub>                                                        |            | literal                             | thorin::Lit     |
-| e           | `.ff`                                                                         |            | alias for `0:(.Int 2)`              | thorin::Lit     |
-| e           | `.tt`                                                                         |            | alias for `1:(.Int 2)`              | thorin::Lit     |
+| e           | `.ff`                                                                         |            | alias for `0:(.Idx 2)`              | thorin::Lit     |
+| e           | `.tt`                                                                         |            | alias for `1:(.Idx 2)`              | thorin::Lit     |
 | e           | ( `.bot` or `.top` ) ( `:` e<sub>type</sub> )?                                |            | bottom/top                          | thorin::TExt    |
 | e           | Sym                                                                           |            | identifier                          | -               |
 | e           | Ax                                                                            |            | use of an axiom                     | -               |

--- a/gtest/restricted_dep_types.cpp
+++ b/gtest/restricted_dep_types.cpp
@@ -40,8 +40,8 @@ TEST(RestrictedDependentTypes, join_singleton) {
         core_d.register_normalizers(normalizers);
         fe::Parser::import_module(w, "core", {}, &normalizers);
 
-        auto i32_t = w.type_int_width(32);
-        auto i64_t = w.type_int_width(64);
+        auto i32_t = w.type_int_(32);
+        auto i64_t = w.type_int_(64);
 
         auto R = w.axiom(w.type(), w.dbg("R"));
         auto W = w.axiom(w.type(), w.dbg("W"));
@@ -136,8 +136,8 @@ TEST(RestrictedDependentTypes, join_singleton) {
 
         for (auto&& test : cases) {
             test_on_world([&test](World& w, auto R, auto W, auto Exp) {
-                auto i32_t = w.type_int_width(32);
-                auto i64_t = w.type_int_width(64);
+                auto i32_t = w.type_int_(32);
+                auto i64_t = w.type_int_(64);
                 auto RW    = w.join({w.singleton(R), w.singleton(W)}, w.dbg("RW"));
                 auto DT    = w.join({w.singleton(i32_t), w.singleton(i64_t)}, w.dbg("DT"));
 
@@ -205,8 +205,8 @@ TEST(RestrictedDependentTypes, join_singleton) {
 
         for (auto&& test : cases) {
             test_on_world([&test](World& w, auto R, auto W, auto Exp) {
-                auto i32_t = w.type_int_width(32);
-                auto i64_t = w.type_int_width(64);
+                auto i32_t = w.type_int_(32);
+                auto i64_t = w.type_int_(64);
                 auto RW    = w.join({w.singleton(R), w.singleton(W)}, w.dbg("RW"));
                 auto DT    = w.join({w.singleton(i32_t), w.singleton(i64_t)}, w.dbg("DT"));
 
@@ -237,7 +237,7 @@ TEST(RestrictedDependentTypes, ll) {
     fe::Parser::import_module(w, "core", {}, &normalizers);
 
     auto mem_t  = mem::type_mem(w);
-    auto i32_t  = w.type_int_width(32);
+    auto i32_t  = w.type_int_(32);
     auto argv_t = mem::type_ptr(mem::type_ptr(i32_t));
 
     // Cn [mem, i32, ptr(ptr(i32, 0), 0) Cn [mem, i32]]

--- a/gtest/test.cpp
+++ b/gtest/test.cpp
@@ -17,17 +17,17 @@ TEST(Zip, fold) {
     World w;
 
     // clang-format off
-    auto a = w.tuple({w.tuple({w.lit_int( 0), w.lit_int( 1), w.lit_int( 2)}),
-                      w.tuple({w.lit_int( 3), w.lit_int( 4), w.lit_int( 5)})});
+    auto a = w.tuple({w.tuple({w.lit_idx( 0), w.lit_idx( 1), w.lit_idx( 2)}),
+                      w.tuple({w.lit_idx( 3), w.lit_idx( 4), w.lit_idx( 5)})});
 
-    auto b = w.tuple({w.tuple({w.lit_int( 6), w.lit_int( 7), w.lit_int( 8)}),
-                      w.tuple({w.lit_int( 9), w.lit_int(10), w.lit_int(11)})});
+    auto b = w.tuple({w.tuple({w.lit_idx( 6), w.lit_idx( 7), w.lit_idx( 8)}),
+                      w.tuple({w.lit_idx( 9), w.lit_idx(10), w.lit_idx(11)})});
 
-    auto c = w.tuple({w.tuple({w.lit_int( 6), w.lit_int( 8), w.lit_int(10)}),
-                      w.tuple({w.lit_int(12), w.lit_int(14), w.lit_int(16)})});
+    auto c = w.tuple({w.tuple({w.lit_idx( 6), w.lit_idx( 8), w.lit_idx(10)}),
+                      w.tuple({w.lit_idx(12), w.lit_idx(14), w.lit_idx(16)})});
 
-    auto f = w.fn(Wrap::add, w.lit_nat(0), w.lit_nat(width2mod(32)));
-    auto i32_t = w.type_int_width(32);
+    auto f = w.fn(Wrap::add, w.lit_nat(0), w.lit_nat(bitwidth2size(32)));
+    auto i32_t = w.type_int_(32);
     auto res = w.app(w.app(w.app(w.ax_zip(), {/*r*/w.lit_nat(2), /*s*/w.tuple({w.lit_nat(2), w.lit_nat(3)})}),
                                              {/*n_i*/ w.lit_nat(2), /*Is*/w.pack(2, i32_t), /*n_o*/w.lit_nat(1), /*Os*/i32_t, f}),
                                              {a, b});
@@ -46,7 +46,7 @@ TEST(World, simplify_one_tuple) {
     type->set({w.type_nat(), w.type_nat()});
     ASSERT_EQ(type, w.sigma({type})) << "constant fold [nom] -> nom";
 
-    auto v = w.tuple(type, {w.lit_int(42), w.lit_int(1337)});
+    auto v = w.tuple(type, {w.lit_idx(42), w.lit_idx(1337)});
     ASSERT_EQ(v, w.tuple({v})) << "constant fold ({42, 1337}) -> {42, 1337}";
 }
 

--- a/lit/CMakeLists.txt
+++ b/lit/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Python3 COMPONENTS Interpreter)
+find_package(Python3 COMPONENTS Idxerpreter)
 set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
 
 configure_file(lit.site.cfg.py.in lit.site.cfg.py @ONLY)

--- a/lit/CMakeLists.txt
+++ b/lit/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Python3 COMPONENTS Idxerpreter)
+find_package(Python3 COMPONENTS Interpreter)
 set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
 
 configure_file(lit.site.cfg.py.in lit.site.cfg.py @ONLY)

--- a/lit/affine/dynamic_for.thorin
+++ b/lit/affine/dynamic_for.thorin
@@ -8,36 +8,36 @@
 .import mem;
 .import core;
 
-.cn atoi [%mem.M, %mem.Ptr («⊤:.Nat; .Int 256», 0:.Nat), .Cn [%mem.M, .Int 4294967296]];
+.cn atoi [%mem.M, %mem.Ptr («⊤:.Nat; .Idx 256», 0:.Nat), .Cn [%mem.M, .Idx 4294967296]];
 
-.cn .extern main [mem : %mem.M, argc : .Int 4294967296, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .Int 256», 0:.Nat)», 0:.Nat), return : .Cn [%mem.M, .Int 4294967296]] = {
-    .cn for_body [i : .Int 4294967296, [acc_a : .Int 4294967296, acc_b : .Int 4294967296], continue : .Cn [.Int 4294967296, .Int 4294967296]] = {
-        .let a : .Int 4294967296 = %core.wrap.add (0:.Nat, 4294967296:.Nat) (i, acc_a);
-        .let b : .Int 4294967296 = %core.wrap.sub (0:.Nat, 4294967296:.Nat) (i, acc_b);
+.cn .extern main [mem : %mem.M, argc : .Idx 4294967296, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .Idx 256», 0:.Nat)», 0:.Nat), return : .Cn [%mem.M, .Idx 4294967296]] = {
+    .cn for_body [i : .Idx 4294967296, [acc_a : .Idx 4294967296, acc_b : .Idx 4294967296], continue : .Cn [.Idx 4294967296, .Idx 4294967296]] = {
+        .let a : .Idx 4294967296 = %core.wrap.add (0:.Nat, 4294967296:.Nat) (i, acc_a);
+        .let b : .Idx 4294967296 = %core.wrap.sub (0:.Nat, 4294967296:.Nat) (i, acc_b);
         continue (a, b)
     };
     
-    .cn atoi_cont_begin [mem : %mem.M, start : .Int 4294967296] = {
-        .let _19234: %mem.Ptr (%mem.Ptr («⊤:.Nat; .Int 256», 0:.Nat), 0:.Nat) = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .Int 256», 0:.Nat)›, 0:.Nat) (argv, 2:(.Int 4294967296));
-        .let _19247: [%mem.M, %mem.Ptr («⊤:.Nat; .Int 256», 0:.Nat)] = %mem.load (%mem.Ptr («⊤:.Nat; .Int 256», 0:.Nat), 0:.Nat) (mem, _19234);
+    .cn atoi_cont_begin [mem : %mem.M, start : .Idx 4294967296] = {
+        .let _19234: %mem.Ptr (%mem.Ptr («⊤:.Nat; .Idx 256», 0:.Nat), 0:.Nat) = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .Idx 256», 0:.Nat)›, 0:.Nat) (argv, 2:(.Idx 4294967296));
+        .let _19247: [%mem.M, %mem.Ptr («⊤:.Nat; .Idx 256», 0:.Nat)] = %mem.load (%mem.Ptr («⊤:.Nat; .Idx 256», 0:.Nat), 0:.Nat) (mem, _19234);
 
-        .cn atoi_cont_end [mem : %mem.M, stop : .Int 4294967296] = {
-            .let _19318: %mem.Ptr (%mem.Ptr («⊤:.Nat; .Int 256», 0:.Nat), 0:.Nat) = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .Int 256», 0:.Nat)›, 0:.Nat) (argv, 3:(.Int 4294967296));
-            .let _19331: [%mem.M, %mem.Ptr («⊤:.Nat; .Int 256», 0:.Nat)] = %mem.load (%mem.Ptr («⊤:.Nat; .Int 256», 0:.Nat), 0:.Nat) (mem, _19318);
-            .cn atoi_cont_step [mem : %mem.M, step : .Int 4294967296] = {
-                .cn for_exit [acc : [.Int 4294967296, .Int 4294967296]] = {
+        .cn atoi_cont_end [mem : %mem.M, stop : .Idx 4294967296] = {
+            .let _19318: %mem.Ptr (%mem.Ptr («⊤:.Nat; .Idx 256», 0:.Nat), 0:.Nat) = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .Idx 256», 0:.Nat)›, 0:.Nat) (argv, 3:(.Idx 4294967296));
+            .let _19331: [%mem.M, %mem.Ptr («⊤:.Nat; .Idx 256», 0:.Nat)] = %mem.load (%mem.Ptr («⊤:.Nat; .Idx 256», 0:.Nat), 0:.Nat) (mem, _19318);
+            .cn atoi_cont_step [mem : %mem.M, step : .Idx 4294967296] = {
+                .cn for_exit [acc : [.Idx 4294967296, .Idx 4294967296]] = {
                     return (mem, acc#.ff)
                 };
 
-                %affine.For (4294967296:.Nat, 2:.Nat, (.Int 4294967296, .Int 4294967296)) (start, stop, step, (0:(.Int 4294967296), 5:(.Int 4294967296)), for_body, for_exit)
+                %affine.For (4294967296:.Nat, 2:.Nat, (.Idx 4294967296, .Idx 4294967296)) (start, stop, step, (0:(.Idx 4294967296), 5:(.Idx 4294967296)), for_body, for_exit)
             };
             atoi (_19331#.ff, _19331#.tt, atoi_cont_step)
         };
         atoi (_19247#.ff, _19247#.tt, atoi_cont_end)
     };
 
-    .let _19093: %mem.Ptr (%mem.Ptr («⊤:.Nat; .Int 256», 0:.Nat), 0:.Nat) = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .Int 256», 0:.Nat)›, 0:.Nat) (argv, 1:(.Int 4294967296));
-    .let _19163: [%mem.M, %mem.Ptr («⊤:.Nat; .Int 256», 0:.Nat)] = %mem.load (%mem.Ptr («⊤:.Nat; .Int 256», 0:.Nat), 0:.Nat) (mem, _19093);
+    .let _19093: %mem.Ptr (%mem.Ptr («⊤:.Nat; .Idx 256», 0:.Nat), 0:.Nat) = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .Idx 256», 0:.Nat)›, 0:.Nat) (argv, 1:(.Idx 4294967296));
+    .let _19163: [%mem.M, %mem.Ptr («⊤:.Nat; .Idx 256», 0:.Nat)] = %mem.load (%mem.Ptr («⊤:.Nat; .Idx 256», 0:.Nat), 0:.Nat) (mem, _19093);
     atoi (_19163#.ff, _19163#.tt, atoi_cont_begin)
 };
 

--- a/lit/affine/for_2acc.thorin
+++ b/lit/affine/for_2acc.thorin
@@ -8,17 +8,17 @@
 .import mem;
 .import core;
 
-.cn .extern main [mem : %mem.M, argc : .Int 4294967296, argv : %mem.Ptr (%mem.Ptr (.Int 4294967296, 0:.Nat), 0:.Nat), return : .Cn [%mem.M, .Int 4294967296]] = {
-    .cn for_exit [acc : [.Int 4294967296, .Int 4294967296]] = {
+.cn .extern main [mem : %mem.M, argc : .Idx 4294967296, argv : %mem.Ptr (%mem.Ptr (.Idx 4294967296, 0:.Nat), 0:.Nat), return : .Cn [%mem.M, .Idx 4294967296]] = {
+    .cn for_exit [acc : [.Idx 4294967296, .Idx 4294967296]] = {
         return (mem, acc#.ff)
     };
 
-    .cn for_body [i : .Int 4294967296, acc : [.Int 4294967296, .Int 4294967296], continue : .Cn [[.Int 4294967296, .Int 4294967296]]] = {
-        .let a : .Int 4294967296 = %core.wrap.add (0:.Nat, 4294967296:.Nat) (i, acc#.ff);
-        .let b : .Int 4294967296 = %core.wrap.sub (0:.Nat, 4294967296:.Nat) (i, acc#.tt);
+    .cn for_body [i : .Idx 4294967296, acc : [.Idx 4294967296, .Idx 4294967296], continue : .Cn [[.Idx 4294967296, .Idx 4294967296]]] = {
+        .let a : .Idx 4294967296 = %core.wrap.add (0:.Nat, 4294967296:.Nat) (i, acc#.ff);
+        .let b : .Idx 4294967296 = %core.wrap.sub (0:.Nat, 4294967296:.Nat) (i, acc#.tt);
         continue (a, b)
     };
-    %affine.For (4294967296, 2, (.Int 4294967296, .Int 4294967296)) (0:(.Int 4294967296), argc, 1:(.Int 4294967296), (0:(.Int 4294967296), 0:(.Int 4294967296)), for_body, for_exit)
+    %affine.For (4294967296, 2, (.Idx 4294967296, .Idx 4294967296)) (0:(.Idx 4294967296), argc, 1:(.Idx 4294967296), (0:(.Idx 4294967296), 0:(.Idx 4294967296)), for_body, for_exit)
 };
 
 // CHECK-NOT: affine.for

--- a/lit/affine/for_2acc_2types.thorin
+++ b/lit/affine/for_2acc_2types.thorin
@@ -8,17 +8,17 @@
 .import mem;
 .import affine;
 
-.cn .extern main [mem : %mem.M, argc : .Int 4294967296, argv : %mem.Ptr (%mem.Ptr (.Int 4294967296, 0:.Nat), 0:.Nat), return : .Cn [%mem.M, .Int 0]] = {
-    .cn for_exit [acc : [.Int 4294967296, .Int 0]] = {
+.cn .extern main [mem : %mem.M, argc : .Idx 4294967296, argv : %mem.Ptr (%mem.Ptr (.Idx 4294967296, 0:.Nat), 0:.Nat), return : .Cn [%mem.M, .Idx 0]] = {
+    .cn for_exit [acc : [.Idx 4294967296, .Idx 0]] = {
         return (mem, acc#.tt)
     };
 
-    .cn for_body [i : .Int 4294967296, acc : [.Int 4294967296, .Int 0], continue : .Cn [[.Int 4294967296, .Int 0]]] = {
-        .let a : .Int 4294967296 = %core.wrap.add (0:.Nat, 4294967296:.Nat) (i, acc#.ff);
-        .let b : .Int 0 = %core.wrap.add (0:.Nat, 0:.Nat) (%core.conv.u2u (0, 4294967296) i, acc#.tt);
+    .cn for_body [i : .Idx 4294967296, acc : [.Idx 4294967296, .Idx 0], continue : .Cn [[.Idx 4294967296, .Idx 0]]] = {
+        .let a : .Idx 4294967296 = %core.wrap.add (0:.Nat, 4294967296:.Nat) (i, acc#.ff);
+        .let b : .Idx 0 = %core.wrap.add (0:.Nat, 0:.Nat) (%core.conv.u2u (0, 4294967296) i, acc#.tt);
         continue (a, b)
     };
-    %affine.For (4294967296, 2, (.Int 4294967296, .Int 0)) (0:(.Int 4294967296), argc, 1:(.Int 4294967296), (0:(.Int 4294967296), 0:(.Int 0)), for_body, for_exit)
+    %affine.For (4294967296, 2, (.Idx 4294967296, .Idx 0)) (0:(.Idx 4294967296), argc, 1:(.Idx 4294967296), (0:(.Idx 4294967296), 0:(.Idx 0)), for_body, for_exit)
 };
 
 // CHECK-NOT: affine.for

--- a/lit/affine/for_2acc_real.thorin
+++ b/lit/affine/for_2acc_real.thorin
@@ -8,17 +8,17 @@
 .import mem;
 .import affine;
 
-.cn .extern main [mem : %mem.M, argc : .Int 4294967296, argv : %mem.Ptr (%mem.Ptr (.Int 4294967296, 0:.Nat), 0:.Nat), return : .Cn [%mem.M, .Int 0]] = {
-    .cn for_exit [acc : [.Int 4294967296, %Real 64]] = {
+.cn .extern main [mem : %mem.M, argc : .Idx 4294967296, argv : %mem.Ptr (%mem.Ptr (.Idx 4294967296, 0:.Nat), 0:.Nat), return : .Cn [%mem.M, .Idx 0]] = {
+    .cn for_exit [acc : [.Idx 4294967296, %Real 64]] = {
         return (mem, %core.conv.r2u (0, 64) acc#.tt)
     };
 
-    .cn for_body [i : .Int 4294967296, [acc_a : .Int 4294967296, acc_b : %Real 64], continue : .Cn [[.Int 4294967296, %Real 64]]] = {
-        .let a : .Int 4294967296 = %core.wrap.add (0:.Nat, 4294967296:.Nat) (i, acc_a);
+    .cn for_body [i : .Idx 4294967296, [acc_a : .Idx 4294967296, acc_b : %Real 64], continue : .Cn [[.Idx 4294967296, %Real 64]]] = {
+        .let a : .Idx 4294967296 = %core.wrap.add (0:.Nat, 4294967296:.Nat) (i, acc_a);
         .let b : %Real 64 = %core.conv.u2r (64, 0) (%core.wrap.add (0:.Nat, 0:.Nat) (%core.conv.u2u (0, 4294967296) i, %core.conv.r2u (0, 64) acc_b));
         continue (a, b)
     };
-    %affine.For (4294967296, 2, (.Int 4294967296, %Real 64)) (0:(.Int 4294967296), argc, 1:(.Int 4294967296), (0:(.Int 4294967296), 0:(%Real 64)), for_body, for_exit)
+    %affine.For (4294967296, 2, (.Idx 4294967296, %Real 64)) (0:(.Idx 4294967296), argc, 1:(.Idx 4294967296), (0:(.Idx 4294967296), 0:(%Real 64)), for_body, for_exit)
 };
 
 // CHECK-NOT: affine.for

--- a/lit/affine/for_over_mem.thorin
+++ b/lit/affine/for_over_mem.thorin
@@ -8,7 +8,7 @@
 .import mem;
 .import core;
 
-.let i32 = .Int 4294967296;
+.let i32 = .Idx 4294967296;
 
 .cn .extern main [mem : %mem.M, argc : i32, argv : %mem.Ptr (%mem.Ptr (i32, 0:.Nat), 0:.Nat), return : .Cn [%mem.M, i32]] = {
     // .let arr_size = 16;

--- a/lit/affine/lower_for.thorin
+++ b/lit/affine/lower_for.thorin
@@ -8,23 +8,23 @@
 .import mem;
 .import core;
 
-.cn .extern main (mem : %mem.M, argc : .Int 4294967296, argv : %mem.Ptr (%mem.Ptr (.Int 256, 0), 0), return : .Cn [%mem.M, .Int 4294967296]) = {
-    .cn for_exit [acc : .Int 4294967296] = {
+.cn .extern main (mem : %mem.M, argc : .Idx 4294967296, argv : %mem.Ptr (%mem.Ptr (.Idx 256, 0), 0), return : .Cn [%mem.M, .Idx 4294967296]) = {
+    .cn for_exit [acc : .Idx 4294967296] = {
         return (mem, acc)
     };
 
-    .cn for_body [i : .Int 4294967296, acc : .Int 4294967296, continue : .Cn [.Int 4294967296]] = {
+    .cn for_body [i : .Idx 4294967296, acc : .Idx 4294967296, continue : .Cn [.Idx 4294967296]] = {
         continue (%core.wrap.add (0, 4294967296) (i, acc))
     };
-    %affine.For (4294967296, 1, (.Int 4294967296)) (0:(.Int 4294967296), argc, 1:(.Int 4294967296), (0:(.Int 4294967296)), for_body, for_exit)
+    %affine.For (4294967296, 1, (.Idx 4294967296)) (0:(.Idx 4294967296), argc, 1:(.Idx 4294967296), (0:(.Idx 4294967296)), for_body, for_exit)
 };
 
-// CHECK-DAG: .cn .extern main _[[mainVar:[0-9_]+]]::[mem_[[memVar:[0-9_]+]]: %mem.M, argc_[[argcId:[0-9_]+]]: (.Int 4294967296), %mem.Ptr (%mem.Ptr ((.Int 256), 0), 0), return_[[returnId:[0-9_]+]]: .Cn [%mem.M, (.Int 4294967296)]] = {
+// CHECK-DAG: .cn .extern main _[[mainVar:[0-9_]+]]::[mem_[[memVar:[0-9_]+]]: %mem.M, argc_[[argcId:[0-9_]+]]: (.Idx 4294967296), %mem.Ptr (%mem.Ptr ((.Idx 256), 0), 0), return_[[returnId:[0-9_]+]]: .Cn [%mem.M, (.Idx 4294967296)]] = {
 
-// CHECK-DAG: .cn return_[[returnId:[0-9_]+]] _[[returnVarId:[0-9_]+]]: [%mem.M, (.Int 4294967296)]
+// CHECK-DAG: .cn return_[[returnId:[0-9_]+]] _[[returnVarId:[0-9_]+]]: [%mem.M, (.Idx 4294967296)]
 
-// CHECK-DAG: .cn for_[[forId:[0-9_]+]] _[[forVarId:[0-9_]+]]::[_[[forIntId:[0-9_]+]]: (.Int 4294967296), _[[forAccId:[0-9_]+]]: (.Int 4294967296)]
-// CHECK-DAG: _[[cmpId:[0-9_]+]]: (.Int 2) = %core.icmp.XygLe
+// CHECK-DAG: .cn for_[[forId:[0-9_]+]] _[[forVarId:[0-9_]+]]::[_[[forIdxId:[0-9_]+]]: (.Idx 4294967296), _[[forAccId:[0-9_]+]]: (.Idx 4294967296)]
+// CHECK-DAG: _[[cmpId:[0-9_]+]]: (.Idx 2) = %core.icmp.XygLe
 // CHECK-DAG: (_[[falseId:[0-9_]+]], for_body_[[bodyId:[0-9_]+]])#_[[cmpId]]
 
 // CHECK-DAG: .cn _{{[0-9]+}} []

--- a/lit/core/normalize_add.thorin
+++ b/lit/core/normalize_add.thorin
@@ -3,22 +3,22 @@
 
 .import core;
 
-.cn .extern add0 [i :.Int 256, return : .Cn .Int 256] = {
-    return (%core.wrap.add (0, 256) (i, 0 : (.Int 256)))
+.cn .extern add0 [i :.Idx 256, return : .Cn .Idx 256] = {
+    return (%core.wrap.add (0, 256) (i, 0 : (.Idx 256)))
 };
 
-// CHECK-DAG: add0 _{{[0-9_]+}}::[i_[[valId:[0-9_]+]]: (.Int 256), return_[[retId:[0-9_]+]]: .Cn (.Int 256)]
+// CHECK-DAG: add0 _{{[0-9_]+}}::[i_[[valId:[0-9_]+]]: (.Idx 256), return_[[retId:[0-9_]+]]: .Cn (.Idx 256)]
 // CHECK-DAG: return_[[etaId:[0-9_]+]] i_[[valId]]
 
-// CHECK-DAG: return_[[etaId]] _[[etaVar:[0-9_]+]]: (.Int 256)
+// CHECK-DAG: return_[[etaId]] _[[etaVar:[0-9_]+]]: (.Idx 256)
 // CHECK-DAG: return_[[retId]] _[[etaVar]]
 
-.cn .extern add_lit [return : .Cn .Int 256] = {
-    return (%core.wrap.add (0, 256) (6 : (.Int 256), 0 : (.Int 256)))
+.cn .extern add_lit [return : .Cn .Idx 256] = {
+    return (%core.wrap.add (0, 256) (6 : (.Idx 256), 0 : (.Idx 256)))
 };
 
-// CHECK-DAG: add_lit _[[retId:[0-9_]+]]: .Cn (.Int 256)
-// CHECK-DAG: _[[etaId:[0-9_]+]] 6:(.Int 256)
+// CHECK-DAG: add_lit _[[retId:[0-9_]+]]: .Cn (.Idx 256)
+// CHECK-DAG: _[[etaId:[0-9_]+]] 6:(.Idx 256)
 
-// CHECK-DAG: _[[etaId]] _[[etaVar:[0-9_]+]]: (.Int 256)
+// CHECK-DAG: _[[etaId]] _[[etaVar:[0-9_]+]]: (.Idx 256)
 // CHECK-DAG: _[[retId]] _[[etaVar]]

--- a/lit/core/normalize_and_ff.thorin
+++ b/lit/core/normalize_and_ff.thorin
@@ -3,12 +3,12 @@
 
 .import core;
 
-.cn .extern and_ff [i :.Int 2, return : .Cn .Int 2] = {
+.cn .extern and_ff [i :.Idx 2, return : .Cn .Idx 2] = {
     return (%core.bit2._and 2 (i, .ff))
 };
 
-// CHECK-DAG: .cn .extern and_ff _{{[0-9_]+}}::[(.Int 2), return_[[retId:[0-9_]+]]: .Cn (.Int 2)]
-// CHECK-DAG: return_[[etaId:[0-9_]+]] 0:(.Int 2)
+// CHECK-DAG: .cn .extern and_ff _{{[0-9_]+}}::[(.Idx 2), return_[[retId:[0-9_]+]]: .Cn (.Idx 2)]
+// CHECK-DAG: return_[[etaId:[0-9_]+]] 0:(.Idx 2)
 
-// CHECK-DAG: .cn return_[[etaId]] _[[etaVar:[0-9_]+]]: (.Int 2)
+// CHECK-DAG: .cn return_[[etaId]] _[[etaVar:[0-9_]+]]: (.Idx 2)
 // CHECK-DAG: return_[[retId]] _[[etaVar]]

--- a/lit/core/normalize_and_ff_tt.thorin
+++ b/lit/core/normalize_and_ff_tt.thorin
@@ -3,12 +3,12 @@
 
 .import core;
 
-.cn .extern and_lit_ff_tt [return : .Cn .Int 2] = {
+.cn .extern and_lit_ff_tt [return : .Cn .Idx 2] = {
     return (%core.bit2._and 2 (.ff, .tt))
 };
 
-// CHECK-DAG: and_lit_ff_tt _[[retId_ff_tt:[0-9_]+]]: .Cn (.Int 2)
-// CHECK-DAG: _[[etaId_ff_tt:[0-9_]+]] 0:(.Int 2)
+// CHECK-DAG: and_lit_ff_tt _[[retId_ff_tt:[0-9_]+]]: .Cn (.Idx 2)
+// CHECK-DAG: _[[etaId_ff_tt:[0-9_]+]] 0:(.Idx 2)
 
-// CHECK-DAG: _[[etaId_ff_tt]] _[[etaVar_ff_tt:[0-9_]+]]: (.Int 2)
+// CHECK-DAG: _[[etaId_ff_tt]] _[[etaVar_ff_tt:[0-9_]+]]: (.Idx 2)
 // CHECK-DAG: _[[retId_ff_tt]] _[[etaVar_ff_tt]]

--- a/lit/core/normalize_and_icmps.thorin
+++ b/lit/core/normalize_and_icmps.thorin
@@ -3,7 +3,7 @@
 
 .import core;
 
-.cn .extern and [a : .Int 2, b : .Int 2, return : .Cn .Int 2] = {
+.cn .extern and [a : .Idx 2, b : .Idx 2, return : .Cn .Idx 2] = {
     return
     (%core.bit2._and 2
         (%core.icmp.uge 2
@@ -12,9 +12,9 @@
             (a, b)))
 };
 
-// CHECK-DAG: .cn .extern and _{{[0-9_]+}}::[a_[[aId:[0-9_]+]]: (.Int 2), b_[[bId:[0-9_]+]]: (.Int 2), return_[[retId:[0-9_]+]]: .Cn (.Int 2)]
-// CHECK-DAG: .let _[[cmpId:[0-9_]+]]: (.Int 2) = %core.icmp.xYGle 2 (a_[[aId]], b_[[bId]]);
+// CHECK-DAG: .cn .extern and _{{[0-9_]+}}::[a_[[aId:[0-9_]+]]: (.Idx 2), b_[[bId:[0-9_]+]]: (.Idx 2), return_[[retId:[0-9_]+]]: .Cn (.Idx 2)]
+// CHECK-DAG: .let _[[cmpId:[0-9_]+]]: (.Idx 2) = %core.icmp.xYGle 2 (a_[[aId]], b_[[bId]]);
 // CHECK-DAG: return_[[etaId:[0-9_]+]] _[[cmpId]]
 
-// CHECK-DAG: return_[[etaId]] _[[etaVar:[0-9_]+]]: (.Int 2)
+// CHECK-DAG: return_[[etaId]] _[[etaVar:[0-9_]+]]: (.Idx 2)
 // CHECK-DAG: return_[[retId]] _[[etaVar]]

--- a/lit/core/normalize_and_icmps_lit.thorin
+++ b/lit/core/normalize_and_icmps_lit.thorin
@@ -3,7 +3,7 @@
 
 .import core;
 
-.cn .extern and_lit [return : .Cn .Int 2] = {
+.cn .extern and_lit [return : .Cn .Idx 2] = {
     return
     (%core.bit2._and 2
         (%core.icmp.uge 2
@@ -12,8 +12,8 @@
             (.tt, .ff)))
 };
 
-// CHECK-DAG: and_lit _[[retId:[0-9_]+]]: .Cn (.Int 2)
-// CHECK-DAG: _[[etaId:[0-9_]+]] 1:(.Int 2)
+// CHECK-DAG: and_lit _[[retId:[0-9_]+]]: .Cn (.Idx 2)
+// CHECK-DAG: _[[etaId:[0-9_]+]] 1:(.Idx 2)
 
-// CHECK-DAG: _[[etaId]] _[[etaVar:[0-9_]+]]: (.Int 2)
+// CHECK-DAG: _[[etaId]] _[[etaVar:[0-9_]+]]: (.Idx 2)
 // CHECK-DAG: _[[retId]] _[[etaVar]]

--- a/lit/core/normalize_and_tree.thorin
+++ b/lit/core/normalize_and_tree.thorin
@@ -3,7 +3,7 @@
 
 .import core;
 
-.cn .extern and_lit [return : .Cn .Int 2] = {
+.cn .extern and_lit [return : .Cn .Idx 2] = {
     return
     (%core.bit2._and 2
         (%core.bit2._and 2
@@ -14,9 +14,9 @@
              %core.bit2._and 2 (.tt, .ff))))
 };
 
-// CHECK-DAG: .cn .extern and_lit _[[retId:[0-9_]+]]: .Cn (.Int 2) = {
-// CHECK-DAG: _[[etaId:[0-9_]+]] 0:(.Int 2)
+// CHECK-DAG: .cn .extern and_lit _[[retId:[0-9_]+]]: .Cn (.Idx 2) = {
+// CHECK-DAG: _[[etaId:[0-9_]+]] 0:(.Idx 2)
 
-// CHECK-DAG: .cn _[[etaId]] _[[etaVar:[0-9_]+]]: (.Int 2) = {
+// CHECK-DAG: .cn _[[etaId]] _[[etaVar:[0-9_]+]]: (.Idx 2) = {
 // CHECK-DAG: _[[retId]] _[[etaVar]]
 

--- a/lit/core/normalize_and_tt.thorin
+++ b/lit/core/normalize_and_tt.thorin
@@ -3,12 +3,12 @@
 
 .import core;
 
-.cn .extern and_tt [i :.Int 2, return : .Cn .Int 2] = {
+.cn .extern and_tt [i :.Idx 2, return : .Cn .Idx 2] = {
     return (%core.bit2._and 2 (i, .tt))
 };
 
-// CHECK-DAG: and_tt _{{[0-9_]+}}::[i_[[valId_tt:[0-9_]+]]: (.Int 2), return_[[retId_tt:[0-9_]+]]: .Cn (.Int 2)] = {
+// CHECK-DAG: and_tt _{{[0-9_]+}}::[i_[[valId_tt:[0-9_]+]]: (.Idx 2), return_[[retId_tt:[0-9_]+]]: .Cn (.Idx 2)] = {
 // CHECK-DAG: return_[[etaId_tt:[0-9_]+]] i_[[valId_tt]]
 
-// CHECK-DAG: return_[[etaId_tt]] _[[etaVar_tt:[0-9_]+]]: (.Int 2) = {
+// CHECK-DAG: return_[[etaId_tt]] _[[etaVar_tt:[0-9_]+]]: (.Idx 2) = {
 // CHECK-DAG: return_[[retId_tt]] _[[etaVar_tt]]

--- a/lit/core/normalize_and_tt_tt.thorin
+++ b/lit/core/normalize_and_tt_tt.thorin
@@ -3,12 +3,12 @@
 
 .import core;
 
-.cn .extern and_lit_tt_tt [return : .Cn .Int 2] = {
+.cn .extern and_lit_tt_tt [return : .Cn .Idx 2] = {
     return (%core.bit2._and 2 (.tt, .tt))
 };
 
-// CHECK-DAG: .cn .extern and_lit_tt_tt _[[retId:[0-9_]+]]: .Cn (.Int 2) = {
-// CHECK-DAG: _[[etaId:[0-9_]+]] 1:(.Int 2)
+// CHECK-DAG: .cn .extern and_lit_tt_tt _[[retId:[0-9_]+]]: .Cn (.Idx 2) = {
+// CHECK-DAG: _[[etaId:[0-9_]+]] 1:(.Idx 2)
 
-// CHECK-DAG: .cn _[[etaId]] _[[etaVar:[0-9_]+]]: (.Int 2) = {
+// CHECK-DAG: .cn _[[etaId]] _[[etaVar:[0-9_]+]]: (.Idx 2) = {
 // CHECK-DAG: _[[retId]] _[[etaVar]]

--- a/lit/core/normalize_bitcast.thorin
+++ b/lit/core/normalize_bitcast.thorin
@@ -4,13 +4,13 @@
 
 .import core;
 
-.cn .extern bitcast_bitcast [i : %mem.Ptr (.Int 256, 0), return : .Cn .Int 4294967296] = {
-    return (%core.bitcast (.Int 4294967296, .Nat) (%core.bitcast (.Nat, %mem.Ptr (.Int 256, 0)) i))
+.cn .extern bitcast_bitcast [i : %mem.Ptr (.Idx 256, 0), return : .Cn .Idx 4294967296] = {
+    return (%core.bitcast (.Idx 4294967296, .Nat) (%core.bitcast (.Nat, %mem.Ptr (.Idx 256, 0)) i))
 };
 
-// CHECK-DAG: bitcast_bitcast _{{[0-9_]+}}::[i_[[valId:[0-9_]+]]: %mem.Ptr ((.Int 256), 0), return_[[retId:[0-9_]+]]: .Cn (.Int 4294967296)] = {
-// CHECK-DAG: .let _[[castedId:[0-9_]+]]: (.Int 4294967296) = %core.bitcast ((.Int 4294967296), %mem.Ptr ((.Int 256), 0)) i_[[valId]];
+// CHECK-DAG: bitcast_bitcast _{{[0-9_]+}}::[i_[[valId:[0-9_]+]]: %mem.Ptr ((.Idx 256), 0), return_[[retId:[0-9_]+]]: .Cn (.Idx 4294967296)] = {
+// CHECK-DAG: .let _[[castedId:[0-9_]+]]: (.Idx 4294967296) = %core.bitcast ((.Idx 4294967296), %mem.Ptr ((.Idx 256), 0)) i_[[valId]];
 // CHECK-DAG: return_[[etaId:[0-9_]+]] _[[castedId]]
 
-// CHECK-DAG: return_[[etaId]] _[[etaVar:[0-9_]+]]: (.Int 4294967296) = {
+// CHECK-DAG: return_[[etaId]] _[[etaVar:[0-9_]+]]: (.Idx 4294967296) = {
 // CHECK-DAG: return_[[retId]] _[[etaVar]]

--- a/lit/core/normalize_icmp.thorin
+++ b/lit/core/normalize_icmp.thorin
@@ -3,7 +3,7 @@
 
 .import core;
 
-.cn .extern icmp_lit [return : .Cn .Int 2] = {
+.cn .extern icmp_lit [return : .Cn .Idx 2] = {
     return
     (%core.icmp.e 2
         (%core.icmp.uge 2
@@ -12,8 +12,8 @@
             (.tt, .ff)))
 };
 
-// CHECK-DAG: icmp_lit _[[retId:[0-9_]+]]: .Cn (.Int 2) = {
-// CHECK-DAG: _[[etaId:[0-9_]+]] 1:(.Int 2)
+// CHECK-DAG: icmp_lit _[[retId:[0-9_]+]]: .Cn (.Idx 2) = {
+// CHECK-DAG: _[[etaId:[0-9_]+]] 1:(.Idx 2)
 
-// CHECK-DAG: _[[etaId]] _[[etaVar:[0-9_]+]]: (.Int 2) = {
+// CHECK-DAG: _[[etaId]] _[[etaVar:[0-9_]+]]: (.Idx 2) = {
 // CHECK-DAG: _[[retId]] _[[etaVar]]

--- a/lit/core/ret_add.thorin
+++ b/lit/core/ret_add.thorin
@@ -7,27 +7,27 @@
 .import core;
 .import mem;
 
-.cn atoi [%mem.M, %mem.Ptr («⊤:.Nat; .Int 256», 0), .Cn [%mem.M, .Int 4294967296]];
+.cn atoi [%mem.M, %mem.Ptr («⊤:.Nat; .Idx 256», 0), .Cn [%mem.M, .Idx 4294967296]];
 
-.cn .extern main [mem : %mem.M, argc : .Int 4294967296, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .Int 256», 0)», 0:.Nat), return : .Cn [%mem.M, .Int 4294967296]] = {
-    .cn atoi_cont_a [mem : %mem.M, a : .Int 4294967296] = {
-        .cn atoi_cont_b [mem : %mem.M, b : .Int 4294967296] = {
+.cn .extern main [mem : %mem.M, argc : .Idx 4294967296, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .Idx 256», 0)», 0:.Nat), return : .Cn [%mem.M, .Idx 4294967296]] = {
+    .cn atoi_cont_a [mem : %mem.M, a : .Idx 4294967296] = {
+        .cn atoi_cont_b [mem : %mem.M, b : .Idx 4294967296] = {
                 return (mem, %core.wrap.add (0, 4294967296) (a, b))
         };
 
-        .let argv_ptr_b = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .Int 256», 0)›, 0) (argv, 2:(.Int 4294967296));
-        .let argv_load_b = %mem.load (%mem.Ptr («⊤:.Nat; .Int 256», 0), 0) (mem, argv_ptr_b);
+        .let argv_ptr_b = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .Idx 256», 0)›, 0) (argv, 2:(.Idx 4294967296));
+        .let argv_load_b = %mem.load (%mem.Ptr («⊤:.Nat; .Idx 256», 0), 0) (mem, argv_ptr_b);
         atoi (argv_load_b#.ff, argv_load_b#.tt, atoi_cont_b)
     };
 
-    .let argv_ptr_a = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .Int 256», 0)›, 0) (argv, 1:(.Int 4294967296));
-    .let argv_load_a = %mem.load (%mem.Ptr («⊤:.Nat; .Int 256», 0), 0) (mem, argv_ptr_a);
+    .let argv_ptr_a = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .Idx 256», 0)›, 0) (argv, 1:(.Idx 4294967296));
+    .let argv_load_a = %mem.load (%mem.Ptr («⊤:.Nat; .Idx 256», 0), 0) (mem, argv_ptr_a);
     atoi (argv_load_a#.ff, argv_load_a#.tt, atoi_cont_a)
 };
 
-// CHECK-DAG: main _{{[0-9_]+}}::[mem_[[memId:[0-9_]+]]: %mem.M, (.Int 4294967296), argv_{{[0-9]+}}: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (.Int 256)», 0)», 0), return_[[returnId:[0-9_]+]]: .Cn [%mem.M, (.Int 4294967296)]] = {
+// CHECK-DAG: main _{{[0-9_]+}}::[mem_[[memId:[0-9_]+]]: %mem.M, (.Idx 4294967296), argv_{{[0-9]+}}: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (.Idx 256)», 0)», 0), return_[[returnId:[0-9_]+]]: .Cn [%mem.M, (.Idx 4294967296)]] = {
 
-// CHECK-DAG: atoi_cont_a_[[aContId:[0-9_]+]] _{{[0-9_]+}}::[mem_{{[0-9]+}}: %mem.M, a_[[aId:[0-9_]+]]: (.Int 4294967296)]
+// CHECK-DAG: atoi_cont_a_[[aContId:[0-9_]+]] _{{[0-9_]+}}::[mem_{{[0-9]+}}: %mem.M, a_[[aId:[0-9_]+]]: (.Idx 4294967296)]
 
-// CHECK-DAG: atoi_cont_b_[[bContId:[0-9_]+]] _{{[0-9_]+}}::[mem_{{[0-9]+}}: %mem.M, b_[[bId:[0-9_]+]]: (.Int 4294967296)]
+// CHECK-DAG: atoi_cont_b_[[bContId:[0-9_]+]] _{{[0-9_]+}}::[mem_{{[0-9]+}}: %mem.M, b_[[bId:[0-9_]+]]: (.Idx 4294967296)]
 // CHECK-DAG: %core.wrap.add (0, 4294967296) (a_[[aId]], b_[[bId]])

--- a/lit/core/ret_and.thorin
+++ b/lit/core/ret_and.thorin
@@ -7,27 +7,27 @@
 .import core;
 .import mem;
 
-.cn atoi [%mem.M, %mem.Ptr («⊤:.Nat; .Int 256», 0), .Cn [%mem.M, .Int 4294967296]];
+.cn atoi [%mem.M, %mem.Ptr («⊤:.Nat; .Idx 256», 0), .Cn [%mem.M, .Idx 4294967296]];
 
-.cn .extern main [mem : %mem.M, argc : .Int 4294967296, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .Int 256», 0)», 0), return : .Cn [%mem.M, .Int 4294967296]] = {
-    .cn atoi_cont_a [mem : %mem.M, a : .Int 4294967296] = {
-        .cn atoi_cont_b [mem : %mem.M, b : .Int 4294967296] = {
+.cn .extern main [mem : %mem.M, argc : .Idx 4294967296, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .Idx 256», 0)», 0), return : .Cn [%mem.M, .Idx 4294967296]] = {
+    .cn atoi_cont_a [mem : %mem.M, a : .Idx 4294967296] = {
+        .cn atoi_cont_b [mem : %mem.M, b : .Idx 4294967296] = {
                 return (mem, %core.bit2._and (4294967296) (a, b))
         };
 
-        .let argv_ptr_b = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .Int 256», 0)›, 0) (argv, 2:(.Int 4294967296));
-        .let argv_load_b = %mem.load (%mem.Ptr («⊤:.Nat; .Int 256», 0), 0) (mem, argv_ptr_b);
+        .let argv_ptr_b = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .Idx 256», 0)›, 0) (argv, 2:(.Idx 4294967296));
+        .let argv_load_b = %mem.load (%mem.Ptr («⊤:.Nat; .Idx 256», 0), 0) (mem, argv_ptr_b);
         atoi (argv_load_b#.ff, argv_load_b#.tt, atoi_cont_b)
     };
 
-    .let argv_ptr_a = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .Int 256», 0)›, 0) (argv, 1:(.Int 4294967296));
-    .let argv_load_a = %mem.load (%mem.Ptr («⊤:.Nat; .Int 256», 0), 0) (mem, argv_ptr_a);
+    .let argv_ptr_a = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .Idx 256», 0)›, 0) (argv, 1:(.Idx 4294967296));
+    .let argv_load_a = %mem.load (%mem.Ptr («⊤:.Nat; .Idx 256», 0), 0) (mem, argv_ptr_a);
     atoi (argv_load_a#.ff, argv_load_a#.tt, atoi_cont_a)
 };
 
-// CHECK-DAG: main _{{[0-9_]+}}::[mem_[[memId:[0-9_]+]]: %mem.M, (.Int 4294967296), argv_{{[0-9]+}}: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (.Int 256)», 0)», 0), return_[[returnId:[0-9_]+]]: .Cn [%mem.M, (.Int 4294967296)]] = {
+// CHECK-DAG: main _{{[0-9_]+}}::[mem_[[memId:[0-9_]+]]: %mem.M, (.Idx 4294967296), argv_{{[0-9]+}}: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (.Idx 256)», 0)», 0), return_[[returnId:[0-9_]+]]: .Cn [%mem.M, (.Idx 4294967296)]] = {
 
-// CHECK-DAG: atoi_cont_a_[[aContId:[0-9_]+]] _{{[0-9_]+}}::[mem_{{[0-9]+}}: %mem.M, a_[[aId:[0-9_]+]]: (.Int 4294967296)]
+// CHECK-DAG: atoi_cont_a_[[aContId:[0-9_]+]] _{{[0-9_]+}}::[mem_{{[0-9]+}}: %mem.M, a_[[aId:[0-9_]+]]: (.Idx 4294967296)]
 
-// CHECK-DAG: atoi_cont_b_[[bContId:[0-9_]+]] _{{[0-9_]+}}::[mem_{{[0-9]+}}: %mem.M, b_[[bId:[0-9_]+]]: (.Int 4294967296)]
+// CHECK-DAG: atoi_cont_b_[[bContId:[0-9_]+]] _{{[0-9_]+}}::[mem_{{[0-9]+}}: %mem.M, b_[[bId:[0-9_]+]]: (.Idx 4294967296)]
 // CHECK-DAG: %core.bit2._and 4294967296 (a_[[aId]], b_[[bId]])

--- a/lit/core/ret_lshr.thorin
+++ b/lit/core/ret_lshr.thorin
@@ -7,27 +7,27 @@
 .import core;
 .import mem;
 
-.cn atoi [%mem.M, %mem.Ptr («⊤:.Nat; .Int 256», 0), .Cn [%mem.M, .Int 4294967296]];
+.cn atoi [%mem.M, %mem.Ptr («⊤:.Nat; .Idx 256», 0), .Cn [%mem.M, .Idx 4294967296]];
 
-.cn .extern main [mem : %mem.M, argc : .Int 4294967296, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .Int 256», 0)», 0), return : .Cn [%mem.M, .Int 4294967296]] = {
-    .cn atoi_cont_a [mem : %mem.M, a : .Int 4294967296] = {
-        .cn atoi_cont_b [mem : %mem.M, b : .Int 4294967296] = {
+.cn .extern main [mem : %mem.M, argc : .Idx 4294967296, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .Idx 256», 0)», 0), return : .Cn [%mem.M, .Idx 4294967296]] = {
+    .cn atoi_cont_a [mem : %mem.M, a : .Idx 4294967296] = {
+        .cn atoi_cont_b [mem : %mem.M, b : .Idx 4294967296] = {
                 return (mem, %core.shr.lshr 4294967296 (a, b))
         };
 
-        .let argv_ptr_b = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .Int 256», 0)›, 0) (argv, 2:(.Int 4294967296));
-        .let argv_load_b = %mem.load (%mem.Ptr («⊤:.Nat; .Int 256», 0), 0) (mem, argv_ptr_b);
+        .let argv_ptr_b = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .Idx 256», 0)›, 0) (argv, 2:(.Idx 4294967296));
+        .let argv_load_b = %mem.load (%mem.Ptr («⊤:.Nat; .Idx 256», 0), 0) (mem, argv_ptr_b);
         atoi (argv_load_b#.ff, argv_load_b#.tt, atoi_cont_b)
     };
 
-    .let argv_ptr_a = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .Int 256», 0)›, 0) (argv, 1:(.Int 4294967296));
-    .let argv_load_a = %mem.load (%mem.Ptr («⊤:.Nat; .Int 256», 0), 0) (mem, argv_ptr_a);
+    .let argv_ptr_a = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .Idx 256», 0)›, 0) (argv, 1:(.Idx 4294967296));
+    .let argv_load_a = %mem.load (%mem.Ptr («⊤:.Nat; .Idx 256», 0), 0) (mem, argv_ptr_a);
     atoi (argv_load_a#.ff, argv_load_a#.tt, atoi_cont_a)
 };
 
-// CHECK-DAG: main _{{[0-9_]+}}::[mem_[[memId:[0-9_]+]]: %mem.M, (.Int 4294967296), argv_{{[0-9]+}}: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (.Int 256)», 0)», 0), return_[[returnId:[0-9_]+]]: .Cn [%mem.M, (.Int 4294967296)]] = {
+// CHECK-DAG: main _{{[0-9_]+}}::[mem_[[memId:[0-9_]+]]: %mem.M, (.Idx 4294967296), argv_{{[0-9]+}}: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (.Idx 256)», 0)», 0), return_[[returnId:[0-9_]+]]: .Cn [%mem.M, (.Idx 4294967296)]] = {
 
-// CHECK-DAG: atoi_cont_a_[[aContId:[0-9_]+]] _{{[0-9_]+}}::[mem_{{[0-9]+}}: %mem.M, a_[[aId:[0-9_]+]]: (.Int 4294967296)]
+// CHECK-DAG: atoi_cont_a_[[aContId:[0-9_]+]] _{{[0-9_]+}}::[mem_{{[0-9]+}}: %mem.M, a_[[aId:[0-9_]+]]: (.Idx 4294967296)]
 
-// CHECK-DAG: atoi_cont_b_[[bContId:[0-9_]+]] _{{[0-9_]+}}::[mem_{{[0-9]+}}: %mem.M, b_[[bId:[0-9_]+]]: (.Int 4294967296)]
+// CHECK-DAG: atoi_cont_b_[[bContId:[0-9_]+]] _{{[0-9_]+}}::[mem_{{[0-9]+}}: %mem.M, b_[[bId:[0-9_]+]]: (.Idx 4294967296)]
 // CHECK-DAG: %core.shr.lshr 4294967296 (a_[[aId]], b_[[bId]])

--- a/lit/debug/debug.thorin
+++ b/lit/debug/debug.thorin
@@ -6,14 +6,14 @@
 .import debug;
 .import mem;
 
-.let I32 = .Int 4294967296;
-.cn .extern main [mem : %mem.M, argc : I32, argv : %mem.Ptr (%mem.Ptr (.Int 256, 0), 0), return : .Cn [%mem.M, I32]] = {
+.let I32 = .Idx 4294967296;
+.cn .extern main [mem : %mem.M, argc : I32, argv : %mem.Ptr (%mem.Ptr (.Idx 256, 0), 0), return : .Cn [%mem.M, I32]] = {
     .let c = %debug.dbg I32 (42:I32);
     return (mem, c)
 };
 
-// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[memId:[_0-9]*]]: %mem.M, (.Int 4294967296), %mem.Ptr (%mem.Ptr ((.Int 256), 0), 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (.Int 4294967296)]] = {
-// CHECK-DAG: return_[[returnEtaId:[_0-9]*]] (mem_[[memId]], 42:(.Int 4294967296))
+// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[memId:[_0-9]*]]: %mem.M, (.Idx 4294967296), %mem.Ptr (%mem.Ptr ((.Idx 256), 0), 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (.Idx 4294967296)]] = {
+// CHECK-DAG: return_[[returnEtaId:[_0-9]*]] (mem_[[memId]], 42:(.Idx 4294967296))
 
-// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Int 4294967296)] = {
+// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Idx 4294967296)] = {
 // CHECK-DAG: return_[[returnId]] _[[returnEtaVarId]]

--- a/lit/debug/debug_perm.thorin
+++ b/lit/debug/debug_perm.thorin
@@ -6,14 +6,14 @@
 .import debug;
 .import mem;
 
-.let I32 = .Int 4294967296;
-.cn .extern main [mem : %mem.M, argc : I32, argv : %mem.Ptr (%mem.Ptr (.Int 256, 0), 0), return : .Cn [%mem.M, I32]] = {
+.let I32 = .Idx 4294967296;
+.cn .extern main [mem : %mem.M, argc : I32, argv : %mem.Ptr (%mem.Ptr (.Idx 256, 0), 0), return : .Cn [%mem.M, I32]] = {
     .let c = %debug.dbg_perm I32 (42:I32);
     return (mem, c)
 };
 
-// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[memId:[_0-9]*]]: %mem.M, (.Int 4294967296), %mem.Ptr (%mem.Ptr ((.Int 256), 0), 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (.Int 4294967296)]] = {
-// CHECK-DAG: return_[[returnEtaId:[_0-9]*]] (mem_[[memId]], 42:(.Int 4294967296))
+// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[memId:[_0-9]*]]: %mem.M, (.Idx 4294967296), %mem.Ptr (%mem.Ptr ((.Idx 256), 0), 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (.Idx 4294967296)]] = {
+// CHECK-DAG: return_[[returnEtaId:[_0-9]*]] (mem_[[memId]], 42:(.Idx 4294967296))
 
-// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Int 4294967296)] = {
+// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Idx 4294967296)] = {
 // CHECK-DAG: return_[[returnId]] _[[returnEtaVarId]]

--- a/lit/direct/ds2cps.thorin
+++ b/lit/direct/ds2cps.thorin
@@ -7,19 +7,19 @@
 .import direct;
 .import mem;
 
-.let I32 = .Int 4294967296;
+.let I32 = .Idx 4294967296;
 
 .lam f [a:I32] -> I32 = {
     %Wrap_add (0, 4294967296) (2:I32, a)
 };
 
-.cn .extern main [mem : %mem.M, argc : I32, argv : %mem.Ptr (%mem.Ptr (.Int 256, 0), 0), return : .Cn [%mem.M, I32]] = {
+.cn .extern main [mem : %mem.M, argc : I32, argv : %mem.Ptr (%mem.Ptr (.Idx 256, 0), 0), return : .Cn [%mem.M, I32]] = {
     .let c = f (40:I32);
     return (mem, c)
 };
 
-// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[memId:[_0-9]*]]: %mem.M, (.Int 4294967296), %mem.Ptr (%mem.Ptr ((.Int 256), 0), 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (.Int 4294967296)]] = {
-// CHECK-DAG: return_[[returnEtaId:[_0-9]*]] (mem_[[memId]], 42:(.Int 4294967296))
+// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[memId:[_0-9]*]]: %mem.M, (.Idx 4294967296), %mem.Ptr (%mem.Ptr ((.Idx 256), 0), 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (.Idx 4294967296)]] = {
+// CHECK-DAG: return_[[returnEtaId:[_0-9]*]] (mem_[[memId]], 42:(.Idx 4294967296))
 
-// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Int 4294967296)] = {
+// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Idx 4294967296)] = {
 // CHECK-DAG: return_[[returnId]] _[[returnEtaVarId]]

--- a/lit/direct/ds2cps_ax_cps2ds.thorin
+++ b/lit/direct/ds2cps_ax_cps2ds.thorin
@@ -6,21 +6,21 @@
 .import direct;
 .import mem;
 
-.let I32 = .Int 4294967296;
+.let I32 = .Idx 4294967296;
 
 .cn f [a:I32, return: .Cn I32] = {
     .let b = %Wrap_add (0, 4294967296) (2:I32, a);
     return b
 };
 
-.cn .extern main [mem : %mem.M, argc : I32, argv : %mem.Ptr (%mem.Ptr (.Int 256, 0), 0), return : .Cn [%mem.M, I32]] = {
+.cn .extern main [mem : %mem.M, argc : I32, argv : %mem.Ptr (%mem.Ptr (.Idx 256, 0), 0), return : .Cn [%mem.M, I32]] = {
     .let g = %direct.cps2ds (I32,I32) f;
     .let c = g (40:I32);
     return (mem, c)
 };
 
-// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[memId:[_0-9]+]]: %mem.M, (.Int 4294967296), %mem.Ptr (%mem.Ptr ((.Int 256), 0), 0), return_[[returnId:[_0-9]+]]: .Cn [%mem.M, (.Int 4294967296)]] = {
-// CHECK-DAG: return_[[returnEtaId:[_0-9]+]] (mem_[[memId]], 42:(.Int 4294967296))
+// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[memId:[_0-9]+]]: %mem.M, (.Idx 4294967296), %mem.Ptr (%mem.Ptr ((.Idx 256), 0), 0), return_[[returnId:[_0-9]+]]: .Cn [%mem.M, (.Idx 4294967296)]] = {
+// CHECK-DAG: return_[[returnEtaId:[_0-9]+]] (mem_[[memId]], 42:(.Idx 4294967296))
 
-// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Int 4294967296)] = {
+// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Idx 4294967296)] = {
 // CHECK-DAG: return_[[returnId]] _[[returnEtaVarId]]

--- a/lit/direct/ds2cps_cps_only.thorin
+++ b/lit/direct/ds2cps_cps_only.thorin
@@ -6,19 +6,19 @@
 .import direct;
 .import mem;
 
-.let I32 = .Int 4294967296;
+.let I32 = .Idx 4294967296;
 
 .cn h [mem : %mem.M, a : I32, return : .Cn [%mem.M, I32]] = {
     .let c = a;
     return (mem, c)
 };
 
-.cn .extern main [mem : %mem.M, argc : I32, argv : %mem.Ptr (%mem.Ptr (.Int 256, 0), 0), return : .Cn [%mem.M, I32]] = {
+.cn .extern main [mem : %mem.M, argc : I32, argv : %mem.Ptr (%mem.Ptr (.Idx 256, 0), 0), return : .Cn [%mem.M, I32]] = {
     h (mem, 40:I32, return)
 };
 
-// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[memId:[_0-9]*]]: %mem.M, (.Int 4294967296), %mem.Ptr (%mem.Ptr ((.Int 256), 0), 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (.Int 4294967296)]] = {
-// CHECK-DAG: return_[[returnEtaId:[_0-9]*]] (mem_[[memId]], 40:(.Int 4294967296))
+// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[memId:[_0-9]*]]: %mem.M, (.Idx 4294967296), %mem.Ptr (%mem.Ptr ((.Idx 256), 0), 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (.Idx 4294967296)]] = {
+// CHECK-DAG: return_[[returnEtaId:[_0-9]*]] (mem_[[memId]], 40:(.Idx 4294967296))
 
-// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Int 4294967296)] = {
+// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Idx 4294967296)] = {
 // CHECK-DAG: return_[[returnId]] _[[returnEtaVarId]]

--- a/lit/direct/ds2cps_mixed.thorin
+++ b/lit/direct/ds2cps_mixed.thorin
@@ -6,7 +6,7 @@
 .import direct;
 .import mem;
 
-.let I32 = .Int 4294967296;
+.let I32 = .Idx 4294967296;
 
 .lam f [a:I32] -> I32 = {
     %Wrap_add (0, 4294967296) (2:I32, a)
@@ -17,12 +17,12 @@
     return (mem, c)
 };
 
-.cn .extern main [mem : %mem.M, argc : I32, argv : %mem.Ptr (%mem.Ptr (.Int 256, 0), 0), return : .Cn [%mem.M, I32]] = {
+.cn .extern main [mem : %mem.M, argc : I32, argv : %mem.Ptr (%mem.Ptr (.Idx 256, 0), 0), return : .Cn [%mem.M, I32]] = {
     h (mem, 40:I32, return)
 };
 
-// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[memId:[_0-9]*]]: %mem.M, (.Int 4294967296), %mem.Ptr (%mem.Ptr ((.Int 256), 0), 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (.Int 4294967296)]] = {
-// CHECK-DAG: return_[[returnEtaId:[_0-9]*]] (mem_[[memId]], 42:(.Int 4294967296))
+// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[memId:[_0-9]*]]: %mem.M, (.Idx 4294967296), %mem.Ptr (%mem.Ptr ((.Idx 256), 0), 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (.Idx 4294967296)]] = {
+// CHECK-DAG: return_[[returnEtaId:[_0-9]*]] (mem_[[memId]], 42:(.Idx 4294967296))
 
-// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Int 4294967296)] = {
+// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Idx 4294967296)] = {
 // CHECK-DAG: return_[[returnId]] _[[returnEtaVarId]]

--- a/lit/direct/ds2cps_mixed2.thorin
+++ b/lit/direct/ds2cps_mixed2.thorin
@@ -6,7 +6,7 @@
 .import direct;
 .import mem;
 
-.let I32 = .Int 4294967296;
+.let I32 = .Idx 4294967296;
 
 .lam f [a:I32] -> I32 = {
     %Wrap_add (0, 4294967296) (2:I32, a)
@@ -22,12 +22,12 @@
     h (mem, b, return)
 };
 
-.cn .extern main [mem : %mem.M, argc : I32, argv : %mem.Ptr (%mem.Ptr (.Int 256, 0), 0), return : .Cn [%mem.M, I32]] = {
+.cn .extern main [mem : %mem.M, argc : I32, argv : %mem.Ptr (%mem.Ptr (.Idx 256, 0), 0), return : .Cn [%mem.M, I32]] = {
     g (mem, 40:I32, return)
 };
 
-// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[memId:[_0-9]*]]: %mem.M, (.Int 4294967296), %mem.Ptr (%mem.Ptr ((.Int 256), 0), 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (.Int 4294967296)]] = {
-// CHECK-DAG: return_[[returnEtaId:[_0-9]*]] (mem_[[memId]], 45:(.Int 4294967296))
+// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[memId:[_0-9]*]]: %mem.M, (.Idx 4294967296), %mem.Ptr (%mem.Ptr ((.Idx 256), 0), 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (.Idx 4294967296)]] = {
+// CHECK-DAG: return_[[returnEtaId:[_0-9]*]] (mem_[[memId]], 45:(.Idx 4294967296))
 
-// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Int 4294967296)] = {
+// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Idx 4294967296)] = {
 // CHECK-DAG: return_[[returnId]] _[[returnEtaVarId]]

--- a/lit/direct/ds2cps_mixed_tuple.thorin
+++ b/lit/direct/ds2cps_mixed_tuple.thorin
@@ -6,7 +6,7 @@
 .import direct;
 .import mem;
 
-.let I32 = .Int 4294967296;
+.let I32 = .Idx 4294967296;
 
 .lam f [a:I32] -> [I32, I32] = {
     (%Wrap_add (0, 4294967296) (2:I32, a), %Wrap_add (0, 4294967296) (3:I32, a))
@@ -14,15 +14,15 @@
 
 .cn h [mem : %mem.M, a : I32, return : .Cn [%mem.M, I32]] = {
     .let c = f a;
-    return (mem, %Wrap_add (0, 4294967296) (c#0:(.Int 2), c#1:(.Int 2)))
+    return (mem, %Wrap_add (0, 4294967296) (c#0:(.Idx 2), c#1:(.Idx 2)))
 };
 
-.cn .extern main [mem : %mem.M, argc : I32, argv : %mem.Ptr (%mem.Ptr (.Int 256, 0), 0), return : .Cn [%mem.M, I32]] = {
+.cn .extern main [mem : %mem.M, argc : I32, argv : %mem.Ptr (%mem.Ptr (.Idx 256, 0), 0), return : .Cn [%mem.M, I32]] = {
     h (mem, 40:I32, return)
 };
 
-// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[memId:[_0-9]*]]: %mem.M, (.Int 4294967296), %mem.Ptr (%mem.Ptr ((.Int 256), 0), 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (.Int 4294967296)]] = {
-// CHECK-DAG: return_[[returnEtaId:[_0-9]*]] (mem_[[memId]], 85:(.Int 4294967296))
+// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[memId:[_0-9]*]]: %mem.M, (.Idx 4294967296), %mem.Ptr (%mem.Ptr ((.Idx 256), 0), 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (.Idx 4294967296)]] = {
+// CHECK-DAG: return_[[returnEtaId:[_0-9]*]] (mem_[[memId]], 85:(.Idx 4294967296))
 
-// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Int 4294967296)] = {
+// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Idx 4294967296)] = {
 // CHECK-DAG: return_[[returnId]] _[[returnEtaVarId]]

--- a/lit/main_loop.thorin
+++ b/lit/main_loop.thorin
@@ -7,36 +7,36 @@
 .import core;
 .import mem;
 
-.cn .extern main(mem: %mem.M, argc: .Int 4294967296, argv: %mem.Ptr (%mem.Ptr (.Int 256, 0), 0), return: .Cn [%mem.M, .Int 4294967296]) = {
-    .cn loop(mem: %mem.M, i: .Int 4294967296, acc: .Int 4294967296) = {
-        .let cond: (.Int 2) = %core.icmp.ul 4294967296 (i, argc);
+.cn .extern main(mem: %mem.M, argc: .Idx 4294967296, argv: %mem.Ptr (%mem.Ptr (.Idx 256, 0), 0), return: .Cn [%mem.M, .Idx 4294967296]) = {
+    .cn loop(mem: %mem.M, i: .Idx 4294967296, acc: .Idx 4294967296) = {
+        .let cond: (.Idx 2) = %core.icmp.ul 4294967296 (i, argc);
 
         .cn exit m: %mem.M = return (m, acc);
 
         .cn body m: %mem.M = {
-            .let inc: .Int 4294967296 = %Wrap_add (0, 4294967296) (1:(.Int 4294967296), i);
-            .let acci: .Int 4294967296 = %Wrap_add (0, 4294967296) (i, acc);
+            .let inc: .Idx 4294967296 = %Wrap_add (0, 4294967296) (1:(.Idx 4294967296), i);
+            .let acci: .Idx 4294967296 = %Wrap_add (0, 4294967296) (i, acc);
             loop (m, inc, acci)
         };
         (exit, body)#cond mem
     };
-    loop (mem, 0:(.Int 4294967296), 0:(.Int 4294967296))
+    loop (mem, 0:(.Idx 4294967296), 0:(.Idx 4294967296))
 };
 
-// CHECK-DAG: .cn .extern main _[[mainVarId:[0-9_]+]]::[mem_[[memId:[0-9_]+]]: %mem.M, argc_[[argcId:[0-9_]+]]: (.Int 4294967296), %mem.Ptr (%mem.Ptr ((.Int 256), 0), 0), return_[[returnId:[0-9_]+]]: .Cn [%mem.M, (.Int 4294967296)]] = {
-// CHECK-DAG: loop_[[loopId:[0-9_]+]] (mem_[[memId]], 0:(.Int 4294967296), 0:(.Int 4294967296))
+// CHECK-DAG: .cn .extern main _[[mainVarId:[0-9_]+]]::[mem_[[memId:[0-9_]+]]: %mem.M, argc_[[argcId:[0-9_]+]]: (.Idx 4294967296), %mem.Ptr (%mem.Ptr ((.Idx 256), 0), 0), return_[[returnId:[0-9_]+]]: .Cn [%mem.M, (.Idx 4294967296)]] = {
+// CHECK-DAG: loop_[[loopId:[0-9_]+]] (mem_[[memId]], 0:(.Idx 4294967296), 0:(.Idx 4294967296))
 
-// CHECK-DAG: .cn return_[[returnEtaId:[0-9_]+]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Int 4294967296)] = {
+// CHECK-DAG: .cn return_[[returnEtaId:[0-9_]+]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Idx 4294967296)] = {
 // CHECK-DAG: return_[[returnId]] _[[returnEtaVarId]]
 
-// CHECK-DAG: .cn loop_[[loopId]] _{{[0-9_]+}}::[mem_[[loopMemId:[0-9_]+]]: %mem.M, i_[[iterId:[0-9_]+]]: (.Int 4294967296), acc_[[accId:[0-9_]+]]: (.Int 4294967296)] = {
-// CHECK-DAG:   _[[condId:[0-9_]+]]: (.Int 2) = %core.icmp.XygLe 4294967296 (i_[[iterId]], argc_[[argcId]]);
+// CHECK-DAG: .cn loop_[[loopId]] _{{[0-9_]+}}::[mem_[[loopMemId:[0-9_]+]]: %mem.M, i_[[iterId:[0-9_]+]]: (.Idx 4294967296), acc_[[accId:[0-9_]+]]: (.Idx 4294967296)] = {
+// CHECK-DAG:   _[[condId:[0-9_]+]]: (.Idx 2) = %core.icmp.XygLe 4294967296 (i_[[iterId]], argc_[[argcId]]);
 // CHECK-DAG: (exit_[[exitId:[0-9_]+]], body_[[bodyId:[0-9_]+]])#_[[condId]] mem_[[loopMemId]]
 
 // CHECK-DAG: .cn exit_[[exitId]] m_[[mExitVarId:[0-9_]+]]: %mem.M = {
 // CHECK-DAG: return_[[returnEtaId]] (m_[[mExitVarId]], acc_[[accId]])
 
 // CHECK-DAG: .cn body_[[bodyId]] m_[[mBodyVarId:[0-9_]+]]: %mem.M = {
-// CHECK-DAG:   _[[addIterId:[0-9_]+]]: (.Int 4294967296) = %Wrap_add (0, 4294967296) (1:(.Int 4294967296), i_[[iterId]]);
-// CHECK-DAG:   _[[addAccId:[0-9_]+]]: (.Int 4294967296) = %Wrap_add (0, 4294967296) (acc_[[accId]], i_[[iterId]]);
+// CHECK-DAG:   _[[addIterId:[0-9_]+]]: (.Idx 4294967296) = %Wrap_add (0, 4294967296) (1:(.Idx 4294967296), i_[[iterId]]);
+// CHECK-DAG:   _[[addAccId:[0-9_]+]]: (.Idx 4294967296) = %Wrap_add (0, 4294967296) (acc_[[accId]], i_[[iterId]]);
 // CHECK-DAG: loop_[[loopId]] (m_[[mBodyVarId]], _[[addIterId]], _[[addAccId]])

--- a/lit/mem/alloc_load_store.thorin
+++ b/lit/mem/alloc_load_store.thorin
@@ -7,21 +7,21 @@
 
 .import mem;
 
-.let i32 = .Int 4294967296;
-.cn .extern main(mem: %mem.M, argc: i32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .Int 256», 0)», 0), return: .Cn [%mem.M, i32]) = {
+.let i32 = .Idx 4294967296;
+.cn .extern main(mem: %mem.M, argc: i32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .Idx 256», 0)», 0), return: .Cn [%mem.M, i32]) = {
     .let Tas = (i32, 0);
     .let allocd = %mem.alloc Tas mem;
-    .let store = %mem.store Tas (allocd#0:(.Int 2), allocd#1:(.Int 2), argc);
-    .let load = %mem.load Tas (store, allocd#1:(.Int 2));
+    .let store = %mem.store Tas (allocd#0:(.Idx 2), allocd#1:(.Idx 2), argc);
+    .let load = %mem.load Tas (store, allocd#1:(.Idx 2));
     // todo: free :)
     return load
 };
 
-// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[mainMemId:[_0-9]*]]: %mem.M, argc_[[argcId:[0-9_]+]]: (.Int 4294967296), %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (.Int 256)», 0)», 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (.Int 4294967296)]] = {
-// CHECK-DAG: _[[appMSlotId:[0-9_]+]]: [%mem.M, %mem.Ptr ((.Int 4294967296), 0)] = %mem.malloc ((.Int 4294967296), 0) (mem_[[mainMemId]], 4);
-// CHECK-DAG: _[[appStoreId:[0-9_]+]]: %mem.M = %mem.store ((.Int 4294967296), 0) (_[[appMSlotId]]#0:(.Int 2), _[[appMSlotId]]#1:(.Int 2), argc_[[argcId]]);
-// CHECK-DAG: _[[appLoadId:[0-9_]+]]: [%mem.M, (.Int 4294967296)] = %mem.load ((.Int 4294967296), 0) (_[[appStoreId]], _[[appMSlotId]]#1:(.Int 2));
+// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[mainMemId:[_0-9]*]]: %mem.M, argc_[[argcId:[0-9_]+]]: (.Idx 4294967296), %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (.Idx 256)», 0)», 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (.Idx 4294967296)]] = {
+// CHECK-DAG: _[[appMSlotId:[0-9_]+]]: [%mem.M, %mem.Ptr ((.Idx 4294967296), 0)] = %mem.malloc ((.Idx 4294967296), 0) (mem_[[mainMemId]], 4);
+// CHECK-DAG: _[[appStoreId:[0-9_]+]]: %mem.M = %mem.store ((.Idx 4294967296), 0) (_[[appMSlotId]]#0:(.Idx 2), _[[appMSlotId]]#1:(.Idx 2), argc_[[argcId]]);
+// CHECK-DAG: _[[appLoadId:[0-9_]+]]: [%mem.M, (.Idx 4294967296)] = %mem.load ((.Idx 4294967296), 0) (_[[appStoreId]], _[[appMSlotId]]#1:(.Idx 2));
 // CHECK-DAG: return_[[returnEtaId:[0-9_]+]] _[[appLoadId]]
 
-// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Int 4294967296)] = {
+// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Idx 4294967296)] = {
 // CHECK-DAG: return_[[returnId]] _[[returnEtaVarId]]

--- a/lit/mem/malloc_load_store.thorin
+++ b/lit/mem/malloc_load_store.thorin
@@ -7,21 +7,21 @@
 
 .import mem;
 
-.let i32 = .Int 4294967296;
-.cn .extern main(mem: %mem.M, argc: i32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .Int 256», 0)», 0), return: .Cn [%mem.M, i32]) = {
+.let i32 = .Idx 4294967296;
+.cn .extern main(mem: %mem.M, argc: i32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .Idx 256», 0)», 0), return: .Cn [%mem.M, i32]) = {
     .let Tas = (i32, 0);
     .let allocd = %mem.malloc Tas (mem, 4);
-    .let store = %mem.store Tas (allocd#0:(.Int 2), allocd#1:(.Int 2), argc);
-    .let load = %mem.load Tas (store, allocd#1:(.Int 2));
+    .let store = %mem.store Tas (allocd#0:(.Idx 2), allocd#1:(.Idx 2), argc);
+    .let load = %mem.load Tas (store, allocd#1:(.Idx 2));
     // todo: free :)
     return load
 };
 
-// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[mainMemId:[_0-9]*]]: %mem.M, argc_[[argcId:[0-9_]+]]: (.Int 4294967296), %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (.Int 256)», 0)», 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (.Int 4294967296)]] = {
-// CHECK-DAG: _[[appMSlotId:[0-9_]+]]: [%mem.M, %mem.Ptr ((.Int 4294967296), 0)] = %mem.malloc ((.Int 4294967296), 0) (mem_[[mainMemId]], 4);
-// CHECK-DAG: _[[appStoreId:[0-9_]+]]: %mem.M = %mem.store ((.Int 4294967296), 0) (_[[appMSlotId]]#0:(.Int 2), _[[appMSlotId]]#1:(.Int 2), argc_[[argcId]]);
-// CHECK-DAG: _[[appLoadId:[0-9_]+]]: [%mem.M, (.Int 4294967296)] = %mem.load ((.Int 4294967296), 0) (_[[appStoreId]], _[[appMSlotId]]#1:(.Int 2));
+// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[mainMemId:[_0-9]*]]: %mem.M, argc_[[argcId:[0-9_]+]]: (.Idx 4294967296), %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (.Idx 256)», 0)», 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (.Idx 4294967296)]] = {
+// CHECK-DAG: _[[appMSlotId:[0-9_]+]]: [%mem.M, %mem.Ptr ((.Idx 4294967296), 0)] = %mem.malloc ((.Idx 4294967296), 0) (mem_[[mainMemId]], 4);
+// CHECK-DAG: _[[appStoreId:[0-9_]+]]: %mem.M = %mem.store ((.Idx 4294967296), 0) (_[[appMSlotId]]#0:(.Idx 2), _[[appMSlotId]]#1:(.Idx 2), argc_[[argcId]]);
+// CHECK-DAG: _[[appLoadId:[0-9_]+]]: [%mem.M, (.Idx 4294967296)] = %mem.load ((.Idx 4294967296), 0) (_[[appStoreId]], _[[appMSlotId]]#1:(.Idx 2));
 // CHECK-DAG: return_[[returnEtaId:[0-9_]+]] _[[appLoadId]]
 
-// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Int 4294967296)] = {
+// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Idx 4294967296)] = {
 // CHECK-DAG: return_[[returnId]] _[[returnEtaVarId]]

--- a/lit/mem/mslot_load_store.thorin
+++ b/lit/mem/mslot_load_store.thorin
@@ -7,20 +7,20 @@
 
 .import mem;
 
-.let i32 = .Int 4294967296;
-.cn .extern main(mem: %mem.M, argc: i32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .Int 256», 0)», 0), return: .Cn [%mem.M, i32]) = {
+.let i32 = .Idx 4294967296;
+.cn .extern main(mem: %mem.M, argc: i32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .Idx 256», 0)», 0), return: .Cn [%mem.M, i32]) = {
     .let Tas = (i32, 0);
     .let slot = %mem.mslot Tas (mem, 4, 0);
-    .let store = %mem.store Tas (slot#0:(.Int 2), slot#1:(.Int 2), argc);
-    .let load = %mem.load Tas (store, slot#1:(.Int 2));
+    .let store = %mem.store Tas (slot#0:(.Idx 2), slot#1:(.Idx 2), argc);
+    .let load = %mem.load Tas (store, slot#1:(.Idx 2));
     return load
 };
 
-// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[mainMemId:[_0-9]*]]: %mem.M, argc_[[argcId:[0-9_]+]]: (.Int 4294967296), %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (.Int 256)», 0)», 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (.Int 4294967296)]] = {
-// CHECK-DAG: _[[appMSlotId:[0-9_]+]]: [%mem.M, %mem.Ptr ((.Int 4294967296), 0)] = %mem.mslot ((.Int 4294967296), 0) (mem_[[mainMemId]], 4, 0);
-// CHECK-DAG: _[[appStoreId:[0-9_]+]]: %mem.M = %mem.store ((.Int 4294967296), 0) (_[[appMSlotId]]#0:(.Int 2), _[[appMSlotId]]#1:(.Int 2), argc_[[argcId]]);
-// CHECK-DAG: _[[appLoadId:[0-9_]+]]: [%mem.M, (.Int 4294967296)] = %mem.load ((.Int 4294967296), 0) (_[[appStoreId]], _[[appMSlotId]]#1:(.Int 2));
+// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[mainMemId:[_0-9]*]]: %mem.M, argc_[[argcId:[0-9_]+]]: (.Idx 4294967296), %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (.Idx 256)», 0)», 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (.Idx 4294967296)]] = {
+// CHECK-DAG: _[[appMSlotId:[0-9_]+]]: [%mem.M, %mem.Ptr ((.Idx 4294967296), 0)] = %mem.mslot ((.Idx 4294967296), 0) (mem_[[mainMemId]], 4, 0);
+// CHECK-DAG: _[[appStoreId:[0-9_]+]]: %mem.M = %mem.store ((.Idx 4294967296), 0) (_[[appMSlotId]]#0:(.Idx 2), _[[appMSlotId]]#1:(.Idx 2), argc_[[argcId]]);
+// CHECK-DAG: _[[appLoadId:[0-9_]+]]: [%mem.M, (.Idx 4294967296)] = %mem.load ((.Idx 4294967296), 0) (_[[appStoreId]], _[[appMSlotId]]#1:(.Idx 2));
 // CHECK-DAG: return_[[returnEtaId:[0-9_]+]] _[[appLoadId]]
 
-// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Int 4294967296)] = {
+// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Idx 4294967296)] = {
 // CHECK-DAG: return_[[returnId]] _[[returnEtaVarId]]

--- a/lit/mem/slot_load_store.thorin
+++ b/lit/mem/slot_load_store.thorin
@@ -7,17 +7,17 @@
 
 .import mem;
 
-.let i32 = .Int 4294967296;
-.cn .extern main(mem: %mem.M, argc: i32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .Int 256», 0)», 0), return: .Cn [%mem.M, i32]) = {
+.let i32 = .Idx 4294967296;
+.cn .extern main(mem: %mem.M, argc: i32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .Idx 256», 0)», 0), return: .Cn [%mem.M, i32]) = {
     .let Tas = (i32, 0);
     .let slot = %mem.slot Tas (mem, 0);
-    .let store = %mem.store Tas (slot#0:(.Int 2), slot#1:(.Int 2), argc);
-    .let load = %mem.load Tas (store, slot#1:(.Int 2));
+    .let store = %mem.store Tas (slot#0:(.Idx 2), slot#1:(.Idx 2), argc);
+    .let load = %mem.load Tas (store, slot#1:(.Idx 2));
     return load
 };
 
-// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[mainMemId:[_0-9]*]]: %mem.M, argc_[[argcId:[0-9_]+]]: (.Int 4294967296), %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (.Int 256)», 0)», 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (.Int 4294967296)]] = {
+// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[mainMemId:[_0-9]*]]: %mem.M, argc_[[argcId:[0-9_]+]]: (.Idx 4294967296), %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; (.Idx 256)», 0)», 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (.Idx 4294967296)]] = {
 // CHECK-DAG: return_[[returnEtaId:[0-9_]+]] (mem_[[mainMemId]], argc_[[argcId]])
 
-// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Int 4294967296)] = {
+// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Idx 4294967296)] = {
 // CHECK-DAG: return_[[returnId]] _[[returnEtaVarId]]

--- a/lit/parse_output_parse.thorin
+++ b/lit/parse_output_parse.thorin
@@ -7,15 +7,15 @@
 
 .import mem;
 
-.cn .extern main [mem : %mem.M, argc : .Int 4294967296, argv : %mem.Ptr (%mem.Ptr (.Int 256, 0), 0), return : .Cn [%mem.M, .Int 4294967296]] = {
+.cn .extern main [mem : %mem.M, argc : .Idx 4294967296, argv : %mem.Ptr (%mem.Ptr (.Idx 256, 0), 0), return : .Cn [%mem.M, .Idx 4294967296]] = {
     .cn single_arg_parse_test mem: %mem.M = {
             return (mem, argc)
     };
     single_arg_parse_test mem
 };
 
-// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[memId:[_0-9]*]]: %mem.M, argc_[[argcId:[0-9_]+]]: (.Int 4294967296), %mem.Ptr (%mem.Ptr ((.Int 256), 0), 0), return_[[returnId:[_0-9]+]]: .Cn [%mem.M, (.Int 4294967296)]] = {
+// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[memId:[_0-9]*]]: %mem.M, argc_[[argcId:[0-9_]+]]: (.Idx 4294967296), %mem.Ptr (%mem.Ptr ((.Idx 256), 0), 0), return_[[returnId:[_0-9]+]]: .Cn [%mem.M, (.Idx 4294967296)]] = {
 // CHECK-DAG: return_[[returnEtaId:[0-9_]+]] (mem_[[memId]], argc_[[argcId]])
 
-// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Int 4294967296)] = {
+// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Idx 4294967296)] = {
 // CHECK-DAG: return_[[returnId]] _[[returnEtaVarId]]

--- a/lit/restructre_free_var.thorin
+++ b/lit/restructre_free_var.thorin
@@ -28,7 +28,7 @@
     ] ->
     %matrix.Mat (n,S,T);
 
-.let I32 = .Int 4294967296;
+.let I32 = .Idx 4294967296;
 .let test = %matrix.mapReduce 
     (2,(4,3),I32,
         2,

--- a/lit/ret_argc.thorin
+++ b/lit/ret_argc.thorin
@@ -7,12 +7,12 @@
 
 .import mem;
 
-.let i8  = .Int 256;
-.let i32 = .Int 4294967296;
+.let i8  = .Idx 256;
+.let i32 = .Idx 4294967296;
 .cn .extern main(mem: %mem.M, argc: i32, argv: %mem.Ptr (%mem.Ptr (i8, 0), 0), return: .Cn [%mem.M, i32]) = return (mem, argc);
 
-// CHECK-DAG: .cn .extern main _[[mainVarId:[0-9_]+]]::[mem_[[memId:[0-9_]+]]: %mem.M, argc_[[argcId:[0-9_]+]]: (.Int 4294967296), %mem.Ptr (%mem.Ptr ((.Int 256), 0), 0), return_[[returnId:[0-9_]+]]: .Cn [%mem.M, (.Int 4294967296)]] = {
+// CHECK-DAG: .cn .extern main _[[mainVarId:[0-9_]+]]::[mem_[[memId:[0-9_]+]]: %mem.M, argc_[[argcId:[0-9_]+]]: (.Idx 4294967296), %mem.Ptr (%mem.Ptr ((.Idx 256), 0), 0), return_[[returnId:[0-9_]+]]: .Cn [%mem.M, (.Idx 4294967296)]] = {
 // CHECK-DAG: return_[[returnEtaId:[0-9_]+]] (mem_[[memId]], argc_[[argcId]])
 
-// CHECK-DAG: .cn return_[[returnEtaId:[0-9_]+]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Int 4294967296)] = {
+// CHECK-DAG: .cn return_[[returnEtaId:[0-9_]+]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Idx 4294967296)] = {
 // CHECK-DAG: return_[[returnId]] _[[returnEtaVarId]]

--- a/lit/type_error/domain.thorin
+++ b/lit/type_error/domain.thorin
@@ -1,6 +1,6 @@
 // RUN: ! %thorin %s 2>&1 | FileCheck %s 
 
-.let I32 = .Int  4294967296;
+.let I32 = .Idx  4294967296;
 .let R32 = %Real 32;
 .ax %foo.bar: .Cn [I32, R32];
 .let err = %foo.bar(23:R32, 42:I32);

--- a/thorin/axiom.h
+++ b/thorin/axiom.h
@@ -156,12 +156,12 @@ Match<Tag2Enum<t>, Tag2Def<t>> as(Tag2Enum<t> f, const Def* d) {
     return {std::get<0>(Axiom::get(d)), d->as<App>()};
 }
 
-constexpr uint64_t width2mod(uint64_t n) {
+constexpr uint64_t bitwidth2size(uint64_t n) {
     assert(n != 0);
     return n == 64 ? 0 : (1_u64 << n);
 }
 
-constexpr std::optional<uint64_t> mod2width(uint64_t n) {
+constexpr std::optional<uint64_t> size2bitwidth(uint64_t n) {
     if (n == 0) return 64;
     if (std::has_single_bit(n)) return std::bit_width(n - 1_u64);
     return {};

--- a/thorin/be/emitter.h
+++ b/thorin/be/emitter.h
@@ -13,7 +13,7 @@ private:
     constexpr const Child& child() const { return *static_cast<const Child*>(this); };
     constexpr Child& child() { return *static_cast<Child*>(this); };
 
-    /// Internal wrapper for Emitter::emit that checks and retrieves/puts the `Value` from
+    /// Idxernal wrapper for Emitter::emit that checks and retrieves/puts the `Value` from
     /// Emitter::locals_/Emitter::globals_.
     Value emit_(const Def* def) {
         auto place = scheduler_.smart(def);

--- a/thorin/be/emitter.h
+++ b/thorin/be/emitter.h
@@ -13,7 +13,7 @@ private:
     constexpr const Child& child() const { return *static_cast<const Child*>(this); };
     constexpr Child& child() { return *static_cast<Child*>(this); };
 
-    /// Idxernal wrapper for Emitter::emit that checks and retrieves/puts the `Value` from
+    /// Integer wrapper for Emitter::emit that checks and retrieves/puts the `Value` from
     /// Emitter::locals_/Emitter::globals_.
     Value emit_(const Def* def) {
         auto place = scheduler_.smart(def);

--- a/thorin/def.cpp
+++ b/thorin/def.cpp
@@ -64,7 +64,7 @@ Def::Def(node_t node, const Def* type, size_t num_ops, flags_t flags, const Def*
 Nat::Nat(World& world)
     : Def(Node, world.type(), Defs{}, 0, nullptr) {}
 
-Int::Int(World& world, const Def* size)
+Idx::Idx(World& world, const Def* size)
     : Def(Node, world.type(), Defs{size}, 0, nullptr) {}
 
 // clang-format off
@@ -78,7 +78,7 @@ const Def* App      ::rebuild(World& w, const Def*  , Defs o, const Def* dbg) co
 const Def* Arr      ::rebuild(World& w, const Def*  , Defs o, const Def* dbg) const { return w.arr(o[0], o[1], dbg); }
 const Def* Extract  ::rebuild(World& w, const Def*  , Defs o, const Def* dbg) const { return w.extract(o[0], o[1], dbg); }
 const Def* Insert   ::rebuild(World& w, const Def*  , Defs o, const Def* dbg) const { return w.insert(o[0], o[1], o[2], dbg); }
-const Def* Int      ::rebuild(World& w, const Def*  , Defs o, const Def*    ) const { return w.type_int(o[0]); }
+const Def* Idx      ::rebuild(World& w, const Def*  , Defs o, const Def*    ) const { return w.type_idx(o[0]); }
 const Def* Lam      ::rebuild(World& w, const Def* t, Defs o, const Def* dbg) const { return w.lam(t->as<Pi>(), o[0], o[1], dbg); }
 const Def* Lit      ::rebuild(World& w, const Def* t, Defs  , const Def* dbg) const { return w.lit(t, get(), dbg); }
 const Def* Nat      ::rebuild(World& w, const Def*  , Defs  , const Def*    ) const { return w.type_nat(); }
@@ -140,13 +140,13 @@ const Sigma* Sigma::restructure() {
 
 const Def* Arr::restructure() {
     auto& w = world();
-    if (auto n = isa_lit(shape())) return w.sigma(DefArray(*n, [&](size_t i) { return reduce(w.lit_int(*n, i)); }));
+    if (auto n = isa_lit(shape())) return w.sigma(DefArray(*n, [&](size_t i) { return reduce(w.lit_idx(*n, i)); }));
     return nullptr;
 }
 
 const Def* Pack::restructure() {
     auto& w = world();
-    if (auto n = isa_lit(shape())) return w.tuple(DefArray(*n, [&](size_t i) { return reduce(w.lit_int(*n, i)); }));
+    if (auto n = isa_lit(shape())) return w.tuple(DefArray(*n, [&](size_t i) { return reduce(w.lit_idx(*n, i)); }));
     return nullptr;
 }
 
@@ -202,8 +202,8 @@ const Var* Def::var(const Def* dbg) {
     if (auto lam  = isa<Lam  >()) return w.var(lam ->dom(), lam, dbg);
     if (auto pi   = isa<Pi   >()) return w.var(pi  ->dom(),  pi, dbg);
     if (auto sig  = isa<Sigma>()) return w.var(sig,         sig, dbg);
-    if (auto arr  = isa<Arr  >()) return w.var(w.type_int(arr ->shape()), arr,  dbg); // TODO shapes like (2, 3)
-    if (auto pack = isa<Pack >()) return w.var(w.type_int(pack->shape()), pack, dbg); // TODO shapes like (2, 3)
+    if (auto arr  = isa<Arr  >()) return w.var(w.type_idx(arr ->shape()), arr,  dbg); // TODO shapes like (2, 3)
+    if (auto pack = isa<Pack >()) return w.var(w.type_idx(pack->shape()), pack, dbg); // TODO shapes like (2, 3)
     if (isa_bound(this)) return w.var(this, this,  dbg);
     if (isa<Infer >())   return nullptr;
     if (isa<Global>())   return nullptr;
@@ -390,11 +390,11 @@ const Def* Def::proj(nat_t a, nat_t i, const Def* dbg) const {
         return op(i);
     } else if (auto arr = isa<Arr>()) {
         if (arr->arity()->isa<Top>()) return arr->body();
-        return arr->reduce(w.lit_int(as_lit(arr->arity()), i));
+        return arr->reduce(w.lit_idx(as_lit(arr->arity()), i));
     } else if (auto pack = isa<Pack>()) {
         if (pack->arity()->isa<Top>()) return pack->body();
         assert(!w.is_frozen() && "TODO");
-        return pack->reduce(w.lit_int(as_lit(pack->arity()), i));
+        return pack->reduce(w.lit_idx(as_lit(pack->arity()), i));
     } else if (sort() == Sort::Term) {
         if (w.is_frozen() || uses().size() < Search_In_Uses_Threshold) {
             for (auto u : uses()) {

--- a/thorin/def.h
+++ b/thorin/def.h
@@ -550,9 +550,13 @@ public:
     friend class World;
 };
 
-class Int : public Def {
+
+/// A type whose inhabitants range from `0`, ..., Idx::size() - 1.
+/// @note `size = 0` is special and actually encodes size $2^64$.
+/// An .Idx `0` (literally) wouldn't have any inhabitants anyway.
+class Idx : public Def {
 private:
-    Int(World&, const Def* size);
+    Idx(World&, const Def* size);
 
 public:
     const Def* size() const { return op(0); }
@@ -562,7 +566,7 @@ public:
     const Def* rebuild(World&, const Def*, Defs, const Def*) const override;
     ///@}
 
-    static constexpr auto Node = Node::Int;
+    static constexpr auto Node = Node::Idx;
     friend class World;
 };
 

--- a/thorin/def.h
+++ b/thorin/def.h
@@ -550,7 +550,6 @@ public:
     friend class World;
 };
 
-
 /// A type whose inhabitants range from `0`, ..., Idx::size() - 1.
 /// @note `size = 0` is special and actually encodes size $2^64$.
 /// An .Idx `0` (literally) wouldn't have any inhabitants anyway.

--- a/thorin/dump.cpp
+++ b/thorin/dump.cpp
@@ -141,8 +141,8 @@ std::ostream& operator<<(std::ostream& os, Inline u) {
         return print(os, "Π {} → {}", pi->dom(), pi->codom());
     } else if (auto lam = u->isa<Lam>()) {
         return print(os, "{}, {}", lam->filter(), lam->body());
-    } else if (auto int_ = u->isa<Int>()) {
-        return print(os, "(.Int {})", int_->size());
+    } else if (auto int_ = u->isa<Idx>()) {
+        return print(os, "(.Idx {})", int_->size());
     } else if (auto real = isa<Tag::Real>(*u)) {
         return print(os, "(%Real {})", real->arg());
     } else if (auto app = u->isa<App>()) {

--- a/thorin/fe/lexer.cpp
+++ b/thorin/fe/lexer.cpp
@@ -183,14 +183,14 @@ std::optional<Tok> Lexer::parse_lit() {
                 next();
             }
             auto m = strtoull(mod.c_str(), nullptr, 10);
-            return Tok{loc_, world().lit_int_mod(m, i)};
+            return Tok{loc_, world().lit_idx_mod(m, i)};
         } else if (accept('_', false)) {
             auto i = strtoull(str_.c_str(), nullptr, 10);
             str_.clear();
             if (accept_if(isdigit)) {
                 parse_digits(10);
                 auto m = strtoull(str_.c_str(), nullptr, 10);
-                return Tok{loc_, world().lit_int_mod(m, i)};
+                return Tok{loc_, world().lit_idx_mod(m, i)};
             } else {
                 err(loc_, "stray underscore in unsigned literal");
                 auto i = strtoull(str_.c_str(), nullptr, 10);

--- a/thorin/fe/parser.cpp
+++ b/thorin/fe/parser.cpp
@@ -255,7 +255,7 @@ const Def* Parser::parse_primary_expr(std::string_view ctxt) {
         case Tok::Tag::D_brckt_l: return parse_sigma();
         case Tok::Tag::D_paren_l: return parse_tuple();
         case Tok::Tag::K_Cn:      return parse_Cn();
-        case Tok::Tag::K_Int:     return parse_int();
+        case Tok::Tag::K_Idx:     return parse_idx();
         case Tok::Tag::K_Type:    return parse_type();
         case Tok::Tag::K_Univ:    lex(); return world().univ();
         case Tok::Tag::K_Bool:    lex(); return world().type_bool();
@@ -349,7 +349,7 @@ const Def* Parser::parse_pack() {
         eat(Tok::Tag::T_colon);
 
         shape      = parse_expr("shape of a pack");
-        auto infer = world().nom_infer(world().type_int(shape), sym);
+        auto infer = world().nom_infer(world().type_idx(shape), sym);
         scopes_.bind(sym, infer);
     } else {
         shape = parse_expr("shape of a pack");
@@ -392,11 +392,11 @@ const Def* Parser::parse_type() {
     return world().type(level, track);
 }
 
-const Def* Parser::parse_int() {
-    eat(Tok::Tag::K_Int);
+const Def* Parser::parse_idx() {
+    eat(Tok::Tag::K_Idx);
     auto [l, r] = Tok::prec(Tok::Prec::App);
-    auto size   = parse_expr("size of .Int", r);
-    return world().type_int(size);
+    auto size   = parse_expr("size of .Idx", r);
+    return world().type_idx(size);
 }
 
 const Def* Parser::parse_pi() {

--- a/thorin/fe/parser.h
+++ b/thorin/fe/parser.h
@@ -91,7 +91,7 @@ private:
     const Def* parse_block();
     const Def* parse_sigma();
     const Def* parse_tuple();
-    const Def* parse_int();
+    const Def* parse_idx();
     const Def* parse_type();
     const Def* parse_pi();
     const Def* parse_lam();

--- a/thorin/fe/tok.h
+++ b/thorin/fe/tok.h
@@ -16,7 +16,7 @@ namespace thorin::fe {
     m(K_let,    ".let"   )             \
     m(K_Bool,   ".Bool"  )             \
     m(K_Nat,    ".Nat"   )             \
-    m(K_Int,    ".Int"   )             \
+    m(K_Idx,    ".Idx"   )             \
     m(K_extern, ".extern")             \
     m(K_Arr,    ".Arr"   )             \
     m(K_Sigma,  ".Sigma" )             \

--- a/thorin/lattice.cpp
+++ b/thorin/lattice.cpp
@@ -13,7 +13,7 @@ size_t Bound::find(const Def* type) const {
     return i == ops().end() ? size_t(-1) : i - ops().begin();
 }
 
-const Lit* Bound::index(const Def* type) const { return world().lit_int(num_ops(), find(type)); }
+//const Lit* Bound::index(const Def* type) const { return world().lit_int(num_ops(), find(type)); }
 const Sigma* Bound::convert() const { return isa<Join>() ? as<Join>()->convert() : as<Meet>()->convert(); }
 
 template<bool up>
@@ -34,9 +34,9 @@ const Sigma* TBound<up>::convert() const {
         }
 
         assert(size % align == 0);
-        auto arr = w.arr(size / align, w.type_int_width(align * 8_u64));
+        auto arr = w.arr(size / align, w.type_int_(align * 8_u64));
 
-        return w.sigma({w.type_int(num_ops()), arr})->template as<Sigma>();
+        return w.sigma({w.type_idx(num_ops()), arr})->template as<Sigma>();
     } else {
         return w.sigma(ops())->template as<Sigma>();
     }

--- a/thorin/lattice.cpp
+++ b/thorin/lattice.cpp
@@ -13,7 +13,6 @@ size_t Bound::find(const Def* type) const {
     return i == ops().end() ? size_t(-1) : i - ops().begin();
 }
 
-//const Lit* Bound::index(const Def* type) const { return world().lit_int(num_ops(), find(type)); }
 const Sigma* Bound::convert() const { return isa<Join>() ? as<Join>()->convert() : as<Meet>()->convert(); }
 
 template<bool up>

--- a/thorin/lattice.h
+++ b/thorin/lattice.h
@@ -19,7 +19,6 @@ protected:
 
 public:
     size_t find(const Def* type) const;
-    //const Lit* index(const Def* type) const;
     const Def* get(const Def* type) const { return op(find(type)); }
     const Sigma* convert() const;
 };
@@ -111,7 +110,8 @@ public:
     friend class World;
 };
 
-/// `test value, probe, match, clash` tests whether [value](@ref Test::value) currently holds **type** [probe](@ref Test::probe).
+/// `test value, probe, match, clash` tests whether [value](@ref Test::value) currently holds **type** [probe](@ref
+/// Test::probe).
 /// @note
 /// * [probe](@ref Test::probe) is a **type**!
 /// * This operation yields [match](@ref Test::match), if `true`, and [clash](@ref Test::clash) otherwise.

--- a/thorin/lattice.h
+++ b/thorin/lattice.h
@@ -19,7 +19,7 @@ protected:
 
 public:
     size_t find(const Def* type) const;
-    const Lit* index(const Def* type) const;
+    //const Lit* index(const Def* type) const;
     const Def* get(const Def* type) const { return op(find(type)); }
     const Sigma* convert() const;
 };

--- a/thorin/normalize.cpp
+++ b/thorin/normalize.cpp
@@ -296,8 +296,8 @@ const Def* normalize_Bit(const Def* type, const Def* c, const Def* arg, const De
 
     // clang-format off
     switch (op) {
-        case Bit::    f: return world.lit_int(*w,        0);
-        case Bit::    t: return world.lit_int(*w, *w-1_u64);
+        case Bit::    f: return world.lit_idx(*w,        0);
+        case Bit::    t: return world.lit_idx(*w, *w-1_u64);
         case Bit::    a: return a;
         case Bit::    b: return b;
         case Bit::   na: return world.op_negate(a, dbg);
@@ -309,21 +309,21 @@ const Def* normalize_Bit(const Def* type, const Def* c, const Def* arg, const De
 
     if (la && lb) {
         switch (op) {
-            case Bit::_and: return world.lit_int    (*w,   *la &  *lb);
-            case Bit:: _or: return world.lit_int    (*w,   *la |  *lb);
-            case Bit::_xor: return world.lit_int    (*w,   *la ^  *lb);
-            case Bit::nand: return world.lit_int_mod(*w, ~(*la &  *lb));
-            case Bit:: nor: return world.lit_int_mod(*w, ~(*la |  *lb));
-            case Bit::nxor: return world.lit_int_mod(*w, ~(*la ^  *lb));
-            case Bit:: iff: return world.lit_int_mod(*w, ~ *la |  *lb);
-            case Bit::niff: return world.lit_int    (*w,   *la & ~*lb);
+            case Bit::_and: return world.lit_idx    (*w,   *la &  *lb);
+            case Bit:: _or: return world.lit_idx    (*w,   *la |  *lb);
+            case Bit::_xor: return world.lit_idx    (*w,   *la ^  *lb);
+            case Bit::nand: return world.lit_idx_mod(*w, ~(*la &  *lb));
+            case Bit:: nor: return world.lit_idx_mod(*w, ~(*la |  *lb));
+            case Bit::nxor: return world.lit_idx_mod(*w, ~(*la ^  *lb));
+            case Bit:: iff: return world.lit_idx_mod(*w, ~ *la |  *lb);
+            case Bit::niff: return world.lit_idx    (*w,   *la & ~*lb);
             default: unreachable();
         }
     }
 
     auto unary = [&](bool x, bool y, const Def* a) -> const Def* {
-        if (!x && !y) return world.lit_int(*w, 0);
-        if ( x &&  y) return world.lit_int(*w, *w-1_u64);
+        if (!x && !y) return world.lit_idx(*w, 0);
+        if ( x &&  y) return world.lit_idx(*w, *w-1_u64);
         if (!x &&  y) return a;
         if ( x && !y && op != Bit::_xor) return world.op_negate(a, dbg);
         return nullptr;
@@ -357,9 +357,9 @@ const Def* normalize_Bit(const Def* type, const Def* c, const Def* arg, const De
 
     if (auto bb = is_not(b); bb && a == bb) {
         switch (op) {
-            case IOp::iand: return world.lit_int(*w,       0);
-            case IOp::ior : return world.lit_int(*w, *w-1_u64);
-            case IOp::ixor: return world.lit_int(*w, *w-1_u64);
+            case IOp::iand: return world.lit_idx(*w,       0);
+            case IOp::ior : return world.lit_idx(*w, *w-1_u64);
+            case IOp::ixor: return world.lit_idx(*w, *w-1_u64);
             default: unreachable();
         }
     }
@@ -433,7 +433,7 @@ const Def* normalize_Shr(const Def* type, const Def* c, const Def* arg, const De
     if (auto result = fold<Shr, op>(world, type, callee, a, b, dbg)) return result;
 
     if (auto la = a->isa<Lit>()) {
-        if (la == world.lit_int(*w, 0)) {
+        if (la == world.lit_idx(*w, 0)) {
             switch (op) {
                 case Shr::ashr: return la;
                 case Shr::lshr: return la;
@@ -443,7 +443,7 @@ const Def* normalize_Shr(const Def* type, const Def* c, const Def* arg, const De
     }
 
     if (auto lb = b->isa<Lit>()) {
-        if (lb == world.lit_int(*w, 0)) {
+        if (lb == world.lit_idx(*w, 0)) {
             switch (op) {
                 case Shr::ashr: return a;
                 case Shr::lshr: return a;
@@ -468,7 +468,7 @@ const Def* normalize_Wrap(const Def* type, const Def* c, const Def* arg, const D
 
     // clang-format off
     if (auto la = a->isa<Lit>()) {
-        if (la == world.lit_int(*w, 0)) {
+        if (la == world.lit_idx(*w, 0)) {
             switch (op) {
                 case Wrap::add: return b;    // 0  + b -> b
                 case Wrap::sub: break;
@@ -478,7 +478,7 @@ const Def* normalize_Wrap(const Def* type, const Def* c, const Def* arg, const D
             }
         }
 
-        if (la == world.lit_int(*w, 1)) {
+        if (la == world.lit_idx(*w, 1)) {
             switch (op) {
                 case Wrap::add: break;
                 case Wrap::sub: break;
@@ -490,7 +490,7 @@ const Def* normalize_Wrap(const Def* type, const Def* c, const Def* arg, const D
     }
 
     if (auto lb = b->isa<Lit>()) {
-        if (lb == world.lit_int(*w, 0)) {
+        if (lb == world.lit_idx(*w, 0)) {
             switch (op) {
                 case Wrap::sub: return a;    // a  - 0 -> a
                 case Wrap::shl: return a;    // a >> 0 -> a
@@ -500,15 +500,15 @@ const Def* normalize_Wrap(const Def* type, const Def* c, const Def* arg, const D
         }
 
         if (op == Wrap::sub)
-            return world.op(Wrap::add, *m, a, world.lit_int_mod(*w, ~lb->get() + 1_u64)); // a - lb -> a + (~lb + 1)
+            return world.op(Wrap::add, *m, a, world.lit_idx_mod(*w, ~lb->get() + 1_u64)); // a - lb -> a + (~lb + 1)
         else if (op == Wrap::shl && lb->get() > *w)
             return world.bot(type, dbg);
     }
 
     if (a == b) {
         switch (op) {
-            case Wrap::add: return world.op(Wrap::mul, *m, world.lit_int(*w, 2), a, dbg); // a + a -> 2 * a
-            case Wrap::sub: return world.lit_int(*w, 0);                                  // a - a -> 0
+            case Wrap::add: return world.op(Wrap::mul, *m, world.lit_idx(*w, 2), a, dbg); // a + a -> 2 * a
+            case Wrap::sub: return world.lit_idx(*w, 0);                                  // a - a -> 0
             case Wrap::mul: break;
             case Wrap::shl: break;
             default: unreachable();
@@ -625,7 +625,7 @@ inline u64 pad(u64 offset, u64 align) {
 }
 
 // TODO this currently hard-codes x86_64 ABI
-// TODO in contrast to C, we might want to give singleton types like 'int 1' or '[]' a size of 0 and simply nuke each
+// TODO in contrast to C, we might want to give singleton types like '.Idx 1' or '[]' a size of 0 and simply nuke each
 // and every occurance of these types in a later phase
 // TODO Pi and others
 template<Trait op>
@@ -637,9 +637,9 @@ const Def* normalize_Trait(const Def*, const Def* callee, const Def* type, const
         return world.lit_nat(8);
     } else if (type->isa<Pi>()) {
         return world.lit_nat(8); // Gets lowered to function ptr
-    } else if (auto int_ = type->isa<Int>()) {
-        if (int_->type()->isa<Top>()) return world.lit_nat(8);
-        if (auto w = isa_lit(int_->size())) {
+    } else if (auto idx = type->isa<Idx>()) {
+        if (idx->type()->isa<Top>()) return world.lit_nat(8);
+        if (auto w = isa_lit(idx->size())) {
             if (*w == 0) return world.lit_nat(8);
             if (*w <= 0x0000'0000'0000'0100_u64) return world.lit_nat(1);
             if (*w <= 0x0000'0000'0001'0000_u64) return world.lit_nat(2);
@@ -679,9 +679,9 @@ const Def* normalize_Trait(const Def*, const Def* callee, const Def* type, const
         if constexpr (op == Trait::align) return align;
 
         if (auto b = isa_lit(world.op(Trait::size, arr->body()))) {
-            auto i64_t = world.type_int_width(64);
+            auto i64_t = world.type_int_(64);
             auto s     = world.op_bitcast(i64_t, arr->shape());
-            auto mul   = world.op(Wrap::mul, WMode::nsw | WMode::nuw, world.lit_int(i64_t, *b), s);
+            auto mul   = world.op(Wrap::mul, WMode::nsw | WMode::nuw, world.lit_idx(i64_t, *b), s);
             return world.op_bitcast(world.type_nat(), mul);
         }
     } else if (auto join = type->isa<Join>()) {
@@ -713,8 +713,8 @@ static const Def* fold_Conv(const Def* dst_type, const App* callee, const Def* s
             return world.lit(dst_type, as_lit(lit_src) % *lit_dw);
         }
 
-        if (src->type()->isa<Int>()) *lit_sw = *mod2width(*lit_sw);
-        if (dst_type->isa<Int>()) *lit_dw = *mod2width(*lit_dw);
+        if (src->type()->isa<Idx>()) *lit_sw = *size2bitwidth(*lit_sw);
+        if (dst_type->isa<Idx>()) *lit_dw = *size2bitwidth(*lit_dw);
 
         Res res;
 #define CODE(sw, dw)                                                                                 \
@@ -778,7 +778,7 @@ const Def* normalize_bitcast(const Def* dst_type, const Def* callee, const Def* 
 
     if (auto lit = src->isa<Lit>()) {
         if (dst_type->isa<Nat>()) return world.lit(dst_type, lit->get(), dbg);
-        if (dst_type->isa<Int>()) return world.lit(dst_type, lit->get(), dbg);
+        if (dst_type->isa<Idx>()) return world.lit(dst_type, lit->get(), dbg);
         if (isa<Tag::Real>(dst_type)) return world.lit(dst_type, lit->get(), dbg);
     }
 

--- a/thorin/normalize.h
+++ b/thorin/normalize.h
@@ -109,13 +109,13 @@ static const Def* fold(World& world, const Def* type, const App* callee, const D
             nsw            = mode & WMode::nsw;
             nuw            = mode & WMode::nuw;
             width          = w;
-        } else if (auto int_t = a->type()->isa<Int>()) {
-            width = as_lit(int_t->size());
+        } else if (auto idx = a->type()->isa<Idx>()) {
+            width = as_lit(idx->size());
         } else {
             width = as_lit(as<Tag::Real>(a->type())->arg());
         }
 
-        if (is_int<Op>()) width = *mod2width(width);
+        if (is_int<Op>()) width = *size2bitwidth(width);
 
         Res res;
         switch (width) {

--- a/thorin/tables.h
+++ b/thorin/tables.h
@@ -25,7 +25,7 @@ using sub_t     = u8;
     m(Proxy, proxy)                                                           \
     m(Axiom, axiom)                                                           \
     m(Lit, lit)                                                               \
-    m(Nat, nat)         m(Int, int)                                           \
+    m(Nat, nat)         m(Idx, int)                                           \
     m(Var, var)                                                               \
     m(Infer, infer)                                                           \
     m(Global, global)                                                         \
@@ -69,9 +69,9 @@ enum RMode : nat_t {
 };
 }
 
-/// Integer operations that neither take a @p WMode nor do produce a side effect - arithmetic or logical shift right.
+/// Idxeger operations that neither take a @p WMode nor do produce a side effect - arithmetic or logical shift right.
 #define THORIN_SHR(m) m(Shr, ashr) m(Shr, lshr)
-/// Integer operations that might wrap and, hence, take @p WMode.
+/// Idxeger operations that might wrap and, hence, take @p WMode.
 #define THORIN_WRAP(m) m(Wrap, add) m(Wrap, sub) m(Wrap, mul) m(Wrap, shl)
 /// Floating point (real) operations that take @p RMode.
 #define THORIN_R_OP(m) m(ROp, add) m(ROp, sub) m(ROp, mul) m(ROp, div) m(ROp, rem)

--- a/thorin/tables.h
+++ b/thorin/tables.h
@@ -69,9 +69,9 @@ enum RMode : nat_t {
 };
 }
 
-/// Idxeger operations that neither take a @p WMode nor do produce a side effect - arithmetic or logical shift right.
+/// Integer operations that neither take a @p WMode nor do produce a side effect - arithmetic or logical shift right.
 #define THORIN_SHR(m) m(Shr, ashr) m(Shr, lshr)
-/// Idxeger operations that might wrap and, hence, take @p WMode.
+/// Integer operations that might wrap and, hence, take @p WMode.
 #define THORIN_WRAP(m) m(Wrap, add) m(Wrap, sub) m(Wrap, mul) m(Wrap, shl)
 /// Floating point (real) operations that take @p RMode.
 #define THORIN_R_OP(m) m(ROp, add) m(ROp, sub) m(ROp, mul) m(ROp, div) m(ROp, rem)

--- a/thorin/util/assert.h
+++ b/thorin/util/assert.h
@@ -5,7 +5,7 @@
 namespace thorin {
 
 // see https://stackoverflow.com/a/65258501
-#ifdef __GNUC__ // GCC 4.8+, Clang, Intel and other compilers compatible with GCC (-std=c++0x or above)
+#ifdef __GNUC__ // GCC 4.8+, Clang, Idxel and other compilers compatible with GCC (-std=c++0x or above)
 [[noreturn]] inline __attribute__((always_inline)) void unreachable() {
     assert(false);
     __builtin_unreachable();

--- a/thorin/util/assert.h
+++ b/thorin/util/assert.h
@@ -5,7 +5,7 @@
 namespace thorin {
 
 // see https://stackoverflow.com/a/65258501
-#ifdef __GNUC__ // GCC 4.8+, Clang, Idxel and other compilers compatible with GCC (-std=c++0x or above)
+#ifdef __GNUC__ // GCC 4.8+, Clang, Intel and other compilers compatible with GCC (-std=c++0x or above)
 [[noreturn]] inline __attribute__((always_inline)) void unreachable() {
     assert(false);
     __builtin_unreachable();

--- a/thorin/world.h
+++ b/thorin/world.h
@@ -306,7 +306,7 @@ public:
     /// @sa core::extract_unsafe
     ///@{
     const Def* extract(const Def* d, const Def* i, const Def* dbg = {});
-    const Def* extract(const Def* d, u64 a, u64 i, const Def* dbg = {}) { return extract(d, lit_int(a, i), dbg); }
+    const Def* extract(const Def* d, u64 a, u64 i, const Def* dbg = {}) { return extract(d, lit_idx(a, i), dbg); }
     const Def* extract(const Def* d, u64 i, const Def* dbg = {}) { return extract(d, as_lit(d->arity()), i, dbg); }
 
     /// Builds `(f, t)cond`.
@@ -321,7 +321,7 @@ public:
     ///@{
     const Def* insert(const Def* d, const Def* i, const Def* val, const Def* dbg = {});
     const Def* insert(const Def* d, u64 a, u64 i, const Def* val, const Def* dbg = {}) {
-        return insert(d, lit_int(a, i), val, dbg);
+        return insert(d, lit_idx(a, i), val, dbg);
     }
     const Def* insert(const Def* d, u64 i, const Def* val, const Def* dbg = {}) {
         return insert(d, as_lit(d->arity()), i, val, dbg);
@@ -331,33 +331,36 @@ public:
     /// @name Lit
     ///@{
     const Lit* lit(const Def* type, u64 val, const Def* dbg = {}) { return unify<Lit>(0, type, val, dbg); }
+    const Lit* lit_univ(u64 level, const Def* dbg = {}) { return lit(univ(), level, dbg); }
+    const Lit* lit_univ_0() { return data_.lit_univ_0_; }
+    const Lit* lit_univ_1() { return data_.lit_univ_1_; }
     const Lit* lit_nat(nat_t a, const Def* dbg = {}) { return lit(type_nat(), a, dbg); }
     const Lit* lit_nat_0() { return data_.lit_nat_0_; }
     const Lit* lit_nat_1() { return data_.lit_nat_1_; }
     const Lit* lit_nat_max() { return data_.lit_nat_max_; }
-    const Lit* lit_int(const Def* type, u64 val, const Def* dbg = {});
-    const Lit* lit_univ(u64 level, const Def* dbg = {}) { return lit(univ(), level, dbg); }
-    const Lit* lit_univ_0() { return data_.lit_univ_0_; }
-    const Lit* lit_univ_1() { return data_.lit_univ_1_; }
+    const Lit* lit_idx(const Def* type, u64 val, const Def* dbg = {});
 
-    /// Constructs Tag::Int Lit @p val via @p width, i.e. converts from *width* to *internal* *mod* value.
-    const Lit* lit_int_width(nat_t width, u64 val, const Def* dbg = {}) {
-        return lit_int(type_int_width(width), val, dbg);
-    }
+    /// Constructs a Lit of type Idx of size @p size.
+    /// @note `size = 0` means `2^64`.
+    const Lit* lit_idx(nat_t size, u64 val, const Def* dbg = {}) { return lit_idx(type_idx(size), val, dbg); }
 
-    /// Constructs Tag::Int Lit @p val with *external* *mod*.
-    /// I.e. if `mod == 0`, it will be adjusted to `uint_t(-1)` (special case for `2^64`).
-    const Lit* lit_int_mod(nat_t mod, u64 val, const Def* dbg = {}) {
-        return lit_int(type_int(mod), mod == 0 ? val : (val % mod), dbg);
-    }
-
-    /// Constructs Tag::Int Lit @p val with *internal* *mod*, i.e. without any conversions - `mod = 0` means `2^64`.
-    /// Use this version if you directly receive an *internal* `mod` which is already converted.
-    const Lit* lit_int(nat_t mod, u64 val, const Def* dbg = {}) { return lit_int(type_int(mod), val, dbg); }
     template<class I>
-    const Lit* lit_int(I val, const Def* dbg = {}) {
+    const Lit* lit_idx(I val, const Def* dbg = {}) {
         static_assert(std::is_integral<I>());
-        return lit_int(type_int(width2mod(sizeof(I) * 8)), val, dbg);
+        return lit_idx(type_idx(bitwidth2size(sizeof(I) * 8)), val, dbg);
+    }
+
+    /// Constructs a Lit @p of type Idx of size $2^width$.
+    /// `val = 64` will be automatically converted to size `0` - the encoding for $2^64$.
+    const Lit* lit_int_(nat_t width, u64 val, const Def* dbg = {}) {
+        return lit_idx(type_int_(width), val, dbg);
+    }
+
+    /// Constructs a Lit of type Idx of size @p mod.
+    /// The value @p val will be adjusted modulo @p mod.
+    /// @note `mod == 0` is the special case for $2^64$ and no modulo will be performed on @p val.
+    const Lit* lit_idx_mod(nat_t mod, u64 val, const Def* dbg = {}) {
+        return lit_idx(type_idx(mod), mod == 0 ? val : (val % mod), dbg);
     }
 
     const Lit* lit_bool(bool val) { return data_.lit_bool_[size_t(val)]; }
@@ -419,10 +422,14 @@ public:
     /// @name types
     ///@{
     const Nat* type_nat() { return data_.type_nat_; }
-    const Int* type_int(const Def* size);
-    const Int* type_int(nat_t size) { return type_int(lit_nat(size)); }
-    const Int* type_int_width(nat_t width) { return type_int(lit_nat(width2mod(width))); }
-    const Int* type_bool() { return data_.type_bool_; }
+    const Idx* type_idx(const Def* size);
+    /// @note `size = 0` means `2^64`.
+    const Idx* type_idx(nat_t size) { return type_idx(lit_nat(size)); }
+
+    /// Constructs a type Idx of size $2^width$.
+    /// `width = 64` will be automatically converted to size `0` - the encoding for $2^64$.
+    const Idx* type_int_(nat_t width) { return type_idx(lit_nat(bitwidth2size(width))); }
+    const Idx* type_bool() { return data_.type_bool_; }
     const Axiom* type_real() { return data_.type_real_; }
     const Def* type_real(const Def* width) { return app(type_real(), width); }
     const Def* type_real(nat_t width) { return type_real(lit_nat(width)); }
@@ -519,7 +526,7 @@ public:
     ///@{
     const Def* op_negate(const Def* a, const Def* dbg = {}) {
         auto w = as_lit(iinfer(a));
-        return op(Bit::_xor, lit_int(w, w - 1_u64), a, dbg);
+        return op(Bit::_xor, lit_idx(w, w - 1_u64), a, dbg);
     }
     const Def* op_rminus(const Def* rmode, const Def* a, const Def* dbg = {}) {
         auto w = as_lit(rinfer(a));
@@ -527,7 +534,7 @@ public:
     }
     const Def* op_wminus(const Def* wmode, const Def* a, const Def* dbg = {}) {
         auto w = as_lit(iinfer(a));
-        return op(Wrap::sub, wmode, lit_int(w, 0), a, dbg);
+        return op(Wrap::sub, wmode, lit_idx(w, 0), a, dbg);
     }
     const Def* op_rminus(nat_t rmode, const Def* a, const Def* dbg = {}) { return op_rminus(lit_nat(rmode), a, dbg); }
     const Def* op_wminus(nat_t wmode, const Def* a, const Def* dbg = {}) { return op_wminus(lit_nat(wmode), a, dbg); }
@@ -545,7 +552,7 @@ public:
         meta     = meta ? meta : bot(type_bot());
         return tuple({sym.str(), loc, meta});
     }
-    const Def* iinfer(const Def* def) { return def->type()->as<Int>()->size(); }
+    const Def* iinfer(const Def* def) { return def->type()->as<Idx>()->size(); }
     const Def* rinfer(const Def* def) { return as<Tag::Real>(def->type())->arg(); }
     ///@}
 
@@ -698,7 +705,7 @@ private:
         const Type* type_0_;
         const Type* type_1_;
         const Bot* type_bot_;
-        const Int* type_bool_;
+        const Idx* type_bool_;
         const Top* top_nat_;
         const Sigma* sigma_;
         const Tuple* tuple_;

--- a/thorin/world.h
+++ b/thorin/world.h
@@ -352,9 +352,7 @@ public:
 
     /// Constructs a Lit @p of type Idx of size $2^width$.
     /// `val = 64` will be automatically converted to size `0` - the encoding for $2^64$.
-    const Lit* lit_int_(nat_t width, u64 val, const Def* dbg = {}) {
-        return lit_idx(type_int_(width), val, dbg);
-    }
+    const Lit* lit_int_(nat_t width, u64 val, const Def* dbg = {}) { return lit_idx(type_int_(width), val, dbg); }
 
     /// Constructs a Lit of type Idx of size @p mod.
     /// The value @p val will be adjusted modulo @p mod.


### PR DESCRIPTION
* `Int` -> `Idx`
* `.Int` -> `.Idx`
* `lit_int_width` -> `lit_int_`
* `type_int_width` -> `type_int_`
* `lit_int` -> `lit_idx`
* `lit_int_mod` -> `lit_idx_mod`
* `type_int` -> `type_idx`

This effectively renames `Int` to `Idx` and uses the term `int w` to refer to an `.Idx 2^w`. Note that I renamed `lit_int_width` to `lit_int_`. This gives you some time to port to the new API and get type errors instead of weird runtime errors.