### PR TITLE
Optimize pipeline

### DIFF
--- a/dialects/core/be/ll/ll.cpp
+++ b/dialects/core/be/ll/ll.cpp
@@ -397,7 +397,7 @@ void Emitter::emit_epilogue(Lam* lam) {
             bb.tail("{} = call {} {}({, })", name, ret_ty, emmited_callee, args);
 
             for (size_t i = 0, e = ret_lam->num_vars(); i != e; ++i) {
-                auto phi   = ret_lam->var(i);
+                auto phi = ret_lam->var(i);
                 if (match<mem::M>(phi->type())) continue;
 
                 auto namei = name;

--- a/dialects/core/be/ll/ll.cpp
+++ b/dialects/core/be/ll/ll.cpp
@@ -396,8 +396,10 @@ void Emitter::emit_epilogue(Lam* lam) {
             auto ret_ty = convert_ret_pi(ret_lam->type());
             bb.tail("{} = call {} {}({, })", name, ret_ty, emmited_callee, args);
 
-            for (size_t i = 1, e = ret_lam->num_vars(); i != e; ++i) {
+            for (size_t i = 0, e = ret_lam->num_vars(); i != e; ++i) {
                 auto phi   = ret_lam->var(i);
+                if (match<mem::M>(phi->type())) continue;
+
                 auto namei = name;
                 if (e > 2) {
                     namei += '.' + std::to_string(i - 1);

--- a/lit/core/pow.thorin
+++ b/lit/core/pow.thorin
@@ -1,0 +1,65 @@
+// RUN: rm -f %t.ll ; \
+// RUN: %thorin -d autodiff %s --output-ll %t.ll --output-thorin - | FileCheck %s
+
+// ./build/bin/thorin -d core ./lit/core/pow.thorin --output-thorin - -VVVV
+.import core;
+.import mem;
+
+.let I32 = %Int 4294967296;
+
+/// if b<=0:
+///     1
+/// else
+///     a*pow(a,b-1)
+/// 
+/// pow(a,b,ret): 
+///     ((pow_else,pow_then)#cmp) ()
+/// then():
+///    ret 1
+/// else():
+///     pow(a,b-1,cont)
+/// cont(v):
+///    ret (a*v)
+/// 
+.cn f [[a:I32, b:I32], ret: .Cn [I32]] = {
+    .cn pow_then [] = {
+        ret (1:I32)
+    };
+    .cn pow_cont [v:I32] = {
+        .let m = %core.wrap.mul (0,4294967296) (a,v);
+        ret m
+    };
+    .cn pow_else [] = {
+        .let b_1 = %core.wrap.sub (0,4294967296) (b,1:I32);
+        f ((a,b_1),pow_cont)
+    };
+    // .let cmp = %core.icmp.sle 4294967296 (b,0:I32);
+    .let cmp = %core.icmp.e 4294967296 (b,0:I32);
+    ((pow_then,pow_else) #cmp) ()
+    // .let x = b;
+    // ret x
+};
+
+.cn .extern main [mem : %mem.M, argc : I32, argv : %mem.Ptr (%mem.Ptr (%Int 256, 0:.Nat), 0:.Nat), return : .Cn [%mem.M, I32]] = {
+
+    .cn ret_cont r::[I32] = {
+        return (mem, r)
+    };
+
+    .let c = (42:I32, 2:I32);
+    f (c,ret_cont)
+};
+
+
+    // .let b = %Wrap_mul (0:.Nat, 4294967296:.Nat) (3:I32, a);
+
+    // .let c = f (42:I32);
+    // return (mem, c)
+
+// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[memId:[_0-9]*]]: %mem.M, (%Int 4294967296), %mem.Ptr (%mem.Ptr ((%Int 256), 0:.Nat), 0:.Nat), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (%Int 4294967296)]] = {
+// CHECK-DAG: _[[appId:[_0-9]*]]: ⊥:★ = return_[[returnEtaId:[_0-9]*]] (mem_[[memId]], 42:(%Int 4294967296));
+// CHECK-DAG: _[[appId]]
+
+// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (%Int 4294967296)] = {
+// CHECK-DAG: return_[[retAppId:[_0-9]*]]: ⊥:★ = return_[[returnId]] _[[returnEtaVarId]];
+// CHECK-DAG: return_[[retAppId]]

--- a/lit/core/pow.thorin
+++ b/lit/core/pow.thorin
@@ -1,12 +1,14 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d autodiff %s --output-ll %t.ll --output-thorin - | FileCheck %s
+// RUN: %thorin -d core %s --output-ll %t.ll --output-thorin - | FileCheck %s
+
+// ./build/bin/thorin -d core ./lit/core/pow.thorin --output-ll test.ll --output-thorin - | FileCheck ./lit/core/pow.thorin
 
 // ./build/bin/thorin -d core ./lit/core/pow.thorin --output-thorin - -VVVV
 // ./build/bin/thorin ./lit/core/pow.thorin --output-thorin - -VVVV
 .import core;
 .import mem;
 
-.let I32 = %Int 4294967296;
+.let I32 = .Idx 4294967296;
 
 /// if b<=0:
 ///     1
@@ -34,14 +36,11 @@
         .let b_1 = %core.wrap.sub (0,4294967296) (b,1:I32);
         f ((a,b_1),pow_cont)
     };
-    // .let cmp = %core.icmp.sle 4294967296 (b,0:I32);
     .let cmp = %core.icmp.e 4294967296 (b,0:I32);
     ((pow_then,pow_else) #cmp) ()
-    // .let x = b;
-    // ret x
 };
 
-.cn .extern main [mem : %mem.M, argc : I32, argv : %mem.Ptr (%mem.Ptr (%Int 256, 0:.Nat), 0:.Nat), return : .Cn [%mem.M, I32]] = {
+.cn .extern main [mem : %mem.M, argc : I32, argv : %mem.Ptr (%mem.Ptr (.Idx 256, 0:.Nat), 0:.Nat), return : .Cn [%mem.M, I32]] = {
 
     .cn ret_cont r::[I32] = {
         return (mem, r)
@@ -52,15 +51,21 @@
 };
 
 
-    // .let b = %Wrap_mul (0:.Nat, 4294967296:.Nat) (3:I32, a);
+// CHECK-DAG: .cn f_{{[0-9_]+}} _{{[0-9_]+}}::[_{{[0-9_]+}}: (.Idx 4294967296), _{{[0-9_]+}}: .Cn (.Idx 4294967296)] = {
+// CHECK-DAG:     .cn _{{[0-9_]+}} _{{[0-9_]+}}: (.Idx 4294967296) = {
+// CHECK-DAG:         _{{[0-9_]+}} _{{[0-9_]+}}
 
-    // .let c = f (42:I32);
-    // return (mem, c)
+// CHECK-DAG:     .cn pow_then_{{[0-9_]+}} [] = {
+// CHECK-DAG:         _{{[0-9_]+}} 1:(.Idx 4294967296)
 
-// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[memId:[_0-9]*]]: %mem.M, (%Int 4294967296), %mem.Ptr (%mem.Ptr ((%Int 256), 0:.Nat), 0:.Nat), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (%Int 4294967296)]] = {
-// CHECK-DAG: _[[appId:[_0-9]*]]: ⊥:★ = return_[[returnEtaId:[_0-9]*]] (mem_[[memId]], 42:(%Int 4294967296));
-// CHECK-DAG: _[[appId]]
+// CHECK-DAG:     .cn pow_cont_{{[0-9_]+}} __{{[0-9_]+}}: (.Idx 4294967296) = {
+// CHECK-DAG:         .let _{{[0-9_]+}}: (.Idx 4294967296) = %core.wrap.mul (0, 4294967296) (42:(.Idx 4294967296), _{{[0-9_]+}});
+// CHECK-DAG:         _{{[0-9_]+}} _{{[0-9_]+}}
 
-// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (%Int 4294967296)] = {
-// CHECK-DAG: return_[[retAppId:[_0-9]*]]: ⊥:★ = return_[[returnId]] _[[returnEtaVarId]];
-// CHECK-DAG: return_[[retAppId]]
+// CHECK-DAG:     .cn pow_else_{{[0-9_]+}} [] = {
+// CHECK-DAG:         .let _{{[0-9_]+}}: (.Idx 4294967296) = %core.wrap.add (0, 4294967296) (4294967295:(.Idx 4294967296), _{{[0-9_]+}});
+// CHECK-DAG:         f_{{[0-9_]+}} (_{{[0-9_]+}}, pow_cont_{{[0-9_]+}})
+
+// CHECK-DAG:     .let _{{[0-9_]+}}: (.Idx 2) = %core.icmp.xyglE 4294967296 (0:(.Idx 4294967296), _{{[0-9_]+}});
+// CHECK-DAG:     (pow_then_{{[0-9_]+}}, pow_else_{{[0-9_]+}})#_{{[0-9_]+}} ()
+

--- a/lit/core/pow.thorin
+++ b/lit/core/pow.thorin
@@ -2,6 +2,7 @@
 // RUN: %thorin -d autodiff %s --output-ll %t.ll --output-thorin - | FileCheck %s
 
 // ./build/bin/thorin -d core ./lit/core/pow.thorin --output-thorin - -VVVV
+// ./build/bin/thorin ./lit/core/pow.thorin --output-thorin - -VVVV
 .import core;
 .import mem;
 

--- a/thorin/fe/parser.cpp
+++ b/thorin/fe/parser.cpp
@@ -755,8 +755,14 @@ void Parser::parse_nom_fun() {
     dom_p->bind(scopes_, lam_var);
 
     if (accept(Tok::Tag::T_assign)) {
-        auto body = parse_expr("body of a lambda");
-        lam->set(false, body);
+        const Def* filter = world().lit_bool(false);
+        auto body         = parse_expr("filter/body of a lambda");
+        if (ahead().tag() == Tok::Tag::T_comma) {
+            eat(Tok::Tag::T_comma);
+            filter = body;
+            body   = parse_expr("body of a lambda");
+        }
+        lam->set(filter, body);
     }
     expect(Tok::Tag::T_semicolon, "end of lambda");
 

--- a/thorin/fe/parser.cpp
+++ b/thorin/fe/parser.cpp
@@ -761,14 +761,8 @@ void Parser::parse_nom_fun() {
     dom_p->bind(scopes_, lam_var);
 
     if (accept(Tok::Tag::T_assign)) {
-        const Def* filter = world().lit_bool(false);
-        auto body         = parse_expr("filter/body of a lambda");
-        if (ahead().tag() == Tok::Tag::T_comma) {
-            eat(Tok::Tag::T_comma);
-            filter = body;
-            body   = parse_expr("body of a lambda");
-        }
-        lam->set(filter, body);
+        auto body = parse_expr("body of a lambda");
+        lam->set(false, body);
     }
     expect(Tok::Tag::T_semicolon, "end of lambda");
 

--- a/thorin/pass/optimize.cpp
+++ b/thorin/pass/optimize.cpp
@@ -50,7 +50,7 @@ void optimize(World& world, PipelineBuilder& builder) {
     builder.extend_opt_phase(200, [](thorin::PassMan& man) { man.add<LamSpec>(); });
     // codegen prep phase
     builder.extend_opt_phase(
-        Codegen_Prep_PHASE, [](thorin::PassMan& man) { man.add<RetWrap>(); }, 50);
+        Codegen_Prep_Phase, [](thorin::PassMan& man) { man.add<RetWrap>(); }, 50);
 
     Pipeline pipe(world);
 

--- a/thorin/pass/optimize.cpp
+++ b/thorin/pass/optimize.cpp
@@ -50,7 +50,7 @@ void optimize(World& world, PipelineBuilder& builder) {
 
     auto passes = builder.passes();
     for (auto p : passes) {
-        world.DLOG("Pass {}", p);
+        // world.DLOG("Pass {}", p);
         pipe.add<PassManPhase>(builder.opt_phase(p, world));
     }
 

--- a/thorin/pass/optimize.cpp
+++ b/thorin/pass/optimize.cpp
@@ -1,22 +1,118 @@
 #include "thorin/pass/optimize.h"
 
+// #include "thorin/pass/pass.h"
+#include "thorin/pass/rw/partial_eval.h"
+#include "thorin/phase/phase.h"
+
+// #include "thorin/pass/fp/beta_red.h"
+// #include "thorin/pass/fp/eta_exp.h"
+// #include "thorin/pass/fp/eta_red.h"
+// #include "thorin/pass/fp/tail_rec_elim.h"
+// #include "thorin/pass/pass.h"
+// #include "thorin/pass/rw/lam_spec.h"
+// #include "thorin/pass/rw/partial_eval.h"
+// #include "thorin/pass/rw/ret_wrap.h"
+// #include "thorin/pass/rw/scalarize.h"
+
+// #include "dialects/mem/passes/fp/copy_prop.h"
+// #include "dialects/mem/passes/fp/ssa_constr.h"
+// #include "dialects/mem/passes/rw/alloc2malloc.h"
+// #include "dialects/mem/passes/rw/remem_elim.h"
+
+#include "thorin/pass/fp/beta_red.h"
+#include "thorin/pass/fp/eta_exp.h"
 #include "thorin/pass/fp/eta_red.h"
 #include "thorin/pass/fp/tail_rec_elim.h"
 #include "thorin/pass/pipelinebuilder.h"
 #include "thorin/pass/rw/lam_spec.h"
+// #include "thorin/pass/rw/partial_eval.h"
+#include "thorin/pass/rw/ret_wrap.h"
 #include "thorin/pass/rw/scalarize.h"
-#include "thorin/phase/phase.h"
 
 namespace thorin {
 
 void optimize(World& world, PipelineBuilder& builder) {
+    builder.extend_opt_phase(0, [](thorin::PassMan& man) { man.add<Scalerize>(); });
+    builder.extend_opt_phase(1, [](thorin::PassMan& man) { man.add<EtaRed>(); });
+    builder.extend_opt_phase(2, [](thorin::PassMan& man) { man.add<TailRecElim>(); });
+
+    // main phase
+    builder.add_opt(100);
+    builder.extend_opt_phase(200, [](thorin::PassMan& man) { man.add<LamSpec>(); });
+    // codegen prep phase
+    builder.extend_opt_phase(300, [](thorin::PassMan& man) { man.add<RetWrap>(); });
+
+    // builder.add_opt(110);
+    // builder.add_opt(120);
+
     Pipeline pipe(world);
-    pipe.add<Scalerize>();
-    pipe.add<EtaRed>();
-    pipe.add<TailRecElim>();
-    pipe.add<PassManPhase>(builder.opt_phase(world));
-    pipe.add<LamSpec>();
-    pipe.add<PassManPhase>(builder.codegen_prep_phase(world));
+
+    auto passes = builder.passes();
+    for (auto p : passes) {
+        world.DLOG("Pass {}", p);
+        pipe.add<PassManPhase>(builder.opt_phase(p, world));
+    }
+
+    // for (auto& p : pipe.phases()) { world.DLOG("Phase {}", p->name()); }
+
+    // pipe.add<PassManPhase>(builder.opt_prep_phase1(world));
+    // pipe.add<Scalerize>();
+    // pipe.add<EtaRed>();
+    // pipe.add<TailRecElim>();
+
+    // {
+    //     auto man = std::make_unique<PassMan>(world);
+    //     // builder.add_opt(*man);
+    //     man->add<PartialEval>();
+    //     man->add<BetaRed>();
+    //     auto er = man->add<EtaRed>();
+    //     auto ee = man->add<EtaExp>(er);
+    //     man->add<Scalerize>(ee);
+    //     man->add<TailRecElim>(er);
+    //     pipe.add<PassManPhase>(std::move(man));
+    // }
+    // // pipe.add<autodiff::AutoDiffEval>();
+    // {
+    //     auto man = std::make_unique<PassMan>(world);
+    //     // builder.add_opt(*man);
+    //     man->add<PartialEval>();
+    //     man->add<BetaRed>();
+    //     auto er = man->add<EtaRed>();
+    //     auto ee = man->add<EtaExp>(er);
+    //     man->add<Scalerize>(ee);
+    //     man->add<TailRecElim>(er);
+    //     pipe.add<PassManPhase>(std::move(man));
+    // }
+    // // pipe.add<autodiff::AutoDiffZero>();
+    // // pipe.add<direct::DS2CPS>();
+    // // pipe.add<direct::CPS2DS>();
+    // {
+    //     auto man = std::make_unique<PassMan>(world);
+    //     // builder.add_opt(*man);
+    //     man->add<PartialEval>();
+    //     man->add<BetaRed>();
+    //     auto er = man->add<EtaRed>();
+    //     auto ee = man->add<EtaExp>(er);
+    //     man->add<Scalerize>(ee);
+    //     man->add<TailRecElim>(er);
+    //     pipe.add<PassManPhase>(std::move(man));
+    // }
+
+    // pipe.add<PassManPhase>(builder.opt_prep_phase2(world));
+    // pipe.add<PassManPhase>(builder.opt_phase(world));
+
+    // pipe.add<LamSpec>();
+
+    // {
+    //     auto man = std::make_unique<PassMan>(world);
+    //     man->add<RetWrap>();
+    //     // zero cleanup
+    //     // external cleanup
+    //     pipe.add<PassManPhase>(std::move(man));
+    // }
+
+    // pipe.add<PassManPhase>(builder.codegen_prep_phase(world));
+    // pipe.add<PassManPhase>(builder.opt_phase2(world));
     pipe.run();
 }
 

--- a/thorin/pass/optimize.cpp
+++ b/thorin/pass/optimize.cpp
@@ -40,7 +40,8 @@ void optimize(World& world, PipelineBuilder& builder) {
     builder.add_opt(100);
     builder.extend_opt_phase(200, [](thorin::PassMan& man) { man.add<LamSpec>(); });
     // codegen prep phase
-    builder.extend_opt_phase(300, [](thorin::PassMan& man) { man.add<RetWrap>(); });
+    builder.extend_opt_phase(
+        300, [](thorin::PassMan& man) { man.add<RetWrap>(); }, 50);
 
     // builder.add_opt(110);
     // builder.add_opt(120);

--- a/thorin/pass/optimize.cpp
+++ b/thorin/pass/optimize.cpp
@@ -1,33 +1,15 @@
 #include "thorin/pass/optimize.h"
 
-// #include "thorin/pass/pass.h"
-#include "thorin/pass/rw/partial_eval.h"
-#include "thorin/phase/phase.h"
-
-// #include "thorin/pass/fp/beta_red.h"
-// #include "thorin/pass/fp/eta_exp.h"
-// #include "thorin/pass/fp/eta_red.h"
-// #include "thorin/pass/fp/tail_rec_elim.h"
-// #include "thorin/pass/pass.h"
-// #include "thorin/pass/rw/lam_spec.h"
-// #include "thorin/pass/rw/partial_eval.h"
-// #include "thorin/pass/rw/ret_wrap.h"
-// #include "thorin/pass/rw/scalarize.h"
-
-// #include "dialects/mem/passes/fp/copy_prop.h"
-// #include "dialects/mem/passes/fp/ssa_constr.h"
-// #include "dialects/mem/passes/rw/alloc2malloc.h"
-// #include "dialects/mem/passes/rw/remem_elim.h"
-
 #include "thorin/pass/fp/beta_red.h"
 #include "thorin/pass/fp/eta_exp.h"
 #include "thorin/pass/fp/eta_red.h"
 #include "thorin/pass/fp/tail_rec_elim.h"
 #include "thorin/pass/pipelinebuilder.h"
 #include "thorin/pass/rw/lam_spec.h"
-// #include "thorin/pass/rw/partial_eval.h"
+#include "thorin/pass/rw/partial_eval.h"
 #include "thorin/pass/rw/ret_wrap.h"
 #include "thorin/pass/rw/scalarize.h"
+#include "thorin/phase/phase.h"
 
 namespace thorin {
 
@@ -36,26 +18,26 @@ namespace thorin {
 /// The passes are added to the phase ordered by their priority
 
 /// Order:
-/// 1-10: initial passes
-/// 100: Main optimization phase (default for extend_opt_phase)
-/// 200: Pre-CodeGen Optimization
-/// 300: CodeGen Preparation (default for extend_codegen_prep_phase)
+/// * 1-10: initial passes
+/// * 100: Main optimization phase (default for extend_opt_phase)
+/// * 200: Pre-CodeGen Optimization
+/// * 300: CodeGen Preparation (default for extend_codegen_prep_phase)
 ///
 /// concrete phases:
-/// 0  : Scalarize
-/// 1  : EtaRed
-/// 2  : TailRecElim
-/// 100: Optimize (Priority 50)
-///        PartialEval
-///        BetaRed
-///        EtaRed
-///        EtaExp
-///        Scalarize
-///        TailRecElim
-///      + Custom (default priority 100)
-/// 200: LamSpec
-/// 300: RetWrap (Priority 50)
-///      + Custom (default priority 100)
+/// * 0  : Scalarize
+/// * 1  : EtaRed
+/// * 2  : TailRecElim
+/// * 100: Optimize (Priority 50)
+///   * PartialEval
+///   * BetaRed
+///   * EtaRed
+///   * EtaExp
+///   * Scalarize
+///   * TailRecElim
+///   * + Custom (default priority 100)
+/// * 200: LamSpec
+/// * 300: RetWrap (Priority 50)
+///   * + Custom (default priority 100)
 
 /// See optimize.h for magic numbers
 void optimize(World& world, PipelineBuilder& builder) {
@@ -64,11 +46,11 @@ void optimize(World& world, PipelineBuilder& builder) {
     builder.extend_opt_phase(2, [](thorin::PassMan& man) { man.add<TailRecElim>(); });
 
     // main phase
-    builder.add_opt(OPT_PHASE);
+    builder.add_opt(Opt_Phase);
     builder.extend_opt_phase(200, [](thorin::PassMan& man) { man.add<LamSpec>(); });
     // codegen prep phase
     builder.extend_opt_phase(
-        CODEGEN_PREP_PHASE, [](thorin::PassMan& man) { man.add<RetWrap>(); }, 50);
+        Codegen_Prep_PHASE, [](thorin::PassMan& man) { man.add<RetWrap>(); }, 50);
 
     Pipeline pipe(world);
 

--- a/thorin/pass/optimize.cpp
+++ b/thorin/pass/optimize.cpp
@@ -31,89 +31,50 @@
 
 namespace thorin {
 
+/// The optimizations proceed in a pipeline ordered by priorities
+/// Each phase is a sequence of passes that are run interleaved
+/// The passes are added to the phase ordered by their priority
+
+/// Order:
+/// 1-10: initial passes
+/// 100: Main optimization phase (default for extend_opt_phase)
+/// 200: Pre-CodeGen Optimization
+/// 300: CodeGen Preparation (default for extend_codegen_prep_phase)
+///
+/// concrete phases:
+/// 0  : Scalarize
+/// 1  : EtaRed
+/// 2  : TailRecElim
+/// 100: Optimize (Priority 50)
+///        PartialEval
+///        BetaRed
+///        EtaRed
+///        EtaExp
+///        Scalarize
+///        TailRecElim
+///      + Custom (default priority 100)
+/// 200: LamSpec
+/// 300: RetWrap (Priority 50)
+///      + Custom (default priority 100)
+
+/// See optimize.h for magic numbers
 void optimize(World& world, PipelineBuilder& builder) {
     builder.extend_opt_phase(0, [](thorin::PassMan& man) { man.add<Scalerize>(); });
     builder.extend_opt_phase(1, [](thorin::PassMan& man) { man.add<EtaRed>(); });
     builder.extend_opt_phase(2, [](thorin::PassMan& man) { man.add<TailRecElim>(); });
 
     // main phase
-    builder.add_opt(100);
+    builder.add_opt(OPT_PHASE);
     builder.extend_opt_phase(200, [](thorin::PassMan& man) { man.add<LamSpec>(); });
     // codegen prep phase
     builder.extend_opt_phase(
-        300, [](thorin::PassMan& man) { man.add<RetWrap>(); }, 50);
-
-    // builder.add_opt(110);
-    // builder.add_opt(120);
+        CODEGEN_PREP_PHASE, [](thorin::PassMan& man) { man.add<RetWrap>(); }, 50);
 
     Pipeline pipe(world);
 
     auto passes = builder.passes();
-    for (auto p : passes) {
-        // world.DLOG("Pass {}", p);
-        pipe.add<PassManPhase>(builder.opt_phase(p, world));
-    }
+    for (auto p : passes) { pipe.add<PassManPhase>(builder.opt_phase(p, world)); }
 
-    // for (auto& p : pipe.phases()) { world.DLOG("Phase {}", p->name()); }
-
-    // pipe.add<PassManPhase>(builder.opt_prep_phase1(world));
-    // pipe.add<Scalerize>();
-    // pipe.add<EtaRed>();
-    // pipe.add<TailRecElim>();
-
-    // {
-    //     auto man = std::make_unique<PassMan>(world);
-    //     // builder.add_opt(*man);
-    //     man->add<PartialEval>();
-    //     man->add<BetaRed>();
-    //     auto er = man->add<EtaRed>();
-    //     auto ee = man->add<EtaExp>(er);
-    //     man->add<Scalerize>(ee);
-    //     man->add<TailRecElim>(er);
-    //     pipe.add<PassManPhase>(std::move(man));
-    // }
-    // // pipe.add<autodiff::AutoDiffEval>();
-    // {
-    //     auto man = std::make_unique<PassMan>(world);
-    //     // builder.add_opt(*man);
-    //     man->add<PartialEval>();
-    //     man->add<BetaRed>();
-    //     auto er = man->add<EtaRed>();
-    //     auto ee = man->add<EtaExp>(er);
-    //     man->add<Scalerize>(ee);
-    //     man->add<TailRecElim>(er);
-    //     pipe.add<PassManPhase>(std::move(man));
-    // }
-    // // pipe.add<autodiff::AutoDiffZero>();
-    // // pipe.add<direct::DS2CPS>();
-    // // pipe.add<direct::CPS2DS>();
-    // {
-    //     auto man = std::make_unique<PassMan>(world);
-    //     // builder.add_opt(*man);
-    //     man->add<PartialEval>();
-    //     man->add<BetaRed>();
-    //     auto er = man->add<EtaRed>();
-    //     auto ee = man->add<EtaExp>(er);
-    //     man->add<Scalerize>(ee);
-    //     man->add<TailRecElim>(er);
-    //     pipe.add<PassManPhase>(std::move(man));
-    // }
-
-    // pipe.add<PassManPhase>(builder.opt_prep_phase2(world));
-    // pipe.add<PassManPhase>(builder.opt_phase(world));
-
-    // pipe.add<LamSpec>();
-
-    // {
-    //     auto man = std::make_unique<PassMan>(world);
-    //     man->add<RetWrap>();
-    //     // zero cleanup
-    //     // external cleanup
-    //     pipe.add<PassManPhase>(std::move(man));
-    // }
-
-    // pipe.add<PassManPhase>(builder.codegen_prep_phase(world));
-    // pipe.add<PassManPhase>(builder.opt_phase2(world));
     pipe.run();
 }
 

--- a/thorin/pass/optimize.h
+++ b/thorin/pass/optimize.h
@@ -2,6 +2,11 @@
 
 namespace thorin {
 
+const int PASS_INTERNAL_PRIORITY = 50;
+const int PASS_DEFAULT_PRIORITY  = 100;
+const int OPT_PHASE              = 100;
+const int CODEGEN_PREP_PHASE     = 300;
+
 class World;
 class PipelineBuilder;
 

--- a/thorin/pass/optimize.h
+++ b/thorin/pass/optimize.h
@@ -5,7 +5,7 @@ namespace thorin {
 static constexpr int Pass_Internal_Priority = 50;
 static constexpr int Pass_Default_Priority  = 100;
 static constexpr int Opt_Phase              = 100;
-static constexpr int Codegen_Prep_PHASE     = 300;
+static constexpr int Codegen_Prep_Phase     = 300;
 
 class World;
 class PipelineBuilder;

--- a/thorin/pass/optimize.h
+++ b/thorin/pass/optimize.h
@@ -2,10 +2,10 @@
 
 namespace thorin {
 
-const int PASS_INTERNAL_PRIORITY = 50;
-const int PASS_DEFAULT_PRIORITY  = 100;
-const int OPT_PHASE              = 100;
-const int CODEGEN_PREP_PHASE     = 300;
+static constexpr int Pass_Internal_Priority = 50;
+static constexpr int Pass_Default_Priority  = 100;
+static constexpr int Opt_Phase              = 100;
+static constexpr int Codegen_Prep_PHASE     = 300;
 
 class World;
 class PipelineBuilder;

--- a/thorin/pass/pipelinebuilder.cpp
+++ b/thorin/pass/pipelinebuilder.cpp
@@ -22,11 +22,11 @@
 
 namespace thorin {
 
-void PipelineBuilder::extend_opt_phase(std::function<void(PassMan&)> extension) {
+void PipelineBuilder::extend_opt_phase(std::function<void(PassMan&)>&& extension) {
     extend_opt_phase(Opt_Phase, std::move(extension));
 }
 
-void PipelineBuilder::extend_codegen_prep_phase(std::function<void(PassMan&)> extension) {
+void PipelineBuilder::extend_codegen_prep_phase(std::function<void(PassMan&)>&& extension) {
     extend_opt_phase(Codegen_Prep_PHASE, std::move(extension));
 }
 

--- a/thorin/pass/pipelinebuilder.cpp
+++ b/thorin/pass/pipelinebuilder.cpp
@@ -66,9 +66,15 @@ std::vector<int> PipelineBuilder::passes() {
 std::unique_ptr<PassMan> PipelineBuilder::opt_phase(int i, World& world) {
     auto man = std::make_unique<PassMan>(world);
 
-    // std::sort(phase_extensions_[i].begin(), phase_extensions_[i].end(), passCmp());
+    std::sort(phase_extensions_[i].begin(), phase_extensions_[i].end(), passCmp());
 
-    for (const auto& ext : phase_extensions_[i]) ext.second(*man);
+    // printf("====\n");
+    for (const auto& ext : phase_extensions_[i]) {
+        // printf("add pass with prio %d\n", ext.first);
+        ext.second(*man);
+    }
+    // printf("====\n");
+    // assert(0);
 
     return man;
 }

--- a/thorin/pass/pipelinebuilder.cpp
+++ b/thorin/pass/pipelinebuilder.cpp
@@ -1,5 +1,12 @@
 #include "thorin/pass/pipelinebuilder.h"
 
+#include <compare>
+
+#include <vector>
+
+#include "thorin/def.h"
+#include "thorin/lattice.h"
+
 #include "thorin/pass/fp/beta_red.h"
 #include "thorin/pass/fp/eta_exp.h"
 #include "thorin/pass/fp/eta_red.h"
@@ -16,34 +23,47 @@
 namespace thorin {
 
 void PipelineBuilder::extend_opt_phase(std::function<void(PassMan&)> extension) {
-    opt_phase_extensions_.push_back(extension);
+    extend_opt_phase(100, std::move(extension));
 }
 
 void PipelineBuilder::extend_codegen_prep_phase(std::function<void(PassMan&)> extension) {
-    codegen_prep_phase_extensions_.push_back(extension);
+    extend_opt_phase(300, std::move(extension));
 }
 
-std::unique_ptr<PassMan> PipelineBuilder::opt_phase(World& world) {
-    auto man = std::make_unique<PassMan>(world);
-
-    man->add<PartialEval>();
-    man->add<BetaRed>();
-    auto er = man->add<EtaRed>();
-    auto ee = man->add<EtaExp>(er);
-    man->add<Scalerize>(ee);
-    man->add<TailRecElim>(er);
-
-    for (const auto& ext : opt_phase_extensions_) ext(*man);
-
-    return man;
+void PipelineBuilder::extend_opt_phase(int i, std::function<void(PassMan&)> extension) {
+    // adds extension to the i-th optimization phase
+    // if the ith phase does not exist, it is created
+    if (phase_extensions_.contains(i)) {
+        phase_extensions_[i].push_back(extension);
+    } else {
+        phase_extensions_[i] = {extension};
+    }
 }
 
-std::unique_ptr<PassMan> PipelineBuilder::codegen_prep_phase(World& world) {
+void PipelineBuilder::add_opt(int i) {
+    extend_opt_phase(i, [](thorin::PassMan& man) {
+        man.add<PartialEval>();
+        man.add<BetaRed>();
+        auto er = man.add<EtaRed>();
+        auto ee = man.add<EtaExp>(er);
+        man.add<Scalerize>(ee);
+        man.add<TailRecElim>(er);
+    });
+}
+
+std::vector<int> PipelineBuilder::passes() {
+    std::vector<int> keys;
+    for (auto iter = phase_extensions_.begin(); iter != phase_extensions_.end(); iter++) {
+        keys.push_back(iter->first);
+    }
+    std::sort(keys.begin(), keys.end());
+    return keys;
+}
+
+std::unique_ptr<PassMan> PipelineBuilder::opt_phase(int i, World& world) {
     auto man = std::make_unique<PassMan>(world);
 
-    man->add<RetWrap>();
-
-    for (const auto& ext : codegen_prep_phase_extensions_) ext(*man);
+    for (const auto& ext : phase_extensions_[i]) ext(*man);
 
     return man;
 }

--- a/thorin/pass/pipelinebuilder.cpp
+++ b/thorin/pass/pipelinebuilder.cpp
@@ -33,8 +33,11 @@ void PipelineBuilder::extend_codegen_prep_phase(std::function<void(PassMan&)> ex
 void PipelineBuilder::extend_opt_phase(int i, std::function<void(PassMan&)> extension, int priority) {
     // adds extension to the i-th optimization phase
     // if the ith phase does not exist, it is created
-    if (!phase_extensions_.contains(i)) { phase_extensions_.emplace(i, std::vector<std::function<void(PassMan&)>>()); }
-    phase_extensions_[i].push({priority, extension});
+    if (!phase_extensions_.contains(i)) {
+        // phase_extensions_.emplace(i, std::vector<>());
+        phase_extensions_[i] = std::vector<PrioPassBuilder>();
+    }
+    phase_extensions_[i].push_back({priority, extension});
 }
 
 void PipelineBuilder::add_opt(int i) {
@@ -63,7 +66,9 @@ std::vector<int> PipelineBuilder::passes() {
 std::unique_ptr<PassMan> PipelineBuilder::opt_phase(int i, World& world) {
     auto man = std::make_unique<PassMan>(world);
 
-    for (const auto& ext : phase_extensions_[i]) ext(*man);
+    // std::sort(phase_extensions_[i].begin(), phase_extensions_[i].end(), passCmp());
+
+    for (const auto& ext : phase_extensions_[i]) ext.second(*man);
 
     return man;
 }

--- a/thorin/pass/pipelinebuilder.cpp
+++ b/thorin/pass/pipelinebuilder.cpp
@@ -23,11 +23,11 @@
 namespace thorin {
 
 void PipelineBuilder::extend_opt_phase(std::function<void(PassMan&)> extension) {
-    extend_opt_phase(OPT_PHASE, std::move(extension));
+    extend_opt_phase(Opt_Phase, std::move(extension));
 }
 
 void PipelineBuilder::extend_codegen_prep_phase(std::function<void(PassMan&)> extension) {
-    extend_opt_phase(CODEGEN_PREP_PHASE, std::move(extension));
+    extend_opt_phase(Codegen_Prep_PHASE, std::move(extension));
 }
 
 void PipelineBuilder::extend_opt_phase(int i, std::function<void(PassMan&)> extension, int priority) {
@@ -48,7 +48,7 @@ void PipelineBuilder::add_opt(int i) {
             man.add<Scalerize>(ee);
             man.add<TailRecElim>(er);
         },
-        PASS_INTERNAL_PRIORITY); // elevated priority
+        Pass_Internal_Priority); // elevated priority
 }
 
 std::vector<int> PipelineBuilder::passes() {
@@ -56,7 +56,7 @@ std::vector<int> PipelineBuilder::passes() {
     for (auto iter = phase_extensions_.begin(); iter != phase_extensions_.end(); iter++) {
         keys.push_back(iter->first);
     }
-    std::sort(keys.begin(), keys.end());
+    std::ranges::sort(keys);
     return keys;
 }
 

--- a/thorin/pass/pipelinebuilder.cpp
+++ b/thorin/pass/pipelinebuilder.cpp
@@ -23,11 +23,11 @@
 namespace thorin {
 
 void PipelineBuilder::extend_opt_phase(std::function<void(PassMan&)>&& extension) {
-    extend_opt_phase(Opt_Phase, std::move(extension));
+    extend_opt_phase(Opt_Phase, extension);
 }
 
 void PipelineBuilder::extend_codegen_prep_phase(std::function<void(PassMan&)>&& extension) {
-    extend_opt_phase(Codegen_Prep_Phase, std::move(extension));
+    extend_opt_phase(Codegen_Prep_Phase, extension);
 }
 
 void PipelineBuilder::extend_opt_phase(int i, std::function<void(PassMan&)> extension, int priority) {

--- a/thorin/pass/pipelinebuilder.cpp
+++ b/thorin/pass/pipelinebuilder.cpp
@@ -27,7 +27,7 @@ void PipelineBuilder::extend_opt_phase(std::function<void(PassMan&)>&& extension
 }
 
 void PipelineBuilder::extend_codegen_prep_phase(std::function<void(PassMan&)>&& extension) {
-    extend_opt_phase(Codegen_Prep_PHASE, std::move(extension));
+    extend_opt_phase(Codegen_Prep_Phase, std::move(extension));
 }
 
 void PipelineBuilder::extend_opt_phase(int i, std::function<void(PassMan&)> extension, int priority) {

--- a/thorin/pass/pipelinebuilder.h
+++ b/thorin/pass/pipelinebuilder.h
@@ -7,11 +7,21 @@
 
 namespace thorin {
 
+typedef std::function<void(PassMan&)> PassBuilder;
+typedef std::pair<int, PassBuilder> PrioPassBuilder;
+typedef std::vector<PrioPassBuilder> PassList;
+
+struct passCmp {
+    constexpr bool operator()(PrioPassBuilder const& a, PrioPassBuilder const& b) const noexcept {
+        return a.first > b.first;
+    }
+};
+
 class PipelineBuilder {
 public:
     explicit PipelineBuilder() {}
 
-    void extend_opt_phase(int i, std::function<void(PassMan&)>);
+    void extend_opt_phase(int i, std::function<void(PassMan&)>, int priority = DEFAULT_PRIORITY);
     void extend_opt_phase(std::function<void(PassMan&)>);
     void add_opt(int i);
     void extend_codegen_prep_phase(std::function<void(PassMan&)>);
@@ -28,10 +38,11 @@ public:
     std::vector<int> passes();
 
 private:
-    std::map<int, std::vector<std::function<void(PassMan&)>>> phase_extensions_;
-    // std::vector<std::function<void(PassMan&)>> codegen_prep_phase_extensions_;
+    std::map<int, std::priority_queue<PrioPassBuilder, PassList, passCmp>> phase_extensions_;
+    // std::vector<std::function<void(PassM#an&)>> codegen_prep_phase_extensions_;
     // std::vector<std::function<void(PassMan&)>> opt_prep_phase1_extensions_;
     // std::vector<std::function<void(PassMan&)>> opt_prep_phase2_extensions_;
+    const int DEFAULT_PRIORITY = 100;
 };
 
 } // namespace thorin

--- a/thorin/pass/pipelinebuilder.h
+++ b/thorin/pass/pipelinebuilder.h
@@ -7,6 +7,7 @@
 
 namespace thorin {
 
+const int DEFAULT_PRIORITY = 100;
 typedef std::function<void(PassMan&)> PassBuilder;
 typedef std::pair<int, PassBuilder> PrioPassBuilder;
 typedef std::vector<PrioPassBuilder> PassList;
@@ -38,11 +39,10 @@ public:
     std::vector<int> passes();
 
 private:
-    std::map<int, std::priority_queue<PrioPassBuilder, PassList, passCmp>> phase_extensions_;
+    std::map<int, PassList> phase_extensions_;
     // std::vector<std::function<void(PassM#an&)>> codegen_prep_phase_extensions_;
     // std::vector<std::function<void(PassMan&)>> opt_prep_phase1_extensions_;
     // std::vector<std::function<void(PassMan&)>> opt_prep_phase2_extensions_;
-    const int DEFAULT_PRIORITY = 100;
 };
 
 } // namespace thorin

--- a/thorin/pass/pipelinebuilder.h
+++ b/thorin/pass/pipelinebuilder.h
@@ -22,7 +22,7 @@ class PipelineBuilder {
 public:
     explicit PipelineBuilder() {}
 
-    void extend_opt_phase(int i, std::function<void(PassMan&)>, int priority = PASS_DEFAULT_PRIORITY);
+    void extend_opt_phase(int i, std::function<void(PassMan&)>, int priority = Pass_Default_Priority);
     void extend_opt_phase(std::function<void(PassMan&)>);
     void add_opt(int i);
     void extend_codegen_prep_phase(std::function<void(PassMan&)>);

--- a/thorin/pass/pipelinebuilder.h
+++ b/thorin/pass/pipelinebuilder.h
@@ -14,7 +14,7 @@ typedef std::vector<PrioPassBuilder> PassList;
 
 struct passCmp {
     constexpr bool operator()(PrioPassBuilder const& a, PrioPassBuilder const& b) const noexcept {
-        return a.first > b.first;
+        return a.first < b.first;
     }
 };
 

--- a/thorin/pass/pipelinebuilder.h
+++ b/thorin/pass/pipelinebuilder.h
@@ -11,15 +11,27 @@ class PipelineBuilder {
 public:
     explicit PipelineBuilder() {}
 
+    void extend_opt_phase(int i, std::function<void(PassMan&)>);
     void extend_opt_phase(std::function<void(PassMan&)>);
+    void add_opt(int i);
     void extend_codegen_prep_phase(std::function<void(PassMan&)>);
+    // void extend_opt_prep_phase1(std::function<void(PassMan&)>);
+    // void extend_opt_prep_phase2(std::function<void(PassMan&)>);
 
-    std::unique_ptr<PassMan> opt_phase(World& world);
-    std::unique_ptr<PassMan> codegen_prep_phase(World& world);
+    std::unique_ptr<PassMan> opt_phase(int i, World& world);
+    // std::unique_ptr<PassMan> opt_phase2(World& world);
+    // std::unique_ptr<PassMan> codegen_prep_phase(World& world);
+    // std::unique_ptr<PassMan> opt_prep_phase1(World& world);
+    // std::unique_ptr<PassMan> opt_prep_phase2(World& world);
+    void add_opt(PassMan man);
+
+    std::vector<int> passes();
 
 private:
-    std::vector<std::function<void(PassMan&)>> opt_phase_extensions_;
-    std::vector<std::function<void(PassMan&)>> codegen_prep_phase_extensions_;
+    std::map<int, std::vector<std::function<void(PassMan&)>>> phase_extensions_;
+    // std::vector<std::function<void(PassMan&)>> codegen_prep_phase_extensions_;
+    // std::vector<std::function<void(PassMan&)>> opt_prep_phase1_extensions_;
+    // std::vector<std::function<void(PassMan&)>> opt_prep_phase2_extensions_;
 };
 
 } // namespace thorin

--- a/thorin/pass/pipelinebuilder.h
+++ b/thorin/pass/pipelinebuilder.h
@@ -23,9 +23,9 @@ public:
     explicit PipelineBuilder() {}
 
     void extend_opt_phase(int i, std::function<void(PassMan&)>, int priority = Pass_Default_Priority);
-    void extend_opt_phase(std::function<void(PassMan&)>);
+    void extend_opt_phase(std::function<void(PassMan&)>&&);
     void add_opt(int i);
-    void extend_codegen_prep_phase(std::function<void(PassMan&)>);
+    void extend_codegen_prep_phase(std::function<void(PassMan&)>&&);
 
     std::unique_ptr<PassMan> opt_phase(int i, World& world);
     void add_opt(PassMan man);

--- a/thorin/pass/pipelinebuilder.h
+++ b/thorin/pass/pipelinebuilder.h
@@ -3,11 +3,11 @@
 #include <functional>
 #include <vector>
 
+#include "thorin/pass/optimize.h"
 #include "thorin/pass/pass.h"
 
 namespace thorin {
 
-const int DEFAULT_PRIORITY = 100;
 typedef std::function<void(PassMan&)> PassBuilder;
 typedef std::pair<int, PassBuilder> PrioPassBuilder;
 typedef std::vector<PrioPassBuilder> PassList;
@@ -22,27 +22,18 @@ class PipelineBuilder {
 public:
     explicit PipelineBuilder() {}
 
-    void extend_opt_phase(int i, std::function<void(PassMan&)>, int priority = DEFAULT_PRIORITY);
+    void extend_opt_phase(int i, std::function<void(PassMan&)>, int priority = PASS_DEFAULT_PRIORITY);
     void extend_opt_phase(std::function<void(PassMan&)>);
     void add_opt(int i);
     void extend_codegen_prep_phase(std::function<void(PassMan&)>);
-    // void extend_opt_prep_phase1(std::function<void(PassMan&)>);
-    // void extend_opt_prep_phase2(std::function<void(PassMan&)>);
 
     std::unique_ptr<PassMan> opt_phase(int i, World& world);
-    // std::unique_ptr<PassMan> opt_phase2(World& world);
-    // std::unique_ptr<PassMan> codegen_prep_phase(World& world);
-    // std::unique_ptr<PassMan> opt_prep_phase1(World& world);
-    // std::unique_ptr<PassMan> opt_prep_phase2(World& world);
     void add_opt(PassMan man);
 
     std::vector<int> passes();
 
 private:
     std::map<int, PassList> phase_extensions_;
-    // std::vector<std::function<void(PassM#an&)>> codegen_prep_phase_extensions_;
-    // std::vector<std::function<void(PassMan&)>> opt_prep_phase1_extensions_;
-    // std::vector<std::function<void(PassMan&)>> opt_prep_phase2_extensions_;
 };
 
 } // namespace thorin


### PR DESCRIPTION
A new optimization pipeline.
The new pipeline is a strict superset of the old one and exposes at least all of the old interfacing functions.

The optimizations proceed in a pipeline ordered by priorities
Each phase is a sequence of passes that are run interleaved
The passes are added to the phase ordered by their priority
``` 
Order:
1-10: initial passes
100: Main optimization phase (default for extend_opt_phase)
200: Pre-CodeGen Optimization
300: CodeGen Preparation (default for extend_codegen_prep_phase)

concrete phases:
0  : Scalarize
1  : EtaRed
2  : TailRecElim
100: Optimize (Priority 50)
       PartialEval
       BetaRed
       EtaRed
       EtaExp
       Scalarize
       TailRecElim
     + Custom (default priority 100)
200: LamSpec
300: RetWrap (Priority 50)
     + Custom (default priority 100)
``` 


Note: This is still not ideal. 
The numbering is global and needs communication between dialects. 
Additionally, one wants an even more expression format to specify individual dependencies and custom execution orders.