### PR TITLE
Idx size

### DIFF
--- a/dialects/affine/affine.h
+++ b/dialects/affine/affine.h
@@ -9,7 +9,7 @@ namespace thorin::affine {
 /// Returns the affine_for axiom applied with \a params.
 /// See documentation for %affine.For axiom in @ref affine.
 inline const Def* fn_for(World& w, Defs params) {
-    return w.app(w.ax<affine::For>(), {w.lit_nat(bitwidth2size(32)), w.lit_nat(params.size()), w.tuple(params)});
+    return w.app(w.ax<affine::For>(), {w.lit_nat(Idx::bitwidth2size(32)), w.lit_nat(params.size()), w.tuple(params)});
 }
 
 /// Returns a fully applied affine_for axiom.

--- a/dialects/core/be/ll/ll.cpp
+++ b/dialects/core/be/ll/ll.cpp
@@ -470,7 +470,9 @@ std::string Emitter::emit_bb(BB& bb, const Def* def) {
 
         if (auto size = Idx::size(index->type())) {
             if (auto w = Idx::size2bitwidth(size); w && *w < 64) {
-                v_i = bb.assign(name + ".zext", "zext {} {} to i{} ; add one more bit for gep index as it is treated as signed value", t_i, v_i, *w + 1);
+                v_i = bb.assign(name + ".zext",
+                                "zext {} {} to i{} ; add one more bit for gep index as it is treated as signed value",
+                                t_i, v_i, *w + 1);
                 t_i = "i" + std::to_string(*w + 1);
             }
         }

--- a/dialects/core/be/ll/ll.cpp
+++ b/dialects/core/be/ll/ll.cpp
@@ -127,10 +127,9 @@ std::string Emitter::id(const Def* def, bool force_bb /*= false*/) const {
     return "%" + def->unique_name();
 }
 
-
 static size_t size2llbits(const Def* size) {
     if (auto s = isa_lit(size)) {
-        if (*s == 0)                         return 64;
+        if (*s == 0) return 64;
         if (*s <= 0x0000'0000'0000'0002_u64) return 1;
         if (*s <= 0x0000'0000'0000'0100_u64) return 8;
         if (*s <= 0x0000'0000'0001'0000_u64) return 16;

--- a/dialects/core/be/ll/ll.cpp
+++ b/dialects/core/be/ll/ll.cpp
@@ -127,7 +127,7 @@ std::string Emitter::id(const Def* def, bool force_bb /*= false*/) const {
     return "%" + def->unique_name();
 }
 
-static size_t size2llbits(const Def* size) {
+static nat_t size2llbits(const Def* size) {
     if (auto s = isa_lit(size)) {
         if (*s == 0) return 64;
         if (*s <= 0x0000'0000'0000'0002_u64) return 1;
@@ -725,9 +725,9 @@ std::string Emitter::emit_bb(BB& bb, const Def* def) {
         // clang-format on
 
         auto size2width = [&](const Def* type) {
-            if (type->isa<Nat>()) return 64_u64;
+            if (type->isa<Nat>()) return 64_n;
             if (auto size = Idx::size(type)) return size2llbits(size);
-            return 0_u64;
+            return 0_n;
         };
 
         auto src_size = size2width(bitcast->arg()->type());

--- a/dialects/core/normalizers.cpp
+++ b/dialects/core/normalizers.cpp
@@ -576,11 +576,11 @@ const Def* normalize_trait(const Def*, const Def* callee, const Def* type, const
         return world.lit_nat(8); // Gets lowered to function ptr
     } else if (auto size = Idx::size(type)) {
         if (size->isa<Top>()) return world.lit_nat(8);
-        if (auto w = isa_lit(size)) {
-            if (*w == 0) return world.lit_nat(8);
-            if (*w <= 0x0000'0000'0000'0100_u64) return world.lit_nat(1);
-            if (*w <= 0x0000'0000'0001'0000_u64) return world.lit_nat(2);
-            if (*w <= 0x0000'0001'0000'0000_u64) return world.lit_nat(4);
+        if (auto s = isa_lit(size)) {
+            if (*s == 0) return world.lit_nat(8); // i64
+            if (*s <= 0x0000'0000'0000'0100_u64) return world.lit_nat(1);
+            if (*s <= 0x0000'0000'0001'0000_u64) return world.lit_nat(2);
+            if (*s <= 0x0000'0001'0000'0000_u64) return world.lit_nat(4);
             return world.lit_nat(8);
         }
     } else if (auto w = math::isa_f(type)) {

--- a/dialects/core/normalizers.cpp
+++ b/dialects/core/normalizers.cpp
@@ -573,7 +573,7 @@ const Def* normalize_trait(const Def*, const Def* callee, const Def* type, const
     } else if (type->isa<Pi>()) {
         return world.lit_nat(8); // Gets lowered to function ptr
     } else if (auto size = Idx::size(type)) {
-        if (auto s = Idx::size2bitwidth(size)) return world.lit_nat(std::max(1_n, std::bit_ceil(*s) / 8_n));
+        if (auto w = Idx::size2bitwidth(size)) return world.lit_nat(std::max(1_n, std::bit_ceil(*w) / 8_n));
     } else if (auto w = math::isa_f(type)) {
         switch (*w) {
             case 16: return world.lit_nat(2);

--- a/dialects/core/normalizers.cpp
+++ b/dialects/core/normalizers.cpp
@@ -110,7 +110,7 @@ fold(World& world, const Def* type, const Def*& a, const Def*& b, const Def* dbg
 
     if (la && lb) {
         auto size  = as_lit(Idx::size(a->type()));
-        auto width = *size2bitwidth(size);
+        auto width = Idx::size2bitwidth(size);
         bool nsw = false, nuw = false;
         if constexpr (std::is_same_v<Id, wrap>) {
             auto m = as_lit(mode);
@@ -519,21 +519,19 @@ const Def* normalize_conv(const Def* dst_ty, const Def* c, const Def* x, const D
             return world.lit(d_ty, *l % *ld);
         }
 
-        auto sw = size2bitwidth(*ls);
-        auto dw = size2bitwidth(*ld);
+        auto sw = Idx::size2bitwidth(*ls);
+        auto dw = Idx::size2bitwidth(*ld);
 
-        if (sw && dw) {
-            // clang-format off
-            if (false) {}
+        // clang-format off
+        if (false) {}
 #define M(S, D) \
-            else if (S == *sw && D == *dw) return world.lit(d_ty, w2s<D>(thorin::bitcast<w2s<S>>(*l)), dbg);
-            M( 1,  8) M( 1, 16) M( 1, 32) M( 1, 64)
-                      M( 8, 16) M( 8, 32) M( 8, 64)
-                                M(16, 32) M(16, 64)
-                                          M(32, 64)
-            else unreachable();
-            // clang-format on
-        }
+        else if (S == sw && D == dw) return world.lit(d_ty, w2s<D>(thorin::bitcast<w2s<S>>(*l)), dbg);
+        M( 1,  8) M( 1, 16) M( 1, 32) M( 1, 64)
+                  M( 8, 16) M( 8, 32) M( 8, 64)
+                            M(16, 32) M(16, 64)
+                                      M(32, 64)
+        else assert(false && "TODO: conversion between different Idx sizes");
+        // clang-format on
     }
 
     return world.raw_app(callee, x, dbg);
@@ -575,14 +573,7 @@ const Def* normalize_trait(const Def*, const Def* callee, const Def* type, const
     } else if (type->isa<Pi>()) {
         return world.lit_nat(8); // Gets lowered to function ptr
     } else if (auto size = Idx::size(type)) {
-        if (size->isa<Top>()) return world.lit_nat(8);
-        if (auto s = isa_lit(size)) {
-            if (*s == 0) return world.lit_nat(8); // i64
-            if (*s <= 0x0000'0000'0000'0100_u64) return world.lit_nat(1);
-            if (*s <= 0x0000'0000'0001'0000_u64) return world.lit_nat(2);
-            if (*s <= 0x0000'0001'0000'0000_u64) return world.lit_nat(4);
-            return world.lit_nat(8);
-        }
+        if (auto s = Idx::size2bitwidth(size)) return world.lit_nat(std::max(1_n, std::bit_ceil(*s) / 8_n));
     } else if (auto w = math::isa_f(type)) {
         switch (*w) {
             case 16: return world.lit_nat(2);

--- a/dialects/math/normalizers.cpp
+++ b/dialects/math/normalizers.cpp
@@ -380,8 +380,8 @@ const Def* normalize_conv(const Def* dst_ty, const Def* c, const Def* x, const D
         constexpr bool df     = id == conv::f2f || id == conv::s2f || id == conv::u2f;
         constexpr nat_t min_s = sf ? 16 : 1;
         constexpr nat_t min_d = df ? 16 : 1;
-        auto sw               = sf ? isa_f(s_ty) : size2bitwidth(*ls);
-        auto dw               = df ? isa_f(d_ty) : size2bitwidth(*ld);
+        auto sw               = sf ? isa_f(s_ty) : Idx::size2bitwidth(*ls);
+        auto dw               = df ? isa_f(d_ty) : Idx::size2bitwidth(*ld);
 
         if (sw && dw) {
             Res res;

--- a/gtest/test.cpp
+++ b/gtest/test.cpp
@@ -32,7 +32,7 @@ TEST(Zip, fold) {
     auto c = w.tuple({w.tuple({w.lit_idx( 6), w.lit_idx( 8), w.lit_idx(10)}),
                       w.tuple({w.lit_idx(12), w.lit_idx(14), w.lit_idx(16)})});
 
-    auto f = core::fn(core::wrap::add, w.lit_nat(bitwidth2size(32)), 0_n);
+    auto f = core::fn(core::wrap::add, w.lit_nat(Idx::bitwidth2size(32)), 0_n);
     auto i32_t = w.type_int(32);
     auto res = w.app(w.app(w.app(w.ax<core::zip>(), {/*r*/w.lit_nat(2), /*s*/w.tuple({w.lit_nat(2), w.lit_nat(3)})}),
                                              {/*n_i*/ w.lit_nat(2), /*Is*/w.pack(2, i32_t), /*n_o*/w.lit_nat(1), /*Os*/i32_t, f}),
@@ -81,4 +81,27 @@ TEST(Axiom, split) {
     EXPECT_EQ(dialect, "foo");
     EXPECT_EQ(group, "bar");
     EXPECT_EQ(tag, "baz");
+}
+
+TEST(trait, idx) {
+    World w;
+    Normalizers normalizers;
+    auto core_d = Dialect::load("core", {});
+    core_d.register_normalizers(normalizers);
+    fe::Parser::import_module(w, "core", {}, &normalizers);
+
+    EXPECT_EQ(as_lit(op(core::trait::size, w.type_idx(0x0000'0000'0000'00FF_n))), 1);
+    EXPECT_EQ(as_lit(op(core::trait::size, w.type_idx(0x0000'0000'0000'0100_n))), 1);
+    EXPECT_EQ(as_lit(op(core::trait::size, w.type_idx(0x0000'0000'0000'0101_n))), 2);
+
+    EXPECT_EQ(as_lit(op(core::trait::size, w.type_idx(0x0000'0000'0000'FFFF_n))), 2);
+    EXPECT_EQ(as_lit(op(core::trait::size, w.type_idx(0x0000'0000'0001'0000_n))), 2);
+    EXPECT_EQ(as_lit(op(core::trait::size, w.type_idx(0x0000'0000'0001'0001_n))), 4);
+
+    EXPECT_EQ(as_lit(op(core::trait::size, w.type_idx(0x0000'0000'FFFF'FFFF_n))), 4);
+    EXPECT_EQ(as_lit(op(core::trait::size, w.type_idx(0x0000'0001'0000'0000_n))), 4);
+    EXPECT_EQ(as_lit(op(core::trait::size, w.type_idx(0x0000'0001'0000'0001_n))), 8);
+
+    EXPECT_EQ(as_lit(op(core::trait::size, w.type_idx(0xFFFF'FFFF'FFFF'FFFF_n))), 8);
+    EXPECT_EQ(as_lit(op(core::trait::size, w.type_idx(0x0000'0000'0000'0000_n))), 8);
 }

--- a/thorin/def.cpp
+++ b/thorin/def.cpp
@@ -418,6 +418,12 @@ const Def* Idx::size(const Def* def) {
     return nullptr;
 }
 
+std::optional<nat_t> Idx::size2bitwidth(const Def* size) {
+    if (size->isa<Top>()) return 64;
+    if (auto s = isa_lit(size)) return size2bitwidth(*s);
+    return {};
+}
+
 /*
  * Global
  */

--- a/thorin/def.h
+++ b/thorin/def.h
@@ -584,16 +584,10 @@ public:
 
     /// @name convert between Idx::size and bitwidth and vice versa
     ///@{
-    static constexpr nat_t bitwidth2size(nat_t n) {
-        assert(n != 0);
-        return n == 64 ? 0 : (1_n << n);
-    }
-
-    static constexpr nat_t size2bitwidth(nat_t n) {
-        if (n == 0) return 64;
-        return std::bit_width(n - 1_n);
-    }
-
+    // clang-format off
+    static constexpr nat_t bitwidth2size(nat_t n) { assert(n != 0); return n == 64 ? 0 : (1_n << n); }
+    static constexpr nat_t size2bitwidth(nat_t n) { return n == 0 ? 64 : std::bit_width(n - 1_n); }
+    // clang-format on
     static std::optional<nat_t> size2bitwidth(const Def* size);
     ///@}
 

--- a/thorin/def.h
+++ b/thorin/def.h
@@ -582,23 +582,24 @@ public:
     /// Checks if @p def isa `.Idx s` and returns s or `nullptr` otherwise.
     static const Def* size(const Def* def);
 
+    /// @name convert between Idx::size and bitwidth and vice versa
+    ///@{
+    static constexpr nat_t bitwidth2size(nat_t n) {
+        assert(n != 0);
+        return n == 64 ? 0 : (1_n << n);
+    }
+
+    static constexpr nat_t size2bitwidth(nat_t n) {
+        if (n == 0) return 64;
+        return std::bit_width(n - 1_n);
+    }
+
+    static std::optional<nat_t> size2bitwidth(const Def* size);
+    ///@}
+
     static constexpr auto Node = Node::Idx;
     friend class World;
 };
-
-/// @name convert Idx::size to bitwidth and vice versa
-///@{
-constexpr u64 bitwidth2size(u64 n) {
-    assert(n != 0);
-    return n == 64 ? 0 : (1_u64 << n);
-}
-
-constexpr std::optional<u64> size2bitwidth(u64 n) {
-    if (n == 0) return 64;
-    if (std::has_single_bit(n)) return std::bit_width(n - 1_u64);
-    return {};
-}
-///@}
 
 class Proxy : public Def {
 private:

--- a/thorin/util/types.h
+++ b/thorin/util/types.h
@@ -84,7 +84,7 @@ using sub_t     = u8;
 
 /// A `size_t` literal. Use `0_s` to disambiguate `0` from `nullptr`.
 constexpr size_t operator""_s(unsigned long long int i) { return size_t(i); }
-constexpr size_t operator""_n(unsigned long long int i) { return nat_t(i); }
+constexpr nat_t operator""_n(unsigned long long int i) { return nat_t(i); }
 inline /*constexpr*/ f16 operator""_f16(long double d) { return f16(float(d)); } // wait till fixed upstream
 constexpr f32 operator""_f32(long double d) { return f32(d); }
 constexpr f64 operator""_f64(long double d) { return f64(d); }

--- a/thorin/world.h
+++ b/thorin/world.h
@@ -347,12 +347,14 @@ public:
     template<class I>
     const Lit* lit_idx(I val, const Def* dbg = {}) {
         static_assert(std::is_integral<I>());
-        return lit_idx(bitwidth2size(sizeof(I) * 8), val, dbg);
+        return lit_idx(Idx::bitwidth2size(sizeof(I) * 8), val, dbg);
     }
 
     /// Constructs a Lit @p of type Idx of size $2^width$.
     /// `val = 64` will be automatically converted to size `0` - the encoding for $2^64$.
-    const Lit* lit_int(nat_t width, u64 val, const Def* dbg = {}) { return lit_idx(bitwidth2size(width), val, dbg); }
+    const Lit* lit_int(nat_t width, u64 val, const Def* dbg = {}) {
+        return lit_idx(Idx::bitwidth2size(width), val, dbg);
+    }
 
     /// Constructs a Lit of type Idx of size @p mod.
     /// The value @p val will be adjusted modulo @p mod.
@@ -411,7 +413,7 @@ public:
 
     /// Constructs a type Idx of size $2^width$.
     /// `width = 64` will be automatically converted to size `0` - the encoding for $2^64$.
-    const Def* type_int(nat_t width) { return type_idx(lit_nat(bitwidth2size(width))); }
+    const Def* type_int(nat_t width) { return type_idx(lit_nat(Idx::bitwidth2size(width))); }
     const Def* type_bool() { return data_.type_bool_; }
     ///@}
 


### PR DESCRIPTION
Use the smallest available LLVM int type for Thorin .Idx types.