### PR TITLE
Remove mem from affine::op_for

### DIFF
--- a/dialects/affine/affine.h
+++ b/dialects/affine/affine.h
@@ -14,15 +14,9 @@ inline const Def* fn_for(World& w, Defs params) {
 
 /// Returns a fully applied affine_for axiom.
 /// See documentation for %affine.For axiom in @ref affine.
-inline const Def* op_for(World& w,
-                         const Def* mem,
-                         const Def* begin,
-                         const Def* end,
-                         const Def* step,
-                         Defs inits,
-                         const Def* body,
-                         const Def* brk) {
+inline const Def*
+op_for(World& w, const Def* begin, const Def* end, const Def* step, Defs inits, const Def* body, const Def* brk) {
     DefArray types(inits.size(), [&](size_t i) { return inits[i]->type(); });
-    return w.app(fn_for(w, types), {mem, begin, end, step, w.tuple(inits), body, brk});
+    return w.app(fn_for(w, types), {begin, end, step, w.tuple(inits), body, brk});
 }
 } // namespace thorin::affine


### PR DESCRIPTION
Mem is now handled in the acc and is therefore obsolete in the op_for call.