### PR TITLE
Bugfix/axiom curry

### DIFF
--- a/dialects/autodiff/auxiliary/autodiff_aux.cpp
+++ b/dialects/autodiff/auxiliary/autodiff_aux.cpp
@@ -146,7 +146,7 @@ const Def* zero_def(const Def* T) {
 const Def* op_sum(const Def* T, DefArray defs) {
     // TODO: assert all are of type T
     auto& world = T->world();
-    return world.raw_app(world.raw_app(world.ax<sum>(), {world.lit_nat(defs.size()), T}), world.tuple(defs));
+    return world.app<false>(world.app<false>(world.ax<sum>(), {world.lit_nat(defs.size()), T}), world.tuple(defs));
 }
 
 } // namespace thorin::autodiff

--- a/dialects/autodiff/auxiliary/autodiff_aux.cpp
+++ b/dialects/autodiff/auxiliary/autodiff_aux.cpp
@@ -146,7 +146,7 @@ const Def* zero_def(const Def* T) {
 const Def* op_sum(const Def* T, DefArray defs) {
     // TODO: assert all are of type T
     auto& world = T->world();
-    return world.app<false>(world.app<false>(world.ax<sum>(), {world.lit_nat(defs.size()), T}), world.tuple(defs));
+    return world.app(world.app(world.ax<sum>(), {world.lit_nat(defs.size()), T}), world.tuple(defs));
 }
 
 } // namespace thorin::autodiff

--- a/dialects/autodiff/auxiliary/autodiff_rewrite_inner.cpp
+++ b/dialects/autodiff/auxiliary/autodiff_rewrite_inner.cpp
@@ -198,14 +198,14 @@ const Def* AutoDiffEval::augment_pack(const Pack* pack, Lam* f, Lam* f_diff) {
     // TODO: special case for const width (special tuple)
 
     // <i:n, cps2ds body_pb (s#i)>
-    app_pb->set(world.app<false>(direct::op_cps2ds_dep(body_pb), world.extract(pb->var((nat_t)0), app_pb->var())));
+    app_pb->set(world.app(direct::op_cps2ds_dep(body_pb), world.extract(pb->var((nat_t)0), app_pb->var())));
 
     world.DLOG("app pb of pack: {} : {}", app_pb, app_pb->type());
 
-    auto sumup = world.app<false>(world.ax<sum>(), {aug_shape, f_arg_ty_diff});
+    auto sumup = world.app(world.ax<sum>(), {aug_shape, f_arg_ty_diff});
     world.DLOG("sumup: {} : {}", sumup, sumup->type());
 
-    pb->app(true, pb->var(1), world.app<false>(sumup, app_pb));
+    pb->app(true, pb->var(1), world.app(sumup, app_pb));
 
     partial_pullback[aug_pack] = pb;
 

--- a/dialects/autodiff/auxiliary/autodiff_rewrite_inner.cpp
+++ b/dialects/autodiff/auxiliary/autodiff_rewrite_inner.cpp
@@ -198,14 +198,14 @@ const Def* AutoDiffEval::augment_pack(const Pack* pack, Lam* f, Lam* f_diff) {
     // TODO: special case for const width (special tuple)
 
     // <i:n, cps2ds body_pb (s#i)>
-    app_pb->set(world.raw_app(direct::op_cps2ds_dep(body_pb), world.extract(pb->var((nat_t)0), app_pb->var())));
+    app_pb->set(world.app<false>(direct::op_cps2ds_dep(body_pb), world.extract(pb->var((nat_t)0), app_pb->var())));
 
     world.DLOG("app pb of pack: {} : {}", app_pb, app_pb->type());
 
-    auto sumup = world.raw_app(world.ax<sum>(), {aug_shape, f_arg_ty_diff});
+    auto sumup = world.app<false>(world.ax<sum>(), {aug_shape, f_arg_ty_diff});
     world.DLOG("sumup: {} : {}", sumup, sumup->type());
 
-    pb->app(true, pb->var(1), world.raw_app(sumup, app_pb));
+    pb->app(true, pb->var(1), world.app<false>(sumup, app_pb));
 
     partial_pullback[aug_pack] = pb;
 

--- a/dialects/autodiff/normalizers.cpp
+++ b/dialects/autodiff/normalizers.cpp
@@ -13,14 +13,14 @@ namespace thorin::autodiff {
 /// TODO: Maybe we want to handle trivial lookup replacements here.
 const Def* normalize_ad(const Def* type, const Def* callee, const Def* arg, const Def* dbg) {
     auto& world = type->world();
-    return world.app<false>(callee, arg, dbg);
+    return world.raw_app(type, callee, arg, dbg);
 }
 
 const Def* normalize_AD(const Def* type, const Def* callee, const Def* arg, const Def* dbg) {
     auto& world = type->world();
     auto ad_ty  = autodiff_type_fun(arg);
     if (ad_ty) return ad_ty;
-    return world.app<false>(callee, arg, dbg);
+    return world.raw_app(type, callee, arg, dbg);
 }
 
 const Def* normalize_Tangent(const Def*, const Def*, const Def* arg, const Def*) { return tangent_type_fun(arg); }
@@ -30,7 +30,7 @@ const Def* normalize_Tangent(const Def*, const Def*, const Def* arg, const Def*)
 /// A high-level addition with zero can be shortened directly.
 const Def* normalize_zero(const Def* type, const Def* callee, const Def* arg, const Def* dbg) {
     auto& world = type->world();
-    return world.app<false>(callee, arg, dbg);
+    return world.raw_app(type, callee, arg, dbg);
 }
 
 /// Currently resolved the full addition.
@@ -85,7 +85,7 @@ const Def* normalize_add(const Def* type, const Def* callee, const Def* arg, con
     }
     // TODO: mem stays here (only resolved after direct simplification)
 
-    return world.app<false>(callee, arg, dbg);
+    return world.raw_app(type, callee, arg, dbg);
 }
 
 const Def* normalize_sum(const Def* type, const Def* callee, const Def* arg, const Def* dbg) {
@@ -105,7 +105,7 @@ const Def* normalize_sum(const Def* type, const Def* callee, const Def* arg, con
     }
     assert(0);
 
-    return world.app<false>(callee, arg, dbg);
+    return world.raw_app(type, callee, arg, dbg);
 }
 
 THORIN_autodiff_NORMALIZER_IMPL

--- a/dialects/autodiff/normalizers.cpp
+++ b/dialects/autodiff/normalizers.cpp
@@ -13,14 +13,14 @@ namespace thorin::autodiff {
 /// TODO: Maybe we want to handle trivial lookup replacements here.
 const Def* normalize_ad(const Def* type, const Def* callee, const Def* arg, const Def* dbg) {
     auto& world = type->world();
-    return world.raw_app(callee, arg, dbg);
+    return world.app<false>(callee, arg, dbg);
 }
 
 const Def* normalize_AD(const Def* type, const Def* callee, const Def* arg, const Def* dbg) {
     auto& world = type->world();
     auto ad_ty  = autodiff_type_fun(arg);
     if (ad_ty) return ad_ty;
-    return world.raw_app(callee, arg, dbg);
+    return world.app<false>(callee, arg, dbg);
 }
 
 const Def* normalize_Tangent(const Def*, const Def*, const Def* arg, const Def*) { return tangent_type_fun(arg); }
@@ -30,7 +30,7 @@ const Def* normalize_Tangent(const Def*, const Def*, const Def* arg, const Def*)
 /// A high-level addition with zero can be shortened directly.
 const Def* normalize_zero(const Def* type, const Def* callee, const Def* arg, const Def* dbg) {
     auto& world = type->world();
-    return world.raw_app(callee, arg, dbg);
+    return world.app<false>(callee, arg, dbg);
 }
 
 /// Currently resolved the full addition.
@@ -85,7 +85,7 @@ const Def* normalize_add(const Def* type, const Def* callee, const Def* arg, con
     }
     // TODO: mem stays here (only resolved after direct simplification)
 
-    return world.raw_app(callee, arg, dbg);
+    return world.app<false>(callee, arg, dbg);
 }
 
 const Def* normalize_sum(const Def* type, const Def* callee, const Def* arg, const Def* dbg) {
@@ -105,7 +105,7 @@ const Def* normalize_sum(const Def* type, const Def* callee, const Def* arg, con
     }
     assert(0);
 
-    return world.raw_app(callee, arg, dbg);
+    return world.app<false>(callee, arg, dbg);
 }
 
 THORIN_autodiff_NORMALIZER_IMPL

--- a/dialects/clos/normalizers.cpp
+++ b/dialects/clos/normalizers.cpp
@@ -5,7 +5,7 @@ namespace thorin::clos {
 template<attr o>
 const Def* normalize_clos(const Def* type, const Def* callee, const Def* arg, const Def* dbg) {
     auto& w = type->world();
-    return o == attr::bot ? arg : w.app<false>(callee, arg, dbg);
+    return o == attr::bot ? arg : w.raw_app(type, callee, arg, dbg);
 }
 
 THORIN_clos_NORMALIZER_IMPL

--- a/dialects/clos/normalizers.cpp
+++ b/dialects/clos/normalizers.cpp
@@ -5,7 +5,7 @@ namespace thorin::clos {
 template<attr o>
 const Def* normalize_clos(const Def* type, const Def* callee, const Def* arg, const Def* dbg) {
     auto& w = type->world();
-    return o == attr::bot ? arg : w.raw_app(callee, arg, dbg);
+    return o == attr::bot ? arg : w.app<false>(callee, arg, dbg);
 }
 
 THORIN_clos_NORMALIZER_IMPL

--- a/dialects/compile/normalizers.cpp
+++ b/dialects/compile/normalizers.cpp
@@ -9,7 +9,7 @@ const Def* normalize_pass_phase(const Def* type, const Def* callee, const Def* a
 
     auto [ax, _] = collect_args(arg);
     if (ax->flags() != flags_t(Axiom::Base<pass_list>)) {
-        // return world.raw_app(callee, arg, dbg);
+        // return world.raw_app(type, callee, arg, dbg);
         // TODO: remove when normalizers are fixed
         if (ax->flags() == flags_t(Axiom::Base<combine_pass_list>)) {
             auto arg_cpl = arg->as<App>();
@@ -23,7 +23,7 @@ const Def* normalize_pass_phase(const Def* type, const Def* callee, const Def* a
     assert(f_ax->flags() == flags_t(Axiom::Base<pass_list>));
     auto n = pass_list_defs.size();
 
-    return world.raw_app(world.raw_app(world.ax<passes_to_phase>(), world.lit_nat(n)), world.tuple(pass_list_defs));
+    return world.raw_app(type, world.raw_app(type, world.ax<passes_to_phase>(), world.lit_nat(n)), world.tuple(pass_list_defs));
 }
 
 /// `combined_phase (phase_list phase1 ... phasen)` -> `phases_to_phase n (phase1, ..., phasen)`
@@ -34,13 +34,13 @@ const Def* normalize_combined_phase(const Def* type, const Def* callee, const De
     assert(ax->flags() == flags_t(Axiom::Base<phase_list>));
     auto n = phase_list_defs.size();
 
-    return world.raw_app(world.raw_app(world.ax<phases_to_phase>(), world.lit_nat(n)), world.tuple(phase_list_defs));
+    return world.raw_app(type, world.raw_app(type, world.ax<phases_to_phase>(), world.lit_nat(n)), world.tuple(phase_list_defs));
 }
 
 /// `single_pass_phase pass` -> `passes_to_phase 1 pass`
 const Def* normalize_single_pass_phase(const Def* type, const Def* callee, const Def* arg, const Def* dbg) {
     auto& world = type->world();
-    return world.raw_app(world.raw_app(world.ax<passes_to_phase>(), world.lit_nat_1()), arg);
+    return world.raw_app(type, world.raw_app(type, world.ax<passes_to_phase>(), world.lit_nat_1()), arg);
 }
 
 /// `combine_pass_list K (pass_list pass11 ... pass1N) ... (pass_list passK1 ... passKM) = pass_list pass11 ... p1N ...
@@ -55,7 +55,7 @@ const Def* normalize_combine_pass_list(const Def* type, const Def* callee, const
         assert(ax->flags() == flags_t(Axiom::Base<pass_list>));
         passes.insert(passes.end(), pass_list_defs.begin(), pass_list_defs.end());
     }
-    return world.raw_app(world.ax<pass_list>(), world.tuple(passes));
+    return world.raw_app(type, world.ax<pass_list>(), world.tuple(passes));
 }
 
 THORIN_compile_NORMALIZER_IMPL

--- a/dialects/compile/normalizers.cpp
+++ b/dialects/compile/normalizers.cpp
@@ -23,7 +23,8 @@ const Def* normalize_pass_phase(const Def* type, const Def* callee, const Def* a
     assert(f_ax->flags() == flags_t(Axiom::Base<pass_list>));
     auto n = pass_list_defs.size();
 
-    return world.raw_app(type, world.raw_app(type, world.ax<passes_to_phase>(), world.lit_nat(n)), world.tuple(pass_list_defs));
+    return world.raw_app(type, world.raw_app(type, world.ax<passes_to_phase>(), world.lit_nat(n)),
+                         world.tuple(pass_list_defs));
 }
 
 /// `combined_phase (phase_list phase1 ... phasen)` -> `phases_to_phase n (phase1, ..., phasen)`
@@ -34,7 +35,8 @@ const Def* normalize_combined_phase(const Def* type, const Def* callee, const De
     assert(ax->flags() == flags_t(Axiom::Base<phase_list>));
     auto n = phase_list_defs.size();
 
-    return world.raw_app(type, world.raw_app(type, world.ax<phases_to_phase>(), world.lit_nat(n)), world.tuple(phase_list_defs));
+    return world.raw_app(type, world.raw_app(type, world.ax<phases_to_phase>(), world.lit_nat(n)),
+                         world.tuple(phase_list_defs));
 }
 
 /// `single_pass_phase pass` -> `passes_to_phase 1 pass`

--- a/dialects/compile/normalizers.cpp
+++ b/dialects/compile/normalizers.cpp
@@ -8,16 +8,7 @@ const Def* normalize_pass_phase(const Def* type, const Def* callee, const Def* a
     auto& world = type->world();
 
     auto [ax, _] = collect_args(arg);
-    if (ax->flags() != flags_t(Axiom::Base<pass_list>)) {
-        // return world.raw_app(type, callee, arg, dbg);
-        // TODO: remove when normalizers are fixed
-        if (ax->flags() == flags_t(Axiom::Base<combine_pass_list>)) {
-            auto arg_cpl = arg->as<App>();
-            arg = normalize_combine_pass_list(arg_cpl->type(), arg_cpl->callee(), arg_cpl->arg(), arg_cpl->dbg());
-        } else {
-            world.ELOG("pass_phase expects a pass_list as argument but got {}", arg);
-        }
-    }
+    assert(ax->flags() == flags_t(Axiom::Base<pass_list>) && "pass_phase expected a pass_list (after normalization)");
 
     auto [f_ax, pass_list_defs] = collect_args(arg);
     assert(f_ax->flags() == flags_t(Axiom::Base<pass_list>));

--- a/dialects/core/normalizers.cpp
+++ b/dialects/core/normalizers.cpp
@@ -190,7 +190,7 @@ const Def* normalize_nop(const Def* type, const Def* callee, const Def* arg, con
         }
     }
 
-    return world.raw_app(callee, arg, dbg);
+    return world.app<false>(callee, arg, dbg);
 }
 
 template<ncmp id>
@@ -219,7 +219,7 @@ const Def* normalize_ncmp(const Def* type, const Def* callee, const Def* arg, co
         }
     }
 
-    return world.raw_app(callee, arg, dbg);
+    return world.app<false>(callee, arg, dbg);
 }
 
 template<icmp id>
@@ -236,7 +236,7 @@ const Def* normalize_icmp(const Def* type, const Def* c, const Def* arg, const D
         if (id == icmp::ne) return world.lit_ff();
     }
 
-    return world.raw_app(callee, {a, b}, dbg);
+    return world.app<false>(callee, {a, b}, dbg);
 }
 
 template<bit1 id>
@@ -255,7 +255,7 @@ const Def* normalize_bit1(const Def* type, const Def* c, const Def* a, const Def
 
     if (l) return world.lit_idx_mod(*s, ~*l);
 
-    return world.raw_app(callee, a, dbg);
+    return world.app<false>(callee, a, dbg);
 }
 
 template<class Id>
@@ -358,7 +358,7 @@ const Def* normalize_bit2(const Def* type, const Def* c, const Def* arg, const D
 
     if (auto res = reassociate<bit2>(id, world, callee, a, b, dbg)) return res;
 
-    return world.raw_app(callee, {a, b}, dbg);
+    return world.app<false>(callee, {a, b}, dbg);
 }
 
 template<shr id>
@@ -391,7 +391,7 @@ const Def* normalize_shr(const Def* type, const Def* c, const Def* arg, const De
         if (ls && lb->get() > *ls) return world.bot(type, dbg);
     }
 
-    return world.raw_app(callee, {a, b}, dbg);
+    return world.app<false>(callee, {a, b}, dbg);
 }
 
 template<wrap id>
@@ -454,7 +454,7 @@ const Def* normalize_wrap(const Def* type, const Def* c, const Def* arg, const D
 
     if (auto res = reassociate<wrap>(id, world, callee, a, b, dbg)) return res;
 
-    return world.raw_app(callee, {a, b}, dbg);
+    return world.app<false>(callee, {a, b}, dbg);
 }
 
 template<div id>
@@ -493,7 +493,7 @@ const Def* normalize_div(const Def* type, const Def* c, const Def* arg, const De
         }
     }
 
-    return world.raw_app(callee, {mem, a, b}, dbg);
+    return world.app<false>(callee, {mem, a, b}, dbg);
 }
 
 template<conv id>
@@ -534,7 +534,7 @@ const Def* normalize_conv(const Def* dst_ty, const Def* c, const Def* x, const D
         // clang-format on
     }
 
-    return world.raw_app(callee, x, dbg);
+    return world.app<false>(callee, x, dbg);
 }
 
 const Def* normalize_bitcast(const Def* dst_t, const Def* callee, const Def* src, const Def* dbg) {
@@ -551,7 +551,7 @@ const Def* normalize_bitcast(const Def* dst_t, const Def* callee, const Def* src
         if (Idx::size(dst_t)) return world.lit(dst_t, lit->get(), dbg);
     }
 
-    return world.raw_app(callee, src, dbg);
+    return world.app<false>(callee, src, dbg);
 }
 
 // TODO I guess we can do that with C++20 <bit>
@@ -609,7 +609,7 @@ const Def* normalize_trait(const Def*, const Def* callee, const Def* type, const
     }
 
 out:
-    return world.raw_app(callee, type, dbg);
+    return world.app<false>(callee, type, dbg);
 }
 
 const Def* normalize_zip(const Def* type, const Def* c, const Def* arg, const Def* dbg) {
@@ -650,7 +650,7 @@ const Def* normalize_zip(const Def* type, const Def* c, const Def* arg, const De
         }
     }
 
-    return w.raw_app(callee, arg, dbg);
+    return w.app<false>(callee, arg, dbg);
 }
 
 template<pe id>
@@ -662,7 +662,7 @@ const Def* normalize_pe(const Def* type, const Def* callee, const Def* arg, cons
         if (arg->dep_const()) return world.lit_tt();
     }
 
-    return world.raw_app(callee, arg, dbg);
+    return world.app<false>(callee, arg, dbg);
 }
 
 THORIN_core_NORMALIZER_IMPL

--- a/dialects/core/normalizers.cpp
+++ b/dialects/core/normalizers.cpp
@@ -190,7 +190,7 @@ const Def* normalize_nop(const Def* type, const Def* callee, const Def* arg, con
         }
     }
 
-    return world.app<false>(callee, arg, dbg);
+    return world.raw_app(type, callee, arg, dbg);
 }
 
 template<ncmp id>
@@ -219,7 +219,7 @@ const Def* normalize_ncmp(const Def* type, const Def* callee, const Def* arg, co
         }
     }
 
-    return world.app<false>(callee, arg, dbg);
+    return world.raw_app(type, callee, arg, dbg);
 }
 
 template<icmp id>
@@ -236,7 +236,7 @@ const Def* normalize_icmp(const Def* type, const Def* c, const Def* arg, const D
         if (id == icmp::ne) return world.lit_ff();
     }
 
-    return world.app<false>(callee, {a, b}, dbg);
+    return world.raw_app(type, callee, {a, b}, dbg);
 }
 
 template<bit1 id>
@@ -255,7 +255,7 @@ const Def* normalize_bit1(const Def* type, const Def* c, const Def* a, const Def
 
     if (l) return world.lit_idx_mod(*s, ~*l);
 
-    return world.app<false>(callee, a, dbg);
+    return world.raw_app(type, callee, a, dbg);
 }
 
 template<class Id>
@@ -358,7 +358,7 @@ const Def* normalize_bit2(const Def* type, const Def* c, const Def* arg, const D
 
     if (auto res = reassociate<bit2>(id, world, callee, a, b, dbg)) return res;
 
-    return world.app<false>(callee, {a, b}, dbg);
+    return world.raw_app(type, callee, {a, b}, dbg);
 }
 
 template<shr id>
@@ -391,7 +391,7 @@ const Def* normalize_shr(const Def* type, const Def* c, const Def* arg, const De
         if (ls && lb->get() > *ls) return world.bot(type, dbg);
     }
 
-    return world.app<false>(callee, {a, b}, dbg);
+    return world.raw_app(type, callee, {a, b}, dbg);
 }
 
 template<wrap id>
@@ -454,7 +454,7 @@ const Def* normalize_wrap(const Def* type, const Def* c, const Def* arg, const D
 
     if (auto res = reassociate<wrap>(id, world, callee, a, b, dbg)) return res;
 
-    return world.app<false>(callee, {a, b}, dbg);
+    return world.raw_app(type, callee, {a, b}, dbg);
 }
 
 template<div id>
@@ -493,30 +493,30 @@ const Def* normalize_div(const Def* type, const Def* c, const Def* arg, const De
         }
     }
 
-    return world.app<false>(callee, {mem, a, b}, dbg);
+    return world.raw_app(type, callee, {mem, a, b}, dbg);
 }
 
 template<conv id>
-const Def* normalize_conv(const Def* dst_ty, const Def* c, const Def* x, const Def* dbg) {
-    auto& world = dst_ty->world();
+const Def* normalize_conv(const Def* dst_t, const Def* c, const Def* x, const Def* dbg) {
+    auto& world = dst_t->world();
     auto callee = c->as<App>();
-    auto s_ty   = x->type()->as<App>();
-    auto d_ty   = dst_ty->as<App>();
-    auto s      = s_ty->arg();
-    auto d      = d_ty->arg();
+    auto s_t    = x->type()->as<App>();
+    auto d_t    = dst_t->as<App>();
+    auto s      = s_t->arg();
+    auto d      = d_t->arg();
     auto ls     = isa_lit(s);
     auto ld     = isa_lit(d);
 
-    if (s_ty == d_ty) return x;
-    if (x->isa<Bot>()) return world.bot(d_ty, dbg);
+    if (s_t == d_t) return x;
+    if (x->isa<Bot>()) return world.bot(d_t, dbg);
     if constexpr (id == conv::s2s) {
-        if (ls && ld && *ld < *ls) return op(conv::u2u, d_ty, x, dbg); // just truncate - we don't care for signedness
+        if (ls && ld && *ld < *ls) return op(conv::u2u, d_t, x, dbg); // just truncate - we don't care for signedness
     }
 
     if (auto l = isa_lit(x); l && ls && ld) {
         if constexpr (id == conv::u2u) {
-            if (*ld == 0) return world.lit(d_ty, *l); // I64
-            return world.lit(d_ty, *l % *ld);
+            if (*ld == 0) return world.lit(d_t, *l); // I64
+            return world.lit(d_t, *l % *ld);
         }
 
         auto sw = Idx::size2bitwidth(*ls);
@@ -525,7 +525,7 @@ const Def* normalize_conv(const Def* dst_ty, const Def* c, const Def* x, const D
         // clang-format off
         if (false) {}
 #define M(S, D) \
-        else if (S == sw && D == dw) return world.lit(d_ty, w2s<D>(thorin::bitcast<w2s<S>>(*l)), dbg);
+        else if (S == sw && D == dw) return world.lit(d_t, w2s<D>(thorin::bitcast<w2s<S>>(*l)), dbg);
         M( 1,  8) M( 1, 16) M( 1, 32) M( 1, 64)
                   M( 8, 16) M( 8, 32) M( 8, 64)
                             M(16, 32) M(16, 64)
@@ -534,7 +534,7 @@ const Def* normalize_conv(const Def* dst_ty, const Def* c, const Def* x, const D
         // clang-format on
     }
 
-    return world.app<false>(callee, x, dbg);
+    return world.raw_app(dst_t, callee, x, dbg);
 }
 
 const Def* normalize_bitcast(const Def* dst_t, const Def* callee, const Def* src, const Def* dbg) {
@@ -551,7 +551,7 @@ const Def* normalize_bitcast(const Def* dst_t, const Def* callee, const Def* src
         if (Idx::size(dst_t)) return world.lit(dst_t, lit->get(), dbg);
     }
 
-    return world.app<false>(callee, src, dbg);
+    return world.raw_app(dst_t, callee, src, dbg);
 }
 
 // TODO I guess we can do that with C++20 <bit>
@@ -609,7 +609,7 @@ const Def* normalize_trait(const Def*, const Def* callee, const Def* type, const
     }
 
 out:
-    return world.app<false>(callee, type, dbg);
+    return world.raw_app(type, callee, type, dbg);
 }
 
 const Def* normalize_zip(const Def* type, const Def* c, const Def* arg, const Def* dbg) {
@@ -650,7 +650,7 @@ const Def* normalize_zip(const Def* type, const Def* c, const Def* arg, const De
         }
     }
 
-    return w.app<false>(callee, arg, dbg);
+    return w.raw_app(type, callee, arg, dbg);
 }
 
 template<pe id>
@@ -662,7 +662,7 @@ const Def* normalize_pe(const Def* type, const Def* callee, const Def* arg, cons
         if (arg->dep_const()) return world.lit_tt();
     }
 
-    return world.app<false>(callee, arg, dbg);
+    return world.raw_app(type, callee, arg, dbg);
 }
 
 THORIN_core_NORMALIZER_IMPL

--- a/dialects/direct/direct.h
+++ b/dialects/direct/direct.h
@@ -33,11 +33,11 @@ inline const Def* op_cps2ds_dep(const Def* f) {
     Uf->set_filter(true);
     Uf->set_body(rewritten_codom);
 
-    auto ax_app = world.raw_app(world.ax<direct::cps2ds_dep>(), {T, Uf});
+    auto ax_app = world.app<false>(world.ax<direct::cps2ds_dep>(), {T, Uf});
 
     world.DLOG("axiom app: {} : {}", ax_app, ax_app->type());
 
-    return world.raw_app(ax_app, f);
+    return world.app<false>(ax_app, f);
 }
 
 } // namespace thorin::direct

--- a/dialects/direct/direct.h
+++ b/dialects/direct/direct.h
@@ -33,11 +33,11 @@ inline const Def* op_cps2ds_dep(const Def* f) {
     Uf->set_filter(true);
     Uf->set_body(rewritten_codom);
 
-    auto ax_app = world.app<false>(world.ax<direct::cps2ds_dep>(), {T, Uf});
+    auto ax_app = world.app(world.ax<direct::cps2ds_dep>(), {T, Uf});
 
     world.DLOG("axiom app: {} : {}", ax_app, ax_app->type());
 
-    return world.app<false>(ax_app, f);
+    return world.app(ax_app, f);
 }
 
 } // namespace thorin::direct

--- a/dialects/direct/direct.thorin
+++ b/dialects/direct/direct.thorin
@@ -22,7 +22,7 @@
 /// This axiom lets the user call a cps function in direct style.
 /// The function is not converted. Only the call site is changed.
 /// 
-.ax %direct.cps2ds: Π [T: *, U: *] -> (.Cn [T, .Cn U]) -> (T -> U), normalize_cps2ds;
+.ax %direct.cps2ds: Π [T: *, U: *] -> (.Cn [T, .Cn U]) -> (T -> U), normalize_cps2ds, 2;
 .ax %direct.cps2ds_dep: Π [T: *, U: T -> *] -> (.Cn [t:T, .Cn ((U t))]) -> (Π [t:T] -> ((U t)));
 ///
 /// ## Compilation Passes and Phases

--- a/dialects/direct/normalizers.cpp
+++ b/dialects/direct/normalizers.cpp
@@ -7,25 +7,9 @@ namespace thorin::direct {
 /// `cps2ds` is directly converted to `op_cps2ds_dep f` in its normalizer.
 const Def* normalize_cps2ds(const Def* type, const Def* callee, const Def* arg, const Def* dbg) {
     auto& world = type->world();
-
-    // Collect all arguments of the application.
-    // For example in
-    // `cps2ds (A,B) f x`
-    // `arg` is `x`
-    // Example2:
-    // `cps2ds (A,B->C) f x y`
-    // `arg` is `y`
-    // `callee` is `cps2ds (A,B->C) f x`
-    // We are mainly interested in `f` here.
-    auto [ax, curry_args] = collect_args(callee);
-    curry_args.push_back(arg);
-    // The function is the second argument (after the type tuple).
-    auto fun = curry_args[1];
-    auto r   = op_cps2ds_dep(fun);
-    for (size_t i = 2; i < curry_args.size(); ++i) r = world.app(r, curry_args[i]);
+    auto fun    = arg;
+    auto r      = op_cps2ds_dep(fun);
     return r;
-
-    return world.raw_app(type, callee, arg, dbg);
 }
 
 THORIN_direct_NORMALIZER_IMPL

--- a/dialects/direct/normalizers.cpp
+++ b/dialects/direct/normalizers.cpp
@@ -39,7 +39,7 @@ const Def* normalize_cps2ds(const Def* type, const Def* callee, const Def* arg, 
     for (size_t i = 2; i < curry_args.size(); ++i) r = world.app(r, curry_args[i]);
     return r;
 
-    return world.app<false>(callee, arg, dbg);
+    return world.raw_app(type, callee, arg, dbg);
 }
 
 THORIN_direct_NORMALIZER_IMPL

--- a/dialects/direct/normalizers.cpp
+++ b/dialects/direct/normalizers.cpp
@@ -39,7 +39,7 @@ const Def* normalize_cps2ds(const Def* type, const Def* callee, const Def* arg, 
     for (size_t i = 2; i < curry_args.size(); ++i) r = world.app(r, curry_args[i]);
     return r;
 
-    return world.raw_app(callee, arg, dbg);
+    return world.app<false>(callee, arg, dbg);
 }
 
 THORIN_direct_NORMALIZER_IMPL

--- a/dialects/math/normalizers.cpp
+++ b/dialects/math/normalizers.cpp
@@ -276,7 +276,7 @@ const Def* normalize_arith(const Def* type, const Def* c, const Def* arg, const 
 
     if (auto res = reassociate<arith>(id, world, callee, a, b, dbg)) return res;
 
-    return world.app<false>(callee, {a, b}, dbg);
+    return world.raw_app(type, callee, {a, b}, dbg);
 }
 
 template<extrema id>
@@ -297,49 +297,49 @@ const Def* normalize_extrema(const Def* type, const Def* c, const Def* arg, cons
         }
     }
 
-    return world.app<false>(c, arg, dbg);
+    return world.raw_app(type, c, arg, dbg);
 }
 
 template<tri id>
 const Def* normalize_tri(const Def* type, const Def* c, const Def* arg, const Def* dbg) {
     auto& world = type->world();
     if (auto lit = fold<tri, id>(world, type, arg, dbg)) return lit;
-    return world.app<false>(c, arg, dbg);
+    return world.raw_app(type, c, arg, dbg);
 }
 
 const Def* normalize_pow(const Def* type, const Def* c, const Def* arg, const Def* dbg) {
     auto& world = type->world();
     auto [a, b] = arg->projs<2>();
     if (auto lit = fold<pow, /*dummy*/ pow(0)>(world, type, a, b, dbg)) return lit;
-    return world.app<false>(c, arg, dbg);
+    return world.raw_app(type, c, arg, dbg);
 }
 
 template<rt id>
 const Def* normalize_rt(const Def* type, const Def* c, const Def* arg, const Def* dbg) {
     auto& world = type->world();
     if (auto lit = fold<rt, id>(world, type, arg, dbg)) return lit;
-    return world.app<false>(c, arg, dbg);
+    return world.raw_app(type, c, arg, dbg);
 }
 
 template<exp id>
 const Def* normalize_exp(const Def* type, const Def* c, const Def* arg, const Def* dbg) {
     auto& world = type->world();
     if (auto lit = fold<exp, id>(world, type, arg, dbg)) return lit;
-    return world.app<false>(c, arg, dbg);
+    return world.raw_app(type, c, arg, dbg);
 }
 
 template<er id>
 const Def* normalize_er(const Def* type, const Def* c, const Def* arg, const Def* dbg) {
     auto& world = type->world();
     if (auto lit = fold<er, id>(world, type, arg, dbg)) return lit;
-    return world.app<false>(c, arg, dbg);
+    return world.raw_app(type, c, arg, dbg);
 }
 
 template<gamma id>
 const Def* normalize_gamma(const Def* type, const Def* c, const Def* arg, const Def* dbg) {
     auto& world = type->world();
     if (auto lit = fold<gamma, id>(world, type, arg, dbg)) return lit;
-    return world.app<false>(c, arg, dbg);
+    return world.raw_app(type, c, arg, dbg);
 }
 
 template<cmp id>
@@ -352,7 +352,7 @@ const Def* normalize_cmp(const Def* type, const Def* c, const Def* arg, const De
     if (id == cmp::f) return world.lit_ff();
     if (id == cmp::t) return world.lit_tt();
 
-    return world.app<false>(callee, {a, b}, dbg);
+    return world.raw_app(type, callee, {a, b}, dbg);
 }
 
 template<class Id, Id id, nat_t sw, nat_t dw>
@@ -363,26 +363,26 @@ Res fold(u64 a) {
 }
 
 template<conv id>
-const Def* normalize_conv(const Def* dst_ty, const Def* c, const Def* x, const Def* dbg) {
-    auto& world = dst_ty->world();
+const Def* normalize_conv(const Def* dst_t, const Def* c, const Def* x, const Def* dbg) {
+    auto& world = dst_t->world();
     auto callee = c->as<App>();
-    auto s_ty   = x->type()->as<App>();
-    auto d_ty   = dst_ty->as<App>();
-    auto s      = s_ty->arg();
-    auto d      = d_ty->arg();
+    auto s_t    = x->type()->as<App>();
+    auto d_t    = dst_t->as<App>();
+    auto s      = s_t->arg();
+    auto d      = d_t->arg();
     auto ls     = isa_lit(s);
     auto ld     = isa_lit(d);
 
-    if (s_ty == d_ty) return x;
-    if (x->isa<Bot>()) return world.bot(d_ty, dbg);
+    if (s_t == d_t) return x;
+    if (x->isa<Bot>()) return world.bot(d_t, dbg);
 
     if (auto l = isa_lit(x); l && ls && ld) {
         constexpr bool sf     = id == conv::f2f || id == conv::f2s || id == conv::f2u;
         constexpr bool df     = id == conv::f2f || id == conv::s2f || id == conv::u2f;
         constexpr nat_t min_s = sf ? 16 : 1;
         constexpr nat_t min_d = df ? 16 : 1;
-        auto sw               = sf ? isa_f(s_ty) : Idx::size2bitwidth(*ls);
-        auto dw               = df ? isa_f(d_ty) : Idx::size2bitwidth(*ld);
+        auto sw               = sf ? isa_f(s_t) : Idx::size2bitwidth(*ls);
+        auto dw               = df ? isa_f(d_t) : Idx::size2bitwidth(*ld);
 
         if (sw && dw) {
             Res res;
@@ -403,12 +403,11 @@ const Def* normalize_conv(const Def* dst_ty, const Def* c, const Def* x, const D
 
             else unreachable();
             // clang-format on
-
-            return world.lit(d_ty, *res, dbg);
+            return world.lit(d_t, *res, dbg);
         }
     }
 out:
-    return world.app<false>(callee, x, dbg);
+    return world.raw_app(dst_t, callee, x, dbg);
 }
 
 // TODO I guess we can do that with C++20 <bit>

--- a/dialects/math/normalizers.cpp
+++ b/dialects/math/normalizers.cpp
@@ -276,7 +276,7 @@ const Def* normalize_arith(const Def* type, const Def* c, const Def* arg, const 
 
     if (auto res = reassociate<arith>(id, world, callee, a, b, dbg)) return res;
 
-    return world.raw_app(callee, {a, b}, dbg);
+    return world.app<false>(callee, {a, b}, dbg);
 }
 
 template<extrema id>
@@ -297,49 +297,49 @@ const Def* normalize_extrema(const Def* type, const Def* c, const Def* arg, cons
         }
     }
 
-    return world.raw_app(c, arg, dbg);
+    return world.app<false>(c, arg, dbg);
 }
 
 template<tri id>
 const Def* normalize_tri(const Def* type, const Def* c, const Def* arg, const Def* dbg) {
     auto& world = type->world();
     if (auto lit = fold<tri, id>(world, type, arg, dbg)) return lit;
-    return world.raw_app(c, arg, dbg);
+    return world.app<false>(c, arg, dbg);
 }
 
 const Def* normalize_pow(const Def* type, const Def* c, const Def* arg, const Def* dbg) {
     auto& world = type->world();
     auto [a, b] = arg->projs<2>();
     if (auto lit = fold<pow, /*dummy*/ pow(0)>(world, type, a, b, dbg)) return lit;
-    return world.raw_app(c, arg, dbg);
+    return world.app<false>(c, arg, dbg);
 }
 
 template<rt id>
 const Def* normalize_rt(const Def* type, const Def* c, const Def* arg, const Def* dbg) {
     auto& world = type->world();
     if (auto lit = fold<rt, id>(world, type, arg, dbg)) return lit;
-    return world.raw_app(c, arg, dbg);
+    return world.app<false>(c, arg, dbg);
 }
 
 template<exp id>
 const Def* normalize_exp(const Def* type, const Def* c, const Def* arg, const Def* dbg) {
     auto& world = type->world();
     if (auto lit = fold<exp, id>(world, type, arg, dbg)) return lit;
-    return world.raw_app(c, arg, dbg);
+    return world.app<false>(c, arg, dbg);
 }
 
 template<er id>
 const Def* normalize_er(const Def* type, const Def* c, const Def* arg, const Def* dbg) {
     auto& world = type->world();
     if (auto lit = fold<er, id>(world, type, arg, dbg)) return lit;
-    return world.raw_app(c, arg, dbg);
+    return world.app<false>(c, arg, dbg);
 }
 
 template<gamma id>
 const Def* normalize_gamma(const Def* type, const Def* c, const Def* arg, const Def* dbg) {
     auto& world = type->world();
     if (auto lit = fold<gamma, id>(world, type, arg, dbg)) return lit;
-    return world.raw_app(c, arg, dbg);
+    return world.app<false>(c, arg, dbg);
 }
 
 template<cmp id>
@@ -352,7 +352,7 @@ const Def* normalize_cmp(const Def* type, const Def* c, const Def* arg, const De
     if (id == cmp::f) return world.lit_ff();
     if (id == cmp::t) return world.lit_tt();
 
-    return world.raw_app(callee, {a, b}, dbg);
+    return world.app<false>(callee, {a, b}, dbg);
 }
 
 template<class Id, Id id, nat_t sw, nat_t dw>
@@ -408,7 +408,7 @@ const Def* normalize_conv(const Def* dst_ty, const Def* c, const Def* x, const D
         }
     }
 out:
-    return world.raw_app(callee, x, dbg);
+    return world.app<false>(callee, x, dbg);
 }
 
 // TODO I guess we can do that with C++20 <bit>

--- a/dialects/mem/normalizers.cpp
+++ b/dialects/mem/normalizers.cpp
@@ -12,7 +12,7 @@ const Def* normalize_lea(const Def* type, const Def* callee, const Def* arg, con
     if (auto a = isa_lit(pointee->arity()); a && *a == 1) return ptr;
     // TODO
 
-    return world.app<false>(callee, {ptr, index}, dbg);
+    return world.raw_app(type, callee, {ptr, index}, dbg);
 }
 
 const Def* normalize_load(const Def* type, const Def* callee, const Def* arg, const Def* dbg) {
@@ -26,14 +26,14 @@ const Def* normalize_load(const Def* type, const Def* callee, const Def* arg, co
     if (auto sigma = pointee->isa<Sigma>(); sigma && sigma->num_ops() == 0)
         return world.tuple({mem, world.tuple(sigma->type(), {}, dbg)});
 
-    return world.app<false>(callee, {mem, ptr}, dbg);
+    return world.raw_app(type, callee, {mem, ptr}, dbg);
 }
 
 const Def* normalize_remem(const Def* type, const Def* callee, const Def* mem, const Def* dbg) {
     auto& world = type->world();
 
     // if (auto m = match<remem>(mem)) mem = m;
-    return world.app<false>(callee, mem, dbg);
+    return world.raw_app(type, callee, mem, dbg);
 }
 
 const Def* normalize_store(const Def* type, const Def* callee, const Def* arg, const Def* dbg) {
@@ -46,7 +46,7 @@ const Def* normalize_store(const Def* type, const Def* callee, const Def* arg, c
         if (std::ranges::all_of(tuple->ops(), [](const Def* op) { return op->isa<Bot>(); })) return mem;
     }
 
-    return world.app<false>(callee, {mem, ptr, val}, dbg);
+    return world.raw_app(type, callee, {mem, ptr, val}, dbg);
 }
 
 THORIN_mem_NORMALIZER_IMPL

--- a/dialects/mem/normalizers.cpp
+++ b/dialects/mem/normalizers.cpp
@@ -12,7 +12,7 @@ const Def* normalize_lea(const Def* type, const Def* callee, const Def* arg, con
     if (auto a = isa_lit(pointee->arity()); a && *a == 1) return ptr;
     // TODO
 
-    return world.raw_app(callee, {ptr, index}, dbg);
+    return world.app<false>(callee, {ptr, index}, dbg);
 }
 
 const Def* normalize_load(const Def* type, const Def* callee, const Def* arg, const Def* dbg) {
@@ -26,14 +26,14 @@ const Def* normalize_load(const Def* type, const Def* callee, const Def* arg, co
     if (auto sigma = pointee->isa<Sigma>(); sigma && sigma->num_ops() == 0)
         return world.tuple({mem, world.tuple(sigma->type(), {}, dbg)});
 
-    return world.raw_app(callee, {mem, ptr}, dbg);
+    return world.app<false>(callee, {mem, ptr}, dbg);
 }
 
 const Def* normalize_remem(const Def* type, const Def* callee, const Def* mem, const Def* dbg) {
     auto& world = type->world();
 
     // if (auto m = match<remem>(mem)) mem = m;
-    return world.raw_app(callee, mem, dbg);
+    return world.app<false>(callee, mem, dbg);
 }
 
 const Def* normalize_store(const Def* type, const Def* callee, const Def* arg, const Def* dbg) {
@@ -46,7 +46,7 @@ const Def* normalize_store(const Def* type, const Def* callee, const Def* arg, c
         if (std::ranges::all_of(tuple->ops(), [](const Def* op) { return op->isa<Bot>(); })) return mem;
     }
 
-    return world.raw_app(callee, {mem, ptr, val}, dbg);
+    return world.app<false>(callee, {mem, ptr, val}, dbg);
 }
 
 THORIN_mem_NORMALIZER_IMPL

--- a/dialects/refly/normalizers.cpp
+++ b/dialects/refly/normalizers.cpp
@@ -18,7 +18,7 @@ template<dbg id>
 const Def* normalize_dbg(const Def*, const Def* callee, const Def* arg, const Def* dbg) {
     auto& world = arg->world();
     debug_print(arg);
-    return id == dbg::perm ? world.raw_app(callee, arg, dbg) : arg;
+    return id == dbg::perm ? world.app<false>(callee, arg, dbg) : arg;
 }
 
 const Def* normalize_reify(const Def*, const Def*, const Def* arg, const Def* dbg) { return do_reify(arg, dbg); }
@@ -33,7 +33,7 @@ const Def* normalize_refine(const Def*, const Def* callee, const Def* arg, const
         return do_reify(def->refine(*l, do_reflect(x)), dbg);
     }
 
-    return world.raw_app(callee, arg, dbg);
+    return world.app<false>(callee, arg, dbg);
 }
 
 const Def* normalize_gid(const Def*, const Def*, const Def* arg, const Def*) {

--- a/dialects/refly/normalizers.cpp
+++ b/dialects/refly/normalizers.cpp
@@ -15,17 +15,17 @@ static const Def* do_reify(const Def* def, const Def* dbg = {}) {
 static const Def* do_reflect(const Def* def) { return reinterpret_cast<const Def*>(def->as<Lit>()->get()); }
 
 template<dbg id>
-const Def* normalize_dbg(const Def*, const Def* callee, const Def* arg, const Def* dbg) {
+const Def* normalize_dbg(const Def* type, const Def* callee, const Def* arg, const Def* dbg) {
     auto& world = arg->world();
     debug_print(arg);
-    return id == dbg::perm ? world.app<false>(callee, arg, dbg) : arg;
+    return id == dbg::perm ? world.raw_app(type, callee, arg, dbg) : arg;
 }
 
 const Def* normalize_reify(const Def*, const Def*, const Def* arg, const Def* dbg) { return do_reify(arg, dbg); }
 
 const Def* normalize_reflect(const Def*, const Def*, const Def* arg, const Def*) { return do_reflect(arg); }
 
-const Def* normalize_refine(const Def*, const Def* callee, const Def* arg, const Def* dbg) {
+const Def* normalize_refine(const Def* type, const Def* callee, const Def* arg, const Def* dbg) {
     auto& world       = arg->world();
     auto [code, i, x] = arg->projs<3>();
     if (auto l = isa_lit(i)) {
@@ -33,7 +33,7 @@ const Def* normalize_refine(const Def*, const Def* callee, const Def* arg, const
         return do_reify(def->refine(*l, do_reflect(x)), dbg);
     }
 
-    return world.app<false>(callee, arg, dbg);
+    return world.raw_app(type, callee, arg, dbg);
 }
 
 const Def* normalize_gid(const Def*, const Def*, const Def* arg, const Def*) {

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -866,7 +866,7 @@ WARN_NO_PARAMDOC       = NO
 # Possible values are: NO, YES and FAIL_ON_WARNINGS.
 # The default value is: NO.
 
-WARN_AS_ERROR          = NO
+WARN_AS_ERROR          = YES
 
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which
@@ -2334,7 +2334,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = THORIN_ENABLE_CHECKS
+PREDEFINED             = THORIN_ENABLE_CHECKS, DOXYGEN
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -866,7 +866,7 @@ WARN_NO_PARAMDOC       = NO
 # Possible values are: NO, YES and FAIL_ON_WARNINGS.
 # The default value is: NO.
 
-WARN_AS_ERROR          = YES
+WARN_AS_ERROR          = NO
 
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which

--- a/gtest/test.cpp
+++ b/gtest/test.cpp
@@ -147,20 +147,20 @@ TEST(Axiom, curry) {
         EXPECT_EQ(trip, 1);
 
         auto ax = w.axiom(normalize_test_curry, curry, trip, rec, w.dbg("test_1_1"));
-        auto a = w.app(w.app(w.app(ax, n[0]), n[1]), n[2]);
+        auto a  = w.app(w.app(w.app(ax, n[0]), n[1]), n[2]);
 
         std::ostringstream os;
         a->stream(os, 0);
         EXPECT_EQ(os.str(), "%test_1_1 42 42 42\n");
     }
     {
-        auto pi = w.pi(nat, w.pi(nat, w.pi(nat, w.pi(nat, nat))));
+        auto pi            = w.pi(nat, w.pi(nat, w.pi(nat, w.pi(nat, nat))));
         auto [curry, trip] = Axiom::infer_curry_and_trip(pi);
         EXPECT_EQ(curry, 4);
         EXPECT_EQ(trip, 0);
 
         auto ax = w.axiom(normalize_test_curry, 3, 0, pi, w.dbg("test_3_0"));
-        auto a = w.app(w.app(w.app(w.app(ax, n[0]), n[1]), n[2]), n[3]);
+        auto a  = w.app(w.app(w.app(w.app(ax, n[0]), n[1]), n[2]), n[3]);
 
         std::ostringstream os;
         a->stream(os, 0);

--- a/gtest/test.cpp
+++ b/gtest/test.cpp
@@ -106,9 +106,9 @@ TEST(trait, idx) {
     EXPECT_EQ(as_lit(op(core::trait::size, w.type_idx(0x0000'0000'0000'0000_n))), 8);
 }
 
-const Def* normalize_test_curry(const Def*, const Def* callee, const Def* arg, const Def* dbg) {
+const Def* normalize_test_curry(const Def* type, const Def* callee, const Def* arg, const Def* dbg) {
     auto& w = arg->world();
-    return w.app<false>(callee, w.lit_nat(42), dbg);
+    return w.raw_app(type, callee, w.lit_nat(42), dbg);
 }
 
 TEST(Axiom, curry) {

--- a/gtest/test.cpp
+++ b/gtest/test.cpp
@@ -105,3 +105,65 @@ TEST(trait, idx) {
     EXPECT_EQ(as_lit(op(core::trait::size, w.type_idx(0xFFFF'FFFF'FFFF'FFFF_n))), 8);
     EXPECT_EQ(as_lit(op(core::trait::size, w.type_idx(0x0000'0000'0000'0000_n))), 8);
 }
+
+const Def* normalize_test_curry(const Def*, const Def* callee, const Def* arg, const Def* dbg) {
+    auto& w = arg->world();
+    return w.app<false>(callee, w.lit_nat(42), dbg);
+}
+
+TEST(Axiom, curry) {
+    World w;
+
+    DefArray n(11, [&w](size_t i) { return w.lit_nat(i); });
+    auto nat = w.type_nat();
+
+    {
+        // N -> N -> N -> N -> N
+        //           ^         |
+        //           |         |
+        //           +---------+
+        auto rec = w.nom_pi(w.type())->set_dom(nat);
+        rec->set_codom(w.pi(nat, w.pi(nat, rec)));
+        auto pi = w.pi(nat, w.pi(nat, rec));
+
+        auto [curry, trip] = Axiom::infer_curry_and_trip(pi);
+        EXPECT_EQ(curry, 5);
+        EXPECT_EQ(trip, 3);
+
+        auto ax = w.axiom(normalize_test_curry, curry, trip, pi, w.dbg("test_5_3"));
+        auto a1 = w.app(w.app(w.app(w.app(w.app(w.app(ax, n[0]), n[1]), n[2]), n[3]), n[4]), n[5]);
+        auto a2 = w.app(w.app(w.app(w.app(w.app(a1, n[6]), n[7]), n[8]), n[9]), n[10]);
+
+        std::ostringstream os;
+        a2->stream(os, 0);
+        EXPECT_EQ(os.str(), "%test_5_3 0 1 2 3 42 5 6 42 8 9 42\n");
+    }
+    {
+        auto rec = w.nom_pi(w.type())->set_dom(nat);
+        rec->set_codom(rec);
+
+        auto [curry, trip] = Axiom::infer_curry_and_trip(rec);
+        EXPECT_EQ(curry, 1);
+        EXPECT_EQ(trip, 1);
+
+        auto ax = w.axiom(normalize_test_curry, curry, trip, rec, w.dbg("test_1_1"));
+        auto a = w.app(w.app(w.app(ax, n[0]), n[1]), n[2]);
+
+        std::ostringstream os;
+        a->stream(os, 0);
+        EXPECT_EQ(os.str(), "%test_1_1 42 42 42\n");
+    }
+    {
+        auto pi = w.pi(nat, w.pi(nat, w.pi(nat, w.pi(nat, nat))));
+        auto [curry, trip] = Axiom::infer_curry_and_trip(pi);
+        EXPECT_EQ(curry, 4);
+        EXPECT_EQ(trip, 0);
+
+        auto ax = w.axiom(normalize_test_curry, 3, 0, pi, w.dbg("test_3_0"));
+        auto a = w.app(w.app(w.app(w.app(ax, n[0]), n[1]), n[2]), n[3]);
+
+        std::ostringstream os;
+        a->stream(os, 0);
+        EXPECT_EQ(os.str(), "%test_3_0 0 1 42 3\n");
+    }
+}

--- a/gtest/test.cpp
+++ b/gtest/test.cpp
@@ -131,11 +131,16 @@ TEST(Axiom, curry) {
         EXPECT_EQ(trip, 3);
 
         auto ax = w.axiom(normalize_test_curry, curry, trip, pi, w.dbg("test_5_3"));
-        auto a1 = w.app(w.app(w.app(w.app(w.app(w.app(ax, n[0]), n[1]), n[2]), n[3]), n[4]), n[5]);
-        auto a2 = w.app(w.app(w.app(w.app(w.app(a1, n[6]), n[7]), n[8]), n[9]), n[10]);
+        auto a1 = w.app(w.app(w.app(w.app(w.app(ax, n[0]), n[1]), n[2]), n[3]), n[4]);
+        auto a2 = w.app(w.app(w.app(a1, n[5]), n[6]), n[7]);
+        auto a3 = w.app(w.app(w.app(a2, n[8]), n[9]), n[10]);
+
+        EXPECT_EQ(a1->as<App>()->curry(), 0);
+        EXPECT_EQ(a2->as<App>()->curry(), 0);
+        EXPECT_EQ(a3->as<App>()->curry(), 0);
 
         std::ostringstream os;
-        a2->stream(os, 0);
+        a3->stream(os, 0);
         EXPECT_EQ(os.str(), "%test_5_3 0 1 2 3 42 5 6 42 8 9 42\n");
     }
     {
@@ -147,10 +152,16 @@ TEST(Axiom, curry) {
         EXPECT_EQ(trip, 1);
 
         auto ax = w.axiom(normalize_test_curry, curry, trip, rec, w.dbg("test_1_1"));
-        auto a  = w.app(w.app(w.app(ax, n[0]), n[1]), n[2]);
+        auto a1 = w.app(ax, n[0]);
+        auto a2 = w.app(a1, n[1]);
+        auto a3 = w.app(a2, n[2]);
+
+        EXPECT_EQ(a1->as<App>()->curry(), 0);
+        EXPECT_EQ(a2->as<App>()->curry(), 0);
+        EXPECT_EQ(a3->as<App>()->curry(), 0);
 
         std::ostringstream os;
-        a->stream(os, 0);
+        a3->stream(os, 0);
         EXPECT_EQ(os.str(), "%test_1_1 42 42 42\n");
     }
     {
@@ -160,10 +171,14 @@ TEST(Axiom, curry) {
         EXPECT_EQ(trip, 0);
 
         auto ax = w.axiom(normalize_test_curry, 3, 0, pi, w.dbg("test_3_0"));
-        auto a  = w.app(w.app(w.app(w.app(ax, n[0]), n[1]), n[2]), n[3]);
+        auto a1 = w.app(w.app(w.app(ax, n[0]), n[1]), n[2]);
+        auto a2 = w.app(a1, n[3]);
+
+        EXPECT_EQ(a1->as<App>()->curry(), 0);
+        EXPECT_EQ(a2->as<App>()->curry(), Axiom::Trip_End);
 
         std::ostringstream os;
-        a->stream(os, 0);
+        a2->stream(os, 0);
         EXPECT_EQ(os.str(), "%test_3_0 0 1 42 3\n");
     }
 }

--- a/thorin/axiom.cpp
+++ b/thorin/axiom.cpp
@@ -4,21 +4,48 @@ using namespace std::literals;
 
 namespace thorin {
 
-Axiom::Axiom(NormalizeFn normalizer, const Def* type, dialect_t dialect, tag_t tag, sub_t sub, const Def* dbg)
+Axiom::Axiom(NormalizeFn normalizer,
+             u8 curry,
+             u8 trip,
+             const Def* type,
+             dialect_t dialect,
+             tag_t tag,
+             sub_t sub,
+             const Def* dbg)
     : Def(Node, type, Defs{}, dialect | (flags_t(tag) << 8_u64) | flags_t(sub), dbg) {
-    u16 curry = 0;
+    normalizer_ = normalizer;
+    curry_      = curry;
+    trip_       = trip;
+}
+
+std::pair<u8, u8> Axiom::infer_curry_and_trip(const Def* type) {
+    u8 curry = 0;
+    u8 trip = 0;
     NomSet done;
     while (auto pi = type->isa<Pi>()) {
         if (auto nom = pi->isa_nom()) {
-            if (auto [_, ins] = done.emplace(nom); !ins) break;
+            if (auto [_, ins] = done.emplace(nom); !ins) {
+                // infer trip
+                auto curr = pi;
+                do {
+                    ++trip;
+                    curr = curr->codom()->as<Pi>();
+                } while (curr != nom);
+                break;
+            }
         }
 
         ++curry;
         type = pi->codom();
     }
 
-    normalizer_ = normalizer;
-    curry_      = curry;
+    return {curry, trip};
+}
+
+std::tuple<const Axiom*, u8, u8> Axiom::get(const Def* def) {
+    if (auto axiom = def->isa<Axiom>()) return {axiom, axiom->curry(), axiom->trip()};
+    if (auto app = def->isa<App>()) return {app->axiom(), app->curry(), app->trip()};
+    return {nullptr, 0, 0};
 }
 
 std::optional<dialect_t> Axiom::mangle(std::string_view s) {
@@ -101,12 +128,6 @@ std::optional<std::array<std::string_view, 3>> Axiom::split(std::string_view s) 
     return {
         {dialect, tag, ""sv}
     };
-}
-
-std::tuple<const Axiom*, u16> Axiom::get(const Def* def) {
-    if (auto axiom = def->isa<Axiom>()) return {axiom, axiom->curry()};
-    if (auto app = def->isa<App>()) return {app->axiom(), app->curry()};
-    return {nullptr, u16(-1)};
 }
 
 } // namespace thorin

--- a/thorin/axiom.cpp
+++ b/thorin/axiom.cpp
@@ -20,7 +20,7 @@ Axiom::Axiom(NormalizeFn normalizer,
 
 std::pair<u8, u8> Axiom::infer_curry_and_trip(const Def* type) {
     u8 curry = 0;
-    u8 trip = 0;
+    u8 trip  = 0;
     NomSet done;
     while (auto pi = type->isa<Pi>()) {
         if (auto nom = pi->isa_nom()) {

--- a/thorin/axiom.h
+++ b/thorin/axiom.h
@@ -8,20 +8,37 @@ namespace thorin {
 
 class Axiom : public Def {
 private:
-    Axiom(NormalizeFn normalizer, const Def* type, dialect_t dialect, tag_t tag, sub_t sub, const Def* dbg);
+    Axiom(NormalizeFn, u8 curry, u8 trip, const Def* type, dialect_t, tag_t, sub_t, const Def* dbg);
 
 public:
-    /// @name curry depth and normalizer
+    /// @name normalization
     ///@{
+    /// For a curried App of an Axiom, you only want to trigger normalization at specific spots.
+    /// For this reason, Thorin maintains a Def::curry_ counter that each App decrements.
+    /// The Axiom::normalizer() will be triggered when Axiom::curry() becomes `0`.
+    /// These are also the spots that you can match/force (@sa Match).
+    /// After that, the counter will be set to Axiom::trip().
+    /// Let's say an Axiom has this type:
+    /// ```
+    /// A -> B -> C -> D -> E
+    ///           ^         |
+    ///           |         |
+    ///           +---------+
+    /// ```
+    /// Using an initial value as `5` for Axiom::curry and `3` as Axiom::trip has the effect that here
+    /// ```
+    /// x a b c1 d1 e1 c2 d2 e2 c3 d3 e3
+    /// ```
+    /// the Axiom::normalizer will be triggered after App'ing `e1`, `e2`, and `e3`.
     NormalizeFn normalizer() const { return normalizer_; }
+    u8 curry() const { return curry_; }
+    u8 trip() const { return trip_; }
 
-    /// Currying depth.
-    /// I.e. the number of arrows (`->`) in this Axiom's Def::type.
-    u16 curry() const { return curry_; }
+    /// Yields currying counter of @p def.
+    /// @returns `{nullptr, 0, 0}` if no Axiom is present.
+    static std::tuple<const Axiom*, u8, u8> get(const Def* def);
 
-    /// Yields currying depth of @p def untill we finally hit an Axiom.
-    /// @returns `{nullptr, u16(-1)}` if no Axiom is present.
-    static std::tuple<const Axiom*, u16> get(const Def* def);
+    static std::pair<u8, u8> infer_curry_and_trip(const Def* type);
     ///@}
 
     /// @name Axiom name
@@ -150,9 +167,9 @@ private:
 ///@{
 template<class Id, bool DynCast = true>
 auto match(const Def* def) {
-    using D             = typename Axiom::Match<Id>::type;
-    auto [axiom, curry] = Axiom::get(def);
-    bool cond           = axiom && curry == 0 && axiom->base() == Axiom::Base<Id>;
+    using D                = typename Axiom::Match<Id>::type;
+    auto [axiom, curry, _] = Axiom::get(def);
+    bool cond              = axiom && curry == 0 && axiom->base() == Axiom::Base<Id>;
 
     if constexpr (DynCast) return cond ? Match<Id, D>(axiom, def->as<D>()) : Match<Id, D>();
     assert(cond && "assumed to be correct axiom");
@@ -161,9 +178,9 @@ auto match(const Def* def) {
 
 template<class Id, bool DynCast = true>
 auto match(Id id, const Def* def) {
-    using D             = typename Axiom::Match<Id>::type;
-    auto [axiom, curry] = Axiom::get(def);
-    bool cond           = axiom && curry == 0 && axiom->flags() == (flags_t)id;
+    using D                = typename Axiom::Match<Id>::type;
+    auto [axiom, curry, _] = Axiom::get(def);
+    bool cond              = axiom && curry == 0 && axiom->flags() == (flags_t)id;
 
     if constexpr (DynCast) return cond ? Match<Id, D>(axiom, def->as<D>()) : Match<Id, D>();
     assert(cond && "assumed to be correct axiom");

--- a/thorin/axiom.h
+++ b/thorin/axiom.h
@@ -18,7 +18,7 @@ public:
     /// The Axiom::normalizer() will be triggered when Axiom::curry() becomes `0`.
     /// These are also the spots that you can match/force (@sa Match).
     /// After that, the counter will be set to Axiom::trip().
-    /// Let's say an Axiom has this type:
+    /// E.g., let's say an Axiom has this type:
     /// ```
     /// A -> B -> C -> D -> E
     ///           ^         |

--- a/thorin/axiom.h
+++ b/thorin/axiom.h
@@ -39,6 +39,7 @@ public:
     static std::tuple<const Axiom*, u8, u8> get(const Def* def);
 
     static std::pair<u8, u8> infer_curry_and_trip(const Def* type);
+    static constexpr u8 Trip_End = u8(-1);
     ///@}
 
     /// @name Axiom name

--- a/thorin/def.cpp
+++ b/thorin/def.cpp
@@ -93,7 +93,7 @@ const Def* Var      ::rebuild(World& w, const Def* t, Defs o, const Def* dbg) co
 const Def* Vel      ::rebuild(World& w, const Def* t, Defs o, const Def* dbg) const { return w.vel(t, o[0], dbg); }
 
 const Def* Axiom    ::rebuild(World& w, const Def* t, Defs  , const Def* dbg) const {
-    auto res = w.axiom(normalizer(), t, dialect(), tag(), sub(), dbg);
+    auto res = w.axiom(normalizer(), curry(), trip(), t, dialect(), tag(), sub(), dbg);
     assert(&w != &world() || gid() == res->gid());
     return res;
 }

--- a/thorin/def.h
+++ b/thorin/def.h
@@ -405,7 +405,8 @@ protected:
     unsigned nom_    : 1;
     unsigned dep_    : 4;
     unsigned pading_ : 3;
-    u16 curry_;
+    u8 curry_;
+    u8 trip_;
     hash_t hash_;
     u32 gid_;
     u32 num_ops_;

--- a/thorin/fe/parser.cpp
+++ b/thorin/fe/parser.cpp
@@ -609,8 +609,7 @@ void Parser::parse_ax() {
 
     if (accept(Tok::Tag::T_comma)) {
         auto c = expect(Tok::Tag::L_u, "curry counter for axiom");
-        if (c.u() > curry)
-            err(c.loc(), "curry counter cannot be greater than {}", curry);
+        if (c.u() > curry) err(c.loc(), "curry counter cannot be greater than {}", curry);
         curry = c.u();
     }
 

--- a/thorin/fe/parser.cpp
+++ b/thorin/fe/parser.cpp
@@ -605,16 +605,27 @@ void Parser::parse_ax() {
         return nullptr;
     };
 
+    auto [curry, trip] = Axiom::infer_curry_and_trip(type);
+
+    if (accept(Tok::Tag::T_comma)) {
+        auto c = expect(Tok::Tag::L_u, "curry counter for axiom");
+        if (c.u() > curry)
+            err(c.loc(), "curry counter cannot be greater than {}", curry);
+        curry = c.u();
+    }
+
+    if (accept(Tok::Tag::T_comma)) trip = expect(Tok::Tag::L_u, "trip count for axiom").u();
+
     dialect_t d = *Axiom::mangle(dialect);
     tag_t t     = info.tag_id;
     sub_t s     = info.subs.size();
     if (new_subs.empty()) {
-        auto axiom = world().axiom(normalizer(d, t, 0), type, d, t, 0, track.named(ax.sym()));
+        auto axiom = world().axiom(normalizer(d, t, 0), curry, trip, type, d, t, 0, track.named(ax.sym()));
         scopes_.bind(ax.sym(), axiom);
     } else {
         for (const auto& sub : new_subs) {
             auto dbg   = track.named(ax_str + "."s + sub.front());
-            auto axiom = world().axiom(normalizer(d, t, s), type, d, t, s, dbg);
+            auto axiom = world().axiom(normalizer(d, t, s), curry, trip, type, d, t, s, dbg);
             for (auto& alias : sub) {
                 Sym name(world().tuple_str(ax_str + "."s + alias), prev_.def(world()));
                 scopes_.bind(name, axiom);

--- a/thorin/lam.h
+++ b/thorin/lam.h
@@ -126,10 +126,11 @@ using Lam2Lam = LamMap<Lam*>;
 
 class App : public Def {
 private:
-    App(const Axiom* axiom, u16 curry, const Def* type, const Def* callee, const Def* arg, const Def* dbg)
+    App(const Axiom* axiom, u8 curry, u8 trip, const Def* type, const Def* callee, const Def* arg, const Def* dbg)
         : Def(Node, type, {callee, arg}, 0, dbg) {
         axiom_ = axiom;
         curry_ = curry;
+        trip_  = trip;
     }
 
 public:
@@ -142,10 +143,11 @@ public:
     THORIN_PROJ(arg, const)
     ///@}
 
-    /// @name get axiom and current currying depth
+    /// @name get axiom, current curry counter and trip count
     ///@{
     const Axiom* axiom() const { return axiom_; }
-    u16 curry() const { return curry_; }
+    u8 curry() const { return curry_; }
+    u8 trip() const { return trip_; }
     ///@}
 
     /// @name virtual methods

--- a/thorin/world.cpp
+++ b/thorin/world.cpp
@@ -433,8 +433,10 @@ const Def* World::gid2def(u32 gid) {
  * instantiate templates
  */
 
+#ifndef DOXYGEN // doxygen doesn't like these two lines ...
 template const Def* World::app<true>(const Def*, const Def*, const Def*);
 template const Def* World::app<false>(const Def*, const Def*, const Def*);
+#endif
 template const Def* World::ext<true>(const Def*, const Def*);
 template const Def* World::ext<false>(const Def*, const Def*);
 template const Def* World::bound<true>(Defs, const Def*);

--- a/thorin/world.cpp
+++ b/thorin/world.cpp
@@ -94,12 +94,11 @@ template<bool Normalize>
 const Def* World::raw_app(const Def* type, const Def* callee, const Def* arg, const Def* dbg) {
     auto [axiom, curry, trip] = Axiom::get(callee);
     if (axiom) {
-        if (curry == 1) {
-            if (auto normalize = axiom->normalizer(); Normalize && normalize) return normalize(type, callee, arg, dbg);
-            curry = trip;
-        } else {
-            --curry;
-        }
+        curry = curry == 0 ? trip : curry;
+        curry = curry == Axiom::Trip_End ? curry : curry - 1;
+
+        if (auto normalize = axiom->normalizer(); Normalize && normalize && curry == 0)
+            return normalize(type, callee, arg, dbg);
     }
 
     return unify<App>(2, axiom, curry, trip, type, callee, arg, dbg);

--- a/thorin/world.cpp
+++ b/thorin/world.cpp
@@ -87,9 +87,12 @@ const Def* World::app(const Def* callee, const Def* arg, const Def* dbg) {
     auto type                 = pi->reduce(arg).back();
     auto [axiom, curry, trip] = Axiom::get(callee);
     if (axiom) {
-        if (auto normalize = axiom->normalizer(); Normalize && normalize && curry == 1)
-            return normalize(type, callee, arg, dbg);
-        curry = curry == 0 ? trip : curry - 1;
+        if (curry == 1) {
+            if (auto normalize = axiom->normalizer(); Normalize && normalize) return normalize(type, callee, arg, dbg);
+            curry = trip;
+        } else {
+            --curry;
+        }
     }
 
     if (auto lam = callee->isa<Lam>(); lam && lam->is_set() && lam->codom()->sort() > Sort::Type)

--- a/thorin/world.h
+++ b/thorin/world.h
@@ -253,11 +253,13 @@ public:
 
     /// @name App
     ///@{
-    template<bool Normalize = true>
     const Def* app(const Def* callee, const Def* arg, const Def* dbg = {});
-    template<bool Normalize = true>
-    const Def* app(const Def* callee, Defs args, const Def* dbg = {}) {
-        return app<Normalize>(callee, tuple(args), dbg);
+    const Def* app(const Def* callee, Defs args, const Def* dbg = {}) { return app(callee, tuple(args), dbg); }
+    template<bool Normalize = false>
+    const Def* raw_app(const Def* type, const Def* callee, const Def* arg, const Def* dbg = {});
+    template<bool Normalize = false>
+    const Def* raw_app(const Def* type, const Def* callee, Defs args, const Def* dbg = {}) {
+        return raw_app<Normalize>(type, callee, tuple(args), dbg);
     }
     ///@}
 

--- a/thorin/world.h
+++ b/thorin/world.h
@@ -202,9 +202,10 @@ public:
     /// This is useful during testing to come up with some entitiy of a specific type.
     /// It uses the dialect Axiom::Global_Dialect and starts with `0` for Axiom::sub and counts up from there.
     /// The Axiom::tag is set to `0` and the Axiom::normalizer to `nullptr`.
-    const Axiom* axiom(const Def* type, const Def* dbg = {}) {
-        return axiom(nullptr, 0, 0, type, Axiom::Global_Dialect, 0, state_.pod.curr_sub++, dbg);
+    const Axiom* axiom(Def::NormalizeFn n, u8 curry, u8 trip, const Def* type, const Def* dbg = {}) {
+        return axiom(n, curry, trip, type, Axiom::Global_Dialect, 0, state_.pod.curr_sub++, dbg);
     }
+    const Axiom* axiom(const Def* type, const Def* dbg = {}) { return axiom(nullptr, 0, 0, type, dbg); } ///< See above.
 
     /// Get Axiom from a dialect.
     /// Use this to get an Axiom via Axiom::id.

--- a/thorin/world.h
+++ b/thorin/world.h
@@ -189,12 +189,13 @@ public:
 
     /// @name Axiom
     ///@{
-    const Axiom* axiom(Def::NormalizeFn n, const Def* type, dialect_t d, tag_t t, sub_t s, const Def* dbg = {}) {
-        auto ax                          = unify<Axiom>(0, n, type, d, t, s, dbg);
+    const Axiom*
+    axiom(Def::NormalizeFn n, u8 curry, u8 trip, const Def* type, dialect_t d, tag_t t, sub_t s, const Def* dbg = {}) {
+        auto ax                          = unify<Axiom>(0, n, curry, trip, type, d, t, s, dbg);
         return move_.axioms[ax->flags()] = ax;
     }
     const Axiom* axiom(const Def* type, dialect_t d, tag_t t, sub_t s, const Def* dbg = {}) {
-        return axiom(nullptr, type, d, t, s, dbg);
+        return axiom(nullptr, 0, 0, type, d, t, s, dbg);
     }
 
     /// Builds a fresh Axiom with descending Axiom::sub.
@@ -202,7 +203,7 @@ public:
     /// It uses the dialect Axiom::Global_Dialect and starts with `0` for Axiom::sub and counts up from there.
     /// The Axiom::tag is set to `0` and the Axiom::normalizer to `nullptr`.
     const Axiom* axiom(const Def* type, const Def* dbg = {}) {
-        return axiom(nullptr, type, Axiom::Global_Dialect, 0, state_.pod.curr_sub++, dbg);
+        return axiom(nullptr, 0, 0, type, Axiom::Global_Dialect, 0, state_.pod.curr_sub++, dbg);
     }
 
     /// Get Axiom from a dialect.
@@ -251,12 +252,12 @@ public:
 
     /// @name App
     ///@{
+    template<bool Normalize = true>
     const Def* app(const Def* callee, const Def* arg, const Def* dbg = {});
-    const Def* app(const Def* callee, Defs args, const Def* dbg = {}) { return app(callee, tuple(args), dbg); }
-    /// Same as World::app but does *not* apply NormalizeFn.
-    const Def* raw_app(const Def* callee, const Def* arg, const Def* dbg = {});
-    /// Same as World::app but does *not* apply NormalizeFn.
-    const Def* raw_app(const Def* callee, Defs args, const Def* dbg = {}) { return raw_app(callee, tuple(args), dbg); }
+    template<bool Normalize = true>
+    const Def* app(const Def* callee, Defs args, const Def* dbg = {}) {
+        return app<Normalize>(callee, tuple(args), dbg);
+    }
     ///@}
 
     /// @name Sigma


### PR DESCRIPTION
For a curried App of an Axiom, you only want to trigger normalization at specific spots. For this reason, Thorin maintains a Def::curry_ counter that each App decrements. The Axiom::normalizer() will be triggered when Axiom::curry() becomes `0`. These are also the spots that you can match/force. After that, the counter will be set to Axiom::trip(). E.g., let's say an Axiom has this type:
```
A -> B -> C -> D -> E
          ^         |
          |         |
          +---------+
```
Using an initial value as `5` for Axiom::curry and `3` as Axiom::trip has the effect that here
```
x a b c1 d1 e1 c2 d2 e2 c3 d3 e3
```
the Axiom::normalizer will be triggered after App'ing `e1`, `e2`, and `e3`

In the above case you can use Axiom::infer_curry_and_trip to automatically retrieve these values (happens as default in the frontend). You can specify other values, as you like in the frontend after the normalizer name:
```
.ax foo: A -> B -> C -> D -> E, normalize_foo, 3;    // curry 3, trip 0
.ax foo: A -> B -> C -> D -> E, normalize_foo, 3, 1; // curry 3, trip 1
```
See also the unit test `Axiom::curry` for details.