### PR TITLE
Enable valgrind for LIT tests

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -59,9 +59,14 @@ jobs:
           update_packager_index: false
           ccache_options: max_size=500M
           override_cache_key: ubuntu-latest-ccache-${{matrix.build-type}}
-        
-      - name: Configure
+
+      - name: Configure Debug
+        if: matrix.build-type == 'Debug'
         run: CXX=g++-11 cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}} -DTHORIN_BUILD_TESTING=ON
+      
+      - name: Configure Release
+        if: matrix.build-type == 'Release'
+        run: CXX=g++-11 cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}} -DTHORIN_BUILD_TESTING=ON -DTHORIN_LIT_WITH_VALGRIND=ON
 
       - name: Build
         run: cmake --build ${{github.workspace}}/build -v --config ${{matrix.build-type}} --target thorin-gtest thorin thorin_affine

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 option(BUILD_SHARED_LIBS "Build shared libraries." ON)
 option(THORIN_BUILD_DOCS "If ON, Thorin will build the documentation (requires Doxygen)." OFF) 
 option(THORIN_BUILD_TESTING "If ON, Thorin will build all of Thorin's own tests." OFF) 
+option(THORIN_LIT_WITH_VALGRIND "If ON, the Thorin CLI in the lit tests will be run under valgrind." OFF) 
 
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}; shared libs: ${BUILD_SHARED_LIBS}")
 

--- a/lit/CMakeLists.txt
+++ b/lit/CMakeLists.txt
@@ -1,6 +1,12 @@
 find_package(Python3 COMPONENTS Interpreter)
 set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
 
+if(THORIN_LIT_WITH_VALGRIND)
+  set(LIT_VALGRIND_COMMANDLINE "${MEMORYCHECK_COMMAND} ${VALGRIND_COMMAND_OPTIONS} ")
+else()
+  set(LIT_VALGRIND_COMMANDLINE "")
+endif()
+
 configure_file(lit.site.cfg.py.in lit.site.cfg.py @ONLY)
 add_custom_target(check
         COMMAND ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/lit" "${CMAKE_CURRENT_BINARY_DIR}" -v

--- a/lit/lit.site.cfg.py.in
+++ b/lit/lit.site.cfg.py.in
@@ -6,7 +6,7 @@ config.my_obj_root = r'@CMAKE_BINARY_DIR@'
 if sys.platform == "win32":
     config.thorin = r'@CMAKE_BINARY_DIR@/bin/thorin.exe'
 else:
-    config.thorin = r'@CMAKE_BINARY_DIR@/bin/thorin'
+    config.thorin = r'@LIT_VALGRIND_COMMANDLINE@@CMAKE_BINARY_DIR@/bin/thorin'
 
 lit_config.load_config(
         config, os.path.join(config.my_src_root, "lit/lit.cfg.py"))


### PR DESCRIPTION
As discussed in #105: adds a flag to replace `%thorin`  in LIT tests with `valgrind <flags> thorin` instead of just `thorin`.

As running this for Release seems feasible, it is activated in the Linux Release CI.

Fixes #105.