### PR TITLE
make things a bit more consistent with the other dialects

### DIFF
--- a/dialects/autodiff/autodiff.h
+++ b/dialects/autodiff/autodiff.h
@@ -10,7 +10,7 @@ inline const Def* op_autodiff(const Def* fun) {
     World& world = fun->world();
     // We rely on the normalized thorin convention that all arguments in functions are grouped.
     // `cn[[args], cont:=cn[returns]]`
-    return world.app(world.app(world.ax<autodiff>(), fun->type()), fun);
+    return world.app(world.app(world.ax<ad>(), fun->type()), fun);
 }
 
 inline const Def* op_zero(const Def* A) {

--- a/dialects/autodiff/autodiff.thorin
+++ b/dialects/autodiff/autodiff.thorin
@@ -11,23 +11,20 @@
 ///
 /// ## Types
 ///
-.ax %autodiff.tangent_type: * -> *, normalize_tangent_type;
+.ax %autodiff.Tangent: * -> *, normalize_Tangent;
 ///
 /// ## Operations
 ///
-/// ### %autodiff.autodiff
+/// ### %autodiff.ad
 /// 
 /// This axiom operates on functions and types.
 ///
 /// For function types the augmented type is computed: `(T -> U) => (T -> U × (U -> T))`
-.ax %autodiff.autodiff_type: * -> *, 
-    normalize_autodiff_type;
+.ax %autodiff.AD: * -> *, normalize_AD;
 /// On closed terms (functions, operators, ho arguments, registered axioms, etc.) the augmented term is returned.
 /// The augmented term `f'` returns the result together with the pullback.
 /// `autodiff f = f' = λ args. (f args, f*)` 
-.ax %autodiff.autodiff: Π [T: *] -> T -> 
-    %autodiff.autodiff_type T, 
-    normalize_autodiff;
+.ax %autodiff.ad: Π [T: *] -> T -> %autodiff.AD T, normalize_ad;
 ///
 /// ### %autodiff.zero
 /// 

--- a/dialects/autodiff/normalizers.cpp
+++ b/dialects/autodiff/normalizers.cpp
@@ -11,19 +11,19 @@ namespace thorin::autodiff {
 
 /// Currently this normalizer does nothin.
 /// TODO: Maybe we want to handle trivial lookup replacements here.
-const Def* normalize_autodiff(const Def* type, const Def* callee, const Def* arg, const Def* dbg) {
+const Def* normalize_ad(const Def* type, const Def* callee, const Def* arg, const Def* dbg) {
     auto& world = type->world();
     return world.raw_app(callee, arg, dbg);
 }
 
-const Def* normalize_autodiff_type(const Def* type, const Def* callee, const Def* arg, const Def* dbg) {
+const Def* normalize_AD(const Def* type, const Def* callee, const Def* arg, const Def* dbg) {
     auto& world = type->world();
     auto ad_ty  = autodiff_type_fun(arg);
     if (ad_ty) return ad_ty;
     return world.raw_app(callee, arg, dbg);
 }
 
-const Def* normalize_tangent_type(const Def*, const Def*, const Def* arg, const Def*) { return tangent_type_fun(arg); }
+const Def* normalize_Tangent(const Def*, const Def*, const Def* arg, const Def*) { return tangent_type_fun(arg); }
 
 /// Currently this normalizer does nothing.
 /// We usually want to keep zeros as long as possible to avoid unnecessary allocations.

--- a/dialects/autodiff/passes/autodiff_eval.cpp
+++ b/dialects/autodiff/passes/autodiff_eval.cpp
@@ -26,7 +26,7 @@ const Def* AutoDiffEval::derive(const Def* def) {
 }
 
 const Def* AutoDiffEval::rewrite(const Def* def) {
-    if (auto ad_app = match<autodiff>(def); ad_app) {
+    if (auto ad_app = match<ad>(def); ad_app) {
         // callee = autodiff T
         // arg = function of type T
         //   (or operator)

--- a/lit/autodiff/2out.thorin.disabled
+++ b/lit/autodiff/2out.thorin.disabled
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll --output-thorin - | FileCheck %s
+// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll -o - | FileCheck %s
 
 .import core;
 .import autodiff;
@@ -24,7 +24,7 @@
         pb((1:I32,0:I32),pb_ret_cont)
     };
 
-    .let f_diff = %autodiff.autodiff (.Cn [I32,.Cn[I32,I32]]) f;
+    .let f_diff = %autodiff.ad (.Cn [I32,.Cn[I32,I32]]) f;
     .let c = (42:I32);
     f_diff (c,ret_cont)
 };

--- a/lit/autodiff/autodiff_mult_in_call.thorin
+++ b/lit/autodiff/autodiff_mult_in_call.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll --output-thorin - | FileCheck %s
+// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll -o - | FileCheck %s
 
 .import core;
 .import autodiff;
@@ -32,7 +32,7 @@
         pb((1:I32),pb_ret_cont)
     };
 
-    .let f_diff = %autodiff.autodiff (.Cn [[I32,I32],.Cn[I32]]) f;
+    .let f_diff = %autodiff.ad (.Cn [[I32,I32],.Cn[I32]]) f;
 
     .let c = (42:I32,43:I32);
     f_diff (c,ret_cont)

--- a/lit/autodiff/autodiff_mult_in_call2.thorin
+++ b/lit/autodiff/autodiff_mult_in_call2.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll --output-thorin - | FileCheck %s
+// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll -o - | FileCheck %s
 
 .import core;
 .import autodiff;
@@ -29,7 +29,7 @@
         pb((1:I32),pb_ret_cont)
     };
 
-    .let f_diff = %autodiff.autodiff (.Cn [[I32,I32],.Cn[I32]]) f;
+    .let f_diff = %autodiff.ad (.Cn [[I32,I32],.Cn[I32]]) f;
 
     .let c = (42:I32,43:I32);
     f_diff (c,ret_cont)

--- a/lit/autodiff/autodiff_mult_in_call2_2.thorin
+++ b/lit/autodiff/autodiff_mult_in_call2_2.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll --output-thorin - | FileCheck %s
+// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll -o - | FileCheck %s
 
 .import core;
 .import autodiff;
@@ -29,7 +29,7 @@
         pb((1:I32),pb_ret_cont)
     };
 
-    .let f_diff = %autodiff.autodiff (.Cn [[I32,I32],.Cn[I32]]) f;
+    .let f_diff = %autodiff.ad (.Cn [[I32,I32],.Cn[I32]]) f;
 
     .let c = (42:I32,43:I32);
     f_diff (c,ret_cont)

--- a/lit/autodiff/autodiff_mult_in_call2_3.thorin
+++ b/lit/autodiff/autodiff_mult_in_call2_3.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll --output-thorin - | FileCheck %s
+// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll -o - | FileCheck %s
 
 .import core;
 .import autodiff;
@@ -29,7 +29,7 @@
         pb((1:I32),pb_ret_cont)
     };
 
-    .let f_diff = %autodiff.autodiff (.Cn [[I32,I32],.Cn[I32]]) f;
+    .let f_diff = %autodiff.ad (.Cn [[I32,I32],.Cn[I32]]) f;
 
     .let c = (42:I32,43:I32);
     f_diff (c,ret_cont)

--- a/lit/autodiff/autodiff_mult_in_call_cont.thorin
+++ b/lit/autodiff/autodiff_mult_in_call_cont.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll --output-thorin - | FileCheck %s
+// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll -o - | FileCheck %s
 
 .import core;
 .import autodiff;
@@ -28,7 +28,7 @@
         pb((1:I32),pb_ret_cont)
     };
 
-    .let f_diff = %autodiff.autodiff (.Cn [[I32,I32],.Cn[I32]]) f;
+    .let f_diff = %autodiff.ad (.Cn [[I32,I32],.Cn[I32]]) f;
 
     .let c = (42:I32,43:I32);
     f_diff (c,ret_cont)

--- a/lit/autodiff/call_autodiff.thorin
+++ b/lit/autodiff/call_autodiff.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll --output-thorin - | FileCheck %s
+// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll -o - | FileCheck %s
 
 .import core;
 .import autodiff;
@@ -30,7 +30,7 @@
         pb((1:I32),pb_ret_cont)
     };
 
-    .let f_diff = %autodiff.autodiff (.Cn [I32,.Cn[I32]]) f;
+    .let f_diff = %autodiff.ad (.Cn [I32,.Cn[I32]]) f;
     .let f_diff_cast = f_diff;
 
     .let c = (42:I32);

--- a/lit/autodiff/call_autodiff_cont.thorin
+++ b/lit/autodiff/call_autodiff_cont.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d direct -d autodiff  %s --output-ll %t.ll --output-thorin - | FileCheck %s
+// RUN: %thorin -d direct -d autodiff  %s --output-ll %t.ll -o - | FileCheck %s
 
 .import core;
 .import autodiff;
@@ -34,7 +34,7 @@
         pb((1:I32),pb_ret_cont)
     };
 
-    .let f_diff = %autodiff.autodiff (.Cn [I32,.Cn[I32]]) f;
+    .let f_diff = %autodiff.ad (.Cn [I32,.Cn[I32]]) f;
 
     .let c = (42:I32);
     f_diff (c,ret_cont)

--- a/lit/autodiff/general/2out.thorin
+++ b/lit/autodiff/general/2out.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll --output-thorin - | FileCheck %s
+// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll -o - | FileCheck %s
 
 .import core;
 .import autodiff;

--- a/lit/autodiff/general/42.thorin
+++ b/lit/autodiff/general/42.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll --output-thorin - | FileCheck %s
+// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll -o - | FileCheck %s
 
 .import core;
 .import autodiff;

--- a/lit/autodiff/general/add_tuple.thorin
+++ b/lit/autodiff/general/add_tuple.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d autodiff %s --output-ll %t.ll --output-thorin - | FileCheck %s
+// RUN: %thorin -d autodiff %s --output-ll %t.ll -o - | FileCheck %s
 
 .import core;
 .import direct;

--- a/lit/autodiff/general/cps_inline.thorin
+++ b/lit/autodiff/general/cps_inline.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin %s --output-ll %t.ll --output-thorin - | FileCheck %s
+// RUN: %thorin %s --output-ll %t.ll -o - | FileCheck %s
 
 .import mem;
 .import core;

--- a/lit/autodiff/general/ds_inline.thorin
+++ b/lit/autodiff/general/ds_inline.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin %s --output-ll %t.ll --output-thorin - | FileCheck %s
+// RUN: %thorin %s --output-ll %t.ll -o - | FileCheck %s
 
 .import core;
 .import mem;

--- a/lit/autodiff/general/invoke_ds.thorin
+++ b/lit/autodiff/general/invoke_ds.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll --output-thorin - | FileCheck %s
+// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll -o - | FileCheck %s
 
 .import core;
 .import direct;

--- a/lit/autodiff/general/simple_real.thorin.disabled
+++ b/lit/autodiff/general/simple_real.thorin.disabled
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d autodiff %s --output-ll %t.ll --output-thorin - | FileCheck %s
+// RUN: %thorin -d autodiff %s --output-ll %t.ll -o - | FileCheck %s
 
 .import autodiff;
 .import mem;

--- a/lit/autodiff/general/tangent_type_cast.thorin
+++ b/lit/autodiff/general/tangent_type_cast.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d autodiff %s --output-ll %t.ll --output-thorin - | FileCheck %s
+// RUN: %thorin -d autodiff %s --output-ll %t.ll -o - | FileCheck %s
 
 .import core;
 .import mem;
@@ -14,13 +14,13 @@
 
 .cn .extern main [mem : %mem.M, argc : I32, argv : %mem.Ptr (%mem.Ptr (.Idx 256, 0:.Nat), 0:.Nat), return : .Cn [%mem.M, I32]] = {
 
-    .cn ret_cont r::[%autodiff.tangent_type I32] = {
-        .let r2=%core.bitcast (I32,(%autodiff.tangent_type I32)) r;
+    .cn ret_cont r::[%autodiff.Tangent I32] = {
+        .let r2=%core.bitcast (I32,(%autodiff.Tangent I32)) r;
         return (mem, r2)
     };
 
     .cn ret_wrap r::[I32] = {
-        .let r2=%core.bitcast ((%autodiff.tangent_type I32),I32) r;
+        .let r2=%core.bitcast ((%autodiff.Tangent I32),I32) r;
         ret_cont r2
     };
 

--- a/lit/autodiff/general/zero_tuple.thorin
+++ b/lit/autodiff/general/zero_tuple.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d autodiff %s --output-ll %t.ll --output-thorin - | FileCheck %s
+// RUN: %thorin -d autodiff %s --output-ll %t.ll -o - | FileCheck %s
 
 .import core;
 .import direct;

--- a/lit/autodiff/id_autodiff.thorin
+++ b/lit/autodiff/id_autodiff.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll --output-thorin - | FileCheck %s
+// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll -o - | FileCheck %s
 
 .import core;
 .import autodiff;
@@ -23,7 +23,7 @@
         pb((1:I32),pb_ret_cont)
     };
 
-    .let f_diff = %autodiff.autodiff (.Cn [I32,.Cn[I32]]) f;
+    .let f_diff = %autodiff.ad (.Cn [I32,.Cn[I32]]) f;
     .let f_diff_cast = f_diff;
 
     .let c = (43:I32);

--- a/lit/autodiff/id_autodiff_info_out.thorin
+++ b/lit/autodiff/id_autodiff_info_out.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll --output-thorin - | FileCheck %s
+// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll -o - | FileCheck %s
 
 .import core;
 .import autodiff;
@@ -23,7 +23,7 @@
         pb((1:I32),pb_ret_cont)
     };
 
-    .let f_diff = %autodiff.autodiff (.Cn [I32,.Cn[I32]]) f;
+    .let f_diff = %autodiff.ad (.Cn [I32,.Cn[I32]]) f;
     .let f_diff_cast = f_diff;
 
     .let c = (43:I32);

--- a/lit/autodiff/id_autodiff_mult_in.thorin
+++ b/lit/autodiff/id_autodiff_mult_in.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll --output-thorin - | FileCheck %s
+// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll -o - | FileCheck %s
 
 .import core;
 .import autodiff;
@@ -26,7 +26,7 @@
         pb((1:I32),pb_ret_cont)
     };
 
-    .let f_diff = %autodiff.autodiff (.Cn [[I32,I32],.Cn[I32]]) f;
+    .let f_diff = %autodiff.ad (.Cn [[I32,I32],.Cn[I32]]) f;
 
     .let c = (42:I32,43:I32);
     f_diff (c,ret_cont)

--- a/lit/autodiff/id_autodiff_mult_in_mem.thorin
+++ b/lit/autodiff/id_autodiff_mult_in_mem.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll --output-thorin - | FileCheck %s
+// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll -o - | FileCheck %s
 
 .import core;
 .import autodiff;
@@ -26,7 +26,7 @@
         pb((rmem,1:I32),pb_ret_cont)
     };
 
-    .let f_diff = %autodiff.autodiff (.Cn [[%mem.M,[I32,I32]],.Cn[%mem.M,I32]]) f;
+    .let f_diff = %autodiff.ad (.Cn [[%mem.M,[I32,I32]],.Cn[%mem.M,I32]]) f;
 
     .let c = (42:I32,43:I32);
     f_diff ((mem,c),ret_cont)

--- a/lit/autodiff/id_autodiff_mult_in_mult.thorin
+++ b/lit/autodiff/id_autodiff_mult_in_mult.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll --output-thorin - | FileCheck %s
+// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll -o - | FileCheck %s
 
 .import core;
 .import autodiff;
@@ -26,7 +26,7 @@
         pb((1:I32),pb_ret_cont)
     };
 
-    .let f_diff = %autodiff.autodiff (.Cn [[I32,I32],.Cn[I32]]) f;
+    .let f_diff = %autodiff.ad (.Cn [[I32,I32],.Cn[I32]]) f;
 
     .let c = (42:I32,43:I32);
     f_diff (c,ret_cont)

--- a/lit/autodiff/id_autodiff_mult_in_mult2.thorin
+++ b/lit/autodiff/id_autodiff_mult_in_mult2.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll --output-thorin - | FileCheck %s
+// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll -o - | FileCheck %s
 
 .import core;
 .import autodiff;
@@ -26,7 +26,7 @@
         pb((1:I32),pb_ret_cont)
     };
 
-    .let f_diff = %autodiff.autodiff (.Cn [[I32,I32],.Cn[I32]]) f;
+    .let f_diff = %autodiff.ad (.Cn [[I32,I32],.Cn[I32]]) f;
 
     .let c = (42:I32,43:I32);
     f_diff (c,ret_cont)

--- a/lit/autodiff/multiply2_autodiff.thorin
+++ b/lit/autodiff/multiply2_autodiff.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll --output-thorin - | FileCheck %s
+// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll -o - | FileCheck %s
 
 .import core;
 .import autodiff;
@@ -26,7 +26,7 @@
         pb((1:I32),pb_ret_cont)
     };
 
-    .let f_diff = %autodiff.autodiff (.Cn [I32,.Cn[I32]]) f;
+    .let f_diff = %autodiff.ad (.Cn [I32,.Cn[I32]]) f;
     .let f_diff_cast = f_diff;
 
     .let c = (42:I32);

--- a/lit/autodiff/multiply_autodiff.thorin
+++ b/lit/autodiff/multiply_autodiff.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll --output-thorin - | FileCheck %s
+// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll -o - | FileCheck %s
 
 .import core;
 .import autodiff;
@@ -24,7 +24,7 @@
         pb((1:I32),pb_ret_cont)
     };
 
-    .let f_diff = %autodiff.autodiff (.Cn [I32,.Cn[I32]]) f;
+    .let f_diff = %autodiff.ad (.Cn [I32,.Cn[I32]]) f;
     .let f_diff_cast = f_diff;
 
     .let c = (42:I32);

--- a/lit/autodiff/multiply_autodiff_cond.thorin
+++ b/lit/autodiff/multiply_autodiff_cond.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll --output-thorin - | FileCheck %s
+// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll -o - | FileCheck %s
 
 .import core;
 .import autodiff;
@@ -32,7 +32,7 @@
         pb((1:I32),pb_ret_cont)
     };
 
-    .let f_diff = %autodiff.autodiff (.Cn [I32,.Cn[I32]]) f;
+    .let f_diff = %autodiff.ad (.Cn [I32,.Cn[I32]]) f;
     .let f_diff_cast = f_diff;
 
     .let c = (4:I32); // 42

--- a/lit/autodiff/multiply_autodiff_cond2.thorin
+++ b/lit/autodiff/multiply_autodiff_cond2.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll --output-thorin - | FileCheck %s
+// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll -o - | FileCheck %s
 
 .import core;
 .import autodiff;
@@ -32,7 +32,7 @@
         pb((1:I32),pb_ret_cont)
     };
 
-    .let f_diff = %autodiff.autodiff (.Cn [I32,.Cn[I32]]) f;
+    .let f_diff = %autodiff.ad (.Cn [I32,.Cn[I32]]) f;
     .let f_diff_cast = f_diff;
 
     .let c = (7:I32); // 42

--- a/lit/autodiff/multiply_autodiff_eval.thorin.eval
+++ b/lit/autodiff/multiply_autodiff_eval.thorin.eval
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d autodiff %s --output-ll %t.ll --output-thorin - | FileCheck %s
+// RUN: %thorin -d autodiff %s --output-ll %t.ll -o - | FileCheck %s
 
 .import autodiff;
 .import core;

--- a/lit/autodiff/multiply_autodiff_eval2.thorin.eval
+++ b/lit/autodiff/multiply_autodiff_eval2.thorin.eval
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d autodiff %s --output-ll %t.ll --output-thorin - | FileCheck %s
+// RUN: %thorin -d autodiff %s --output-ll %t.ll -o - | FileCheck %s
 
 .import autodiff;
 .import core;

--- a/lit/autodiff/pow_autodiff.thorin.disabled
+++ b/lit/autodiff/pow_autodiff.thorin.disabled
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll --output-thorin - | FileCheck %s
+// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll -o - | FileCheck %s
 
 .import core;
 .import autodiff;
@@ -51,7 +51,7 @@
         pb((1:I32),pb_ret_cont)
     };
 
-    .let f_diff = %autodiff.autodiff (.Cn [[I32,I32],.Cn[I32]]) f;
+    .let f_diff = %autodiff.ad (.Cn [[I32,I32],.Cn[I32]]) f;
 
     .let c = (4:I32,3:I32);
     f_diff (c,ret_cont)

--- a/lit/autodiff/second/double_diff.thorin.disabled
+++ b/lit/autodiff/second/double_diff.thorin.disabled
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll --output-thorin - | FileCheck %s
+// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll -o - | FileCheck %s
 
 .import core;
 .import autodiff;
@@ -19,7 +19,7 @@
         };
         pb((1:I32),pb_ret_cont)
     }
-    .let f_diff = %autodiff.autodiff (.Cn [I32,.Cn[I32]]) f;
+    .let f_diff = %autodiff.ad (.Cn [I32,.Cn[I32]]) f;
     f_diff (a, ret_cont)
 };
 
@@ -35,7 +35,7 @@
         pb((1:I32),pb_ret_cont)
     };
 
-    .let f_diff = %autodiff.autodiff (.Cn [I32,.Cn[I32]]) f;
+    .let f_diff = %autodiff.ad (.Cn [I32,.Cn[I32]]) f;
     .let f_diff_cast = f_diff;
 
     .let c = (42:I32);

--- a/lit/autodiff/second/snd_order.thorin.disabled
+++ b/lit/autodiff/second/snd_order.thorin.disabled
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll --output-thorin - | FileCheck %s
+// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll -o - | FileCheck %s
 
 .import core;
 .import autodiff;
@@ -28,7 +28,7 @@
         };
         pb((1:I32),pb_ret_cont)
     };
-    .let g_diff = %autodiff.autodiff (.Cn [I32,.Cn[I32]]) g;
+    .let g_diff = %autodiff.ad (.Cn [I32,.Cn[I32]]) g;
     g_diff (a,ret_cont)
 };
 
@@ -44,7 +44,7 @@
         pb((1:I32),pb_ret_cont)
     };
 
-    .let f_diff = %autodiff.autodiff (.Cn [I32,.Cn[I32]]) f;
+    .let f_diff = %autodiff.ad (.Cn [I32,.Cn[I32]]) f;
     .let f_diff_cast = f_diff;
 
     .let c = (42:I32);

--- a/lit/autodiff/second/snd_order_man.thorin
+++ b/lit/autodiff/second/snd_order_man.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll --output-thorin - | FileCheck %s
+// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll -o - | FileCheck %s
 
 .import core;
 .import autodiff;
@@ -40,7 +40,7 @@
         pb((1:I32),pb_ret_cont)
     };
 
-    .let f_diff = %autodiff.autodiff (.Cn [I32,.Cn[I32]]) f;
+    .let f_diff = %autodiff.ad (.Cn [I32,.Cn[I32]]) f;
     .let f_diff_cast = f_diff;
 
     .let c = (42:I32);

--- a/lit/autodiff/simple_autodiff.thorin
+++ b/lit/autodiff/simple_autodiff.thorin
@@ -1,9 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll --output-thorin - | FileCheck %s
-
-// a call to a autodiff style function
-// ./build/bin/thorin -d direct -d autodiff ./lit/autodiff/simple_autodiff.thorin --output-thorin -
-// ./build/bin/thorin -d direct -d autodiff ./lit/autodiff/simple_autodiff.thorin --output-ll ./lit/autodiff/simple_autodiff.ll --output-thorin - | FileCheck ./lit/autodiff/simple_autodiff.thorin
+// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll -o - | FileCheck %s
 
 .import core;
 .import autodiff;
@@ -27,7 +23,7 @@
         pb((1:I32),pb_ret_cont)
     };
 
-    .let f_diff = %autodiff.autodiff (.Cn [I32,.Cn[I32]]) f;
+    .let f_diff = %autodiff.ad (.Cn [I32,.Cn[I32]]) f;
     .let f_diff_cast = f_diff;
 
     .let c = (43:I32);

--- a/lit/autodiff/square.thorin
+++ b/lit/autodiff/square.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll --output-thorin - | FileCheck %s
+// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll -o - | FileCheck %s
 
 .import core;
 .import autodiff;
@@ -24,7 +24,7 @@
         pb((1:I32),pb_ret_cont)
     };
 
-    .let f_diff = %autodiff.autodiff (.Cn [I32,.Cn[I32]]) f;
+    .let f_diff = %autodiff.ad (.Cn [I32,.Cn[I32]]) f;
     .let f_diff_cast = f_diff;
 
     .let c = (42:I32);

--- a/lit/autodiff/square_autodiff.thorin
+++ b/lit/autodiff/square_autodiff.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll --output-thorin - | FileCheck %s
+// RUN: %thorin -d direct -d autodiff %s --output-ll %t.ll -o - | FileCheck %s
 
 .import core;
 .import autodiff;
@@ -24,7 +24,7 @@
         pb((1:I32),pb_ret_cont)
     };
 
-    .let f_diff = %autodiff.autodiff (.Cn [I32,.Cn[I32]]) f;
+    .let f_diff = %autodiff.ad (.Cn [I32,.Cn[I32]]) f;
     .let f_diff_cast = 
         f_diff;
 

--- a/lit/core/pow.thorin
+++ b/lit/core/pow.thorin
@@ -1,10 +1,6 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d core %s --output-ll %t.ll --output-thorin - | FileCheck %s
+// RUN: %thorin -d core %s --output-ll %t.ll -o - | FileCheck %s
 
-// ./build/bin/thorin -d core ./lit/core/pow.thorin --output-ll test.ll --output-thorin - | FileCheck ./lit/core/pow.thorin
-
-// ./build/bin/thorin -d core ./lit/core/pow.thorin --output-thorin - -VVVV
-// ./build/bin/thorin ./lit/core/pow.thorin --output-thorin - -VVVV
 .import core;
 .import mem;
 

--- a/lit/demo/const.thorin
+++ b/lit/demo/const.thorin
@@ -1,7 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d demo %s --output-ll %t.ll --output-thorin - | FileCheck %s
-
-// ./build/bin/thorin -d demo lit/demo/const.thorin --output-thorin - -VVVV
+// RUN: %thorin -d demo %s --output-ll %t.ll -o - | FileCheck %s
 
 .import mem;
 .import demo;

--- a/lit/direct/Issue.txt
+++ b/lit/direct/Issue.txt
@@ -1,5 +1,5 @@
 ds2cps_ax_cps2ds_dependent.thorin
-./build/bin/thorin -d direct ./lit/direct/ds2cps_ax_cps2ds_dependent.thorin --output-thorin - -VVVV
+./build/bin/thorin -d direct ./lit/direct/ds2cps_ax_cps2ds_dependent.thorin -o - -VVVV
 
 ./lit/direct/ds2cps_ax_cps2ds_dependent.thorin:32:14-32:47: error: cannot pass argument 'f_258568' of type 
 '.Cn [n_258456: .Nat, _258468: .Cn (.Idx n_258456)]' to '%direct.cps2ds_dep (.Nat, U_259700)' of domain 

--- a/lit/parse_output_parse.thorin
+++ b/lit/parse_output_parse.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll %t.thorin ; \
-// RUN: %thorin --output-thorin - %s > %t.thorin && %thorin %t.thorin --output-ll %t.ll -o - | FileCheck %s
+// RUN: %thorin -o - %s > %t.thorin && %thorin %t.thorin --output-ll %t.ll -o - | FileCheck %s
 // RUN: clang %t.ll -o %t -Wno-override-module
 // RUN: %t ; test $? -eq 1
 // RUN: %t 1 2 3 ; test $? -eq 4

--- a/lit/refly/debug.thorin
+++ b/lit/refly/debug.thorin
@@ -1,7 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d refly %s --output-ll %t.ll --output-thorin - | FileCheck %s
-
-// ./build/bin/thorin -d refly ./lit/refly/debug.thorin --output-thorin - -VVVV
+// RUN: %thorin -d refly %s --output-ll %t.ll -o - | FileCheck %s
 
 .import refly;
 .import mem;

--- a/lit/refly/debug_perm.thorin
+++ b/lit/refly/debug_perm.thorin
@@ -1,7 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin -d refly %s --output-ll %t.ll --output-thorin - | FileCheck %s
-
-// ./build/bin/thorin -d refly ./lit/refly/debug_perm.thorin --output-thorin - -VVVV
+// RUN: %thorin -d refly %s --output-ll %t.ll -o - | FileCheck %s
 
 .import refly;
 .import mem;


### PR DESCRIPTION
* autodiff.autodiff_type -> autodiff.AD
* autodiff.autodiff -> autodiff.ad
* autodiff.tangent_type -> autodiff.Tangent
* --output-thorin -> -o
* remove some superfluous comments