### PR TITLE
Demo dialect

### DIFF
--- a/dialects/CMakeLists.txt
+++ b/dialects/CMakeLists.txt
@@ -82,3 +82,11 @@ add_thorin_dialect(refly
         refly/normalizers.cpp
     INSTALL
 )
+
+add_thorin_dialect(demo
+    SOURCES
+        demo/demo.cpp
+        demo/demo.h
+        demo/normalizers.cpp
+    INSTALL
+)

--- a/dialects/demo/demo.cpp
+++ b/dialects/demo/demo.cpp
@@ -1,0 +1,14 @@
+#include "dialects/demo/demo.h"
+
+#include <thorin/config.h>
+#include <thorin/dialects.h>
+#include <thorin/pass/pass.h>
+
+using namespace thorin;
+
+/// heart of the dialect
+/// registers passes in the different optimization phases
+/// as well as normalizers for the axioms
+extern "C" THORIN_EXPORT thorin::DialectInfo thorin_get_dialect_info() {
+    return {"demo", nullptr, nullptr, [](Normalizers& normalizers) { demo::register_normalizers(normalizers); }};
+}

--- a/dialects/demo/demo.h
+++ b/dialects/demo/demo.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <thorin/world.h>
+
+#include "dialects/demo/autogen.h"
+
+namespace thorin::demo {} // namespace thorin::demo

--- a/dialects/demo/demo.thorin
+++ b/dialects/demo/demo.thorin
@@ -1,0 +1,20 @@
+/// # The demo dialect {#demo}
+///
+/// [TOC]
+///
+/// A minimal demo plugin
+///
+/// ## Dependencies
+///
+/// none
+///
+/// ## Types
+///
+/// none 
+///
+/// ## Operations
+///
+/// ### %demo.const
+/// 
+/// The 42 constant, evaluated using a normalizer
+.ax %demo.constIdx: Π [n:.Nat] -> .Idx n, normalize_const;

--- a/dialects/demo/normalizers.cpp
+++ b/dialects/demo/normalizers.cpp
@@ -7,9 +7,7 @@ namespace thorin::demo {
 const Def* normalize_const(const Def* type, const Def* callee, const Def* arg, const Def* dbg) {
     auto& world = type->world();
 
-    return world.lit_idx(arg, 42);
-
-    return world.raw_app(callee, arg, dbg);
+    return world.lit_idx(world.type_idx(arg), 42);
 }
 
 THORIN_demo_NORMALIZER_IMPL

--- a/dialects/demo/normalizers.cpp
+++ b/dialects/demo/normalizers.cpp
@@ -1,0 +1,17 @@
+#include "thorin/world.h"
+
+#include "dialects/demo/demo.h"
+
+namespace thorin::demo {
+
+const Def* normalize_const(const Def* type, const Def* callee, const Def* arg, const Def* dbg) {
+    auto& world = type->world();
+
+    return world.lit_idx(arg, 42);
+
+    return world.raw_app(callee, arg, dbg);
+}
+
+THORIN_demo_NORMALIZER_IMPL
+
+} // namespace thorin::demo

--- a/lit/CMakeLists.txt
+++ b/lit/CMakeLists.txt
@@ -4,7 +4,7 @@ set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
 configure_file(lit.site.cfg.py.in lit.site.cfg.py @ONLY)
 add_custom_target(check
         COMMAND ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/lit" "${CMAKE_CURRENT_BINARY_DIR}" -v
-        DEPENDS thorin thorin_affine thorin_core thorin_mem thorin_direct thorin_refly)
+        DEPENDS thorin thorin_affine thorin_core thorin_mem thorin_direct thorin_refly thorin_demo)
 
 # We don't want to test python for memory leaks.. :/
 # add_test(NAME lit COMMAND python3 "${CMAKE_CURRENT_SOURCE_DIR}/lit" "${CMAKE_CURRENT_BINARY_DIR}" -v)

--- a/lit/demo/const.thorin
+++ b/lit/demo/const.thorin
@@ -1,0 +1,23 @@
+// RUN: rm -f %t.ll ; \
+// RUN: %thorin -d demo %s --output-ll %t.ll --output-thorin - | FileCheck %s
+
+// ./build/bin/thorin -d demo lit/demo/const.thorin --output-thorin - -VVVV
+
+.import mem;
+.import demo;
+
+.let _32 = 4294967296;
+.let I32 = .Idx _32;
+
+.cn .extern main [mem : %mem.M, argc : I32, argv : %mem.Ptr (%mem.Ptr (.Idx 256, 0:.Nat), 0:.Nat), return : .Cn [%mem.M, I32]] = {
+    .cn ret_cont r::[I32] = return (mem, r);
+
+    .let c = %demo.constIdx _32;
+    ret_cont c
+};
+
+// CHECK-DAG: .cn .extern main _{{[0-9_]+}}::[mem_[[memId:[_0-9]*]]: %mem.M, (.Idx 4294967296), %mem.Ptr (%mem.Ptr ((.Idx 256), 0), 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, (.Idx 4294967296)]] = {
+// CHECK-DAG: return_[[returnEtaId:[_0-9]*]] (mem_[[memId]], 42:(.Idx 4294967296))
+
+// CHECK-DAG: return_[[returnEtaId]] _[[returnEtaVarId:[0-9_]+]]: [%mem.M, (.Idx 4294967296)] = {
+// CHECK-DAG: return_[[returnId]] _[[returnEtaVarId]]


### PR DESCRIPTION
A simple demo dialect without any passes or fancy stuff.

The dialect just adds the axiom
`%demo.constIdx: Π [n:.Nat] -> .Idx n`
and a single test case.

The axiom is resolved to `42` by its normalizer.

This PR addresses #93 