### PR TITLE
[CI] Downgrade MacOS Runner to 11 for now

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-and-test:
     name: Build and test ${{matrix.build-type}} mode
-    runs-on: macos-latest
+    runs-on: macos-11
     strategy:
       matrix:
         build-type: [Debug, Release]


### PR DESCRIPTION
Pin the MacOS runner to MacOS 11.x, since the 12.x makes the download-release-asset action fail.

Since I don't know much about Node.JS I opened an issue against the action's repo: https://github.com/i3h/download-release-asset/issues/9