### PR TITLE
bug fix in llvm for generating certain not operations

### DIFF
--- a/dialects/core/be/ll/ll.cpp
+++ b/dialects/core/be/ll/ll.cpp
@@ -497,13 +497,18 @@ std::string Emitter::emit_bb(BB& bb, const Def* def) {
         unreachable();
     } else if (def->isa<Bot>()) {
         return "undef";
-    } else if (auto bit = match<core::bit2>(def)) {
-        auto [a, b] = bit->args<2>([this](auto def) { return emit(def); });
-        auto t      = convert(bit->type());
+    } else if (auto bit1 = match<core::bit1>(def)) {
+        assert(bit1.id() == core::bit1::neg);
+        auto x = emit(bit1->arg());
+        auto t = convert(bit1->type());
+        return bb.assign(name, "xor {} -1, {}", t, x);
+    } else if (auto bit2 = match<core::bit2>(def)) {
+        auto [a, b] = bit2->args<2>([this](auto def) { return emit(def); });
+        auto t      = convert(bit2->type());
 
-        auto neg = [&](std::string_view x) { return bb.assign(name + ".neg", "xor {} 0, {}", t, x); };
+        auto neg = [&](std::string_view x) { return bb.assign(name + ".neg", "xor {} -1, {}", t, x); };
 
-        switch (bit.id()) {
+        switch (bit2.id()) {
             // clang-format off
             case core::bit2::_and: return bb.assign(name, "and {} {}, {}", t, a, b);
             case core::bit2:: _or: return bb.assign(name, "or  {} {}, {}", t, a, b);

--- a/lit/core/ret_nand.thorin
+++ b/lit/core/ret_nand.thorin
@@ -1,0 +1,28 @@
+// RUN: rm -f %t.ll ; \
+// RUN: %thorin %s --output-ll %t.ll
+// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %t 3 10 ; test $? -eq 13
+
+.import core;
+.import mem;
+
+.let _32 = 4294967296;
+.let I32 = .Idx _32;
+
+.cn atoi [%mem.M, %mem.Ptr («⊤:.Nat; .Idx 256», 0), .Cn [%mem.M, I32]];
+
+.cn .extern main [mem: %mem.M, argc: I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .Idx 256», 0)», 0), return: .Cn [%mem.M, I32]] = {
+    .cn atoi_cont_a [mem: %mem.M, a: I32] = {
+        .cn atoi_cont_b [mem: %mem.M, b: I32] = {
+                return (mem, %core.bit2._and _32 (0b00000000000000000000000000001111:I32, %core.bit2.nand _32 (a, b)))
+        };
+
+        .let argv_ptr_b = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .Idx 256», 0)›, 0) (argv, 2:I32);
+        .let argv_load_b = %mem.load (%mem.Ptr («⊤:.Nat; .Idx 256», 0), 0) (mem, argv_ptr_b);
+        atoi (argv_load_b#.ff, argv_load_b#.tt, atoi_cont_b)
+    };
+
+    .let argv_ptr_a = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .Idx 256», 0)›, 0) (argv, 1:I32);
+    .let argv_load_a = %mem.load (%mem.Ptr («⊤:.Nat; .Idx 256», 0), 0) (mem, argv_ptr_a);
+    atoi (argv_load_a#.ff, argv_load_a#.tt, atoi_cont_a)
+};


### PR DESCRIPTION
Correct way to do it is:
```
xor -1, x
```
and **NOT**
```
xor 0, x
```
Also added codegen for bit1