### PR TITLE
RWPhase that writes into the same world

### DIFF
--- a/thorin/phase/phase.cpp
+++ b/thorin/phase/phase.cpp
@@ -9,10 +9,8 @@ void Phase::run() {
 }
 
 void RWPhase::start() {
-    for (const auto& [_, ax] : old_world().axioms()) rewrite(ax);
-    for (const auto& [_, nom] : old_world().externals()) rewrite(nom)->as_nom()->make_external();
-
-    swap(Phase::world_, new_world_);
+    for (const auto& [_, ax] : world().axioms()) rewrite(ax);
+    for (const auto& [_, nom] : world().externals()) rewrite(nom)->as_nom()->make_external();
 }
 
 void FPPhase::start() {
@@ -22,6 +20,16 @@ void FPPhase::start() {
     }
 
     RWPhase::start();
+}
+
+void Cleanup::start() {
+    World new_world(world().state());
+    Rewriter rewriter(new_world);
+
+    for (const auto& [_, ax] : world().axioms()) rewriter.rewrite(ax);
+    for (const auto& [_, nom] : world().externals()) rewriter.rewrite(nom)->as_nom()->make_external();
+
+    swap(world(), new_world);
 }
 
 void Pipeline::start() {

--- a/thorin/phase/phase.h
+++ b/thorin/phase/phase.h
@@ -52,28 +52,21 @@ protected:
 /// @note You can override Rewriter::rewrite, Rewriter::rewrite_structural, and Rewriter::rewrite_nom.
 class RWPhase : public Phase, public Rewriter {
 public:
-    RWPhase(World& old_world, std::string_view name)
-        : Phase(old_world, name, false)
-        , Rewriter(new_world_)
-        , new_world_(old_world.state()) {}
+    RWPhase(World& world, std::string_view name)
+        : Phase(world, name, true)
+        , Rewriter(world) {}
 
+    World& world() { return Phase::world(); }
     void start() override;
-
-    /// @name getters
-    ///@{
-    const World& old_world() const { return Phase::world_; }
-    World& world() { return new_world_; } ///< The "target" World RWPhase::new_world_ is the "default" world.
-    ///@}
-
-protected:
-    World new_world_;
 };
 
 /// Removes unreachable and dead code by rebuilding the whole World into a new one and `swap`ping afterwards.
-class Cleanup : public RWPhase {
+class Cleanup : public Phase {
 public:
     Cleanup(World& world)
-        : RWPhase(world, "cleanup") {}
+        : Phase(world, "cleanup", false) {}
+
+    void start() override;
 };
 
 /// Like a RWPhase but starts with a fixed-point loop of FPPhase::analyze beforehand.


### PR DESCRIPTION
The old `RWPhase` needed to always rewrite everything as it filled a new world. This makes it difficult to **not** rewrite anything. With this change, you can simply opt to return the original def to stop recursing.