### PR TITLE
Feature/ptrn group

### DIFF
--- a/dialects/autodiff/autodiff.thorin
+++ b/dialects/autodiff/autodiff.thorin
@@ -123,7 +123,7 @@
 ///
 .lam .extern internal_diff_core_wrap_add!s:.Nat -> .Nat -> (.Cn[[.Idx s, .Idx s], .Cn[.Idx s, .Cn[.Idx s, .Cn[.Idx s, .Idx s]]]]) = 
     .lm m: .Nat -> (.Cn[[.Idx s, .Idx s], .Cn[.Idx s, .Cn[.Idx s, .Cn[.Idx s, .Idx s]]]]) =
-        .cn ![[a:.Idx s, b:.Idx s], ret:.Cn[.Idx s, .Cn[.Idx s, .Cn[.Idx s, .Idx s]]]] = {
+        .cn !((a b:.Idx s), ret:.Cn[.Idx s, .Cn[.Idx s, .Cn[.Idx s, .Idx s]]]) = {
             .let result = %core.wrap.add s m (a,b);
             ret (result, .cn ![i:(.Idx s), pb_ret:(.Cn [.Idx s, .Idx s])] = pb_ret (i,i))
         };
@@ -134,7 +134,7 @@
 /// 
 .lam .extern internal_diff_core_wrap_mul!s:.Nat -> .Nat -> (.Cn[[.Idx s, .Idx s], .Cn[.Idx s, .Cn[.Idx s, .Cn[.Idx s, .Idx s]]]]) = 
     .lm m: .Nat -> (.Cn[[.Idx s, .Idx s], .Cn[.Idx s, .Cn[.Idx s, .Cn[.Idx s, .Idx s]]]]) =
-        .cn ![[a:.Idx s, b:.Idx s], ret:.Cn[.Idx s, .Cn[.Idx s, .Cn[.Idx s, .Idx s]]]] = { 
+        .cn !((a b:.Idx s), ret:.Cn[.Idx s, .Cn[.Idx s, .Cn[.Idx s, .Idx s]]]) = { 
             .let result = %core.wrap.mul s m (a,b);
             ret (result, .cn ![i:(.Idx s), pb_ret:(.Cn [.Idx s, .Idx s])] = { 
                 .let lhs = %core.wrap.mul s m (i,b);

--- a/lit/core/pow.thorin
+++ b/lit/core/pow.thorin
@@ -21,7 +21,7 @@
 /// cont(v):
 ///    ret (a*v)
 /// 
-.con f [[a:I32, b:I32], ret: .Cn [I32]] = {
+.con f ((a b: I32), ret: .Cn I32) = {
     .con pow_then [] = ret (1:I32);
 
     .con pow_cont [v:I32] = {


### PR DESCRIPTION
Just a small feature in the frontend that lets you declare a group of identifiers within a tuple pattern with the same type - similar to Coq and other languages:
```
.con foo(x y z: I32, ret: .Cn I32) = /*...*/;
```
Only works for `()`-style patterns, not for `[]`-style patterns. For `[]`-style patterns it's way more difficult to parse and a questionable feature anyway.