### PR TITLE
Refactor/core

### DIFF
--- a/dialects/CMakeLists.txt
+++ b/dialects/CMakeLists.txt
@@ -92,6 +92,8 @@ add_thorin_plugin(core
     DEPENDS
         math
         mem
+    HEADER_DEPENDS
+        clos
     INSTALL
 )
 

--- a/dialects/clos/pass/rw/clos2sjlj.cpp
+++ b/dialects/clos/pass/rw/clos2sjlj.cpp
@@ -88,7 +88,7 @@ Lam* Clos2SJLJ::get_throw(const Def* dom) {
         auto [jbuf, rbuf, tag] = env->projs<3>();
         auto [m1, r]           = mem::op_alloc(var->type(), m0)->projs<2>();
         auto m2                = w.call<mem::store>(Defs{m1, r, var});
-        rbuf                   = core::op_bitcast(mem::type_ptr(mem::type_ptr(var->type())), rbuf);
+        rbuf                   = w.call<core::bitcast>(mem::type_ptr(mem::type_ptr(var->type())), rbuf);
         auto m3                = w.call<mem::store>(Defs{m2, rbuf, r});
         tlam->set(false, op_longjmp(m3, jbuf, tag));
         ignore_.emplace(tlam);
@@ -106,7 +106,7 @@ Lam* Clos2SJLJ::get_lpad(Lam* lam, const Def* rb) {
         lpad                    = w.nom_lam(pi)->set("lpad");
         auto [m, env, __]       = split(lpad->var());
         auto [m1, arg_ptr]      = w.call<mem::load>(Defs{m, rb})->projs<2>();
-        arg_ptr                 = core::op_bitcast(mem::type_ptr(dom), arg_ptr);
+        arg_ptr                 = w.call<core::bitcast>(mem::type_ptr(dom), arg_ptr);
         auto [m2, args]         = w.call<mem::load>(Defs{m1, arg_ptr})->projs<2>();
         auto full_args          = (lam->num_doms() == 3) ? rebuild(m2, env, {args}) : rebuild(m2, env, args->ops());
         lpad->app(false, lam, full_args);

--- a/dialects/clos/phase/lower_typed_clos.cpp
+++ b/dialects/clos/phase/lower_typed_clos.cpp
@@ -59,7 +59,7 @@ Lam* LowerTypedClos::make_stub(Lam* lam, enum Mode mode, bool adjust_bb_type) {
         lcm          = w.extract(env_mem, 0_u64)->set("mem");
         env          = w.extract(env_mem, 1_u64)->set("closure_env");
     } else if (mode == Unbox) {
-        env = core::op_bitcast(lam->dom(Clos_Env_Param), env)->set("unboxed_env");
+        env = w.call<core::bitcast>(lam->dom(Clos_Env_Param), env)->set("unboxed_env");
     }
     auto new_args = w.tuple(Array<const Def*>(lam->num_doms(), [&](auto i) {
         return (i == Clos_Env_Param) ? env : (lam->var(i) == mem::mem_var(lam)) ? lcm : *new_lam->var(i);
@@ -123,8 +123,8 @@ const Def* LowerTypedClos::rewrite(const Def* def) {
             map(lvm_, lcm_);
             env = env_ptr;
         }
-        fn  = core::op_bitcast(new_type->op(0), fn);
-        env = core::op_bitcast(new_type->op(1), env);
+        fn  = w.call<core::bitcast>(new_type->op(0), fn);
+        env = w.call<core::bitcast>(new_type->op(1), env);
         return map(def, w.tuple({fn, env}));
     } else if (auto lam = def->isa_nom<Lam>()) {
         return make_stub(lam, No_Env, false);

--- a/dialects/core/be/ll/ll.cpp
+++ b/dialects/core/be/ll/ll.cpp
@@ -553,12 +553,12 @@ std::string Emitter::emit_bb(BB& bb, const Def* def) {
         auto [pointee, addr_space] = force<mem::Ptr>(global->type())->args<2>();
         print(vars_decls_, "{} = global {} {}\n", name, convert(pointee), v_init);
         return globals_[global] = name;
-    } else if (auto nop = match<core::nop>(def)) {
-        auto [a, b] = nop->args<2>([this](auto def) { return emit(def); });
+    } else if (auto nat = match<core::nat>(def)) {
+        auto [a, b] = nat->args<2>([this](auto def) { return emit(def); });
 
-        switch (nop.id()) {
-            case core::nop::add: op = "add"; break;
-            case core::nop::mul: op = "mul"; break;
+        switch (nat.id()) {
+            case core::nat::add: op = "add"; break;
+            case core::nat::mul: op = "mul"; break;
         }
 
         return bb.assign(name, "{} nsw nuw i64 {}, {}", op, a, b);

--- a/dialects/core/be/ll/ll.cpp
+++ b/dialects/core/be/ll/ll.cpp
@@ -192,7 +192,7 @@ std::string Emitter::convert(const Def* type) {
 
 std::string Emitter::convert_ret_pi(const Pi* pi) {
     auto dom = mem::strip_mem_ty(pi->dom());
-    if (dom == world().sigma()) { return "void"; }
+    if (dom == world().sigma()) return "void";
     return convert(dom);
 }
 
@@ -261,9 +261,8 @@ void Emitter::finalize(const Scope& scope) {
             print(func_impls_, "{}:\n", lam->unique_name());
 
             ++tab;
-            for (const auto& part : bb.parts) {
+            for (const auto& part : bb.parts)
                 for (const auto& line : part) tab.print(func_impls_, "{}\n", line.str());
-            }
             --tab;
             func_impls_ << std::endl;
         }
@@ -344,9 +343,8 @@ void Emitter::emit_epilogue(Lam* lam) {
 
         std::vector<std::string> args;
         auto app_args = app->args();
-        for (auto arg : app_args.skip_back()) {
+        for (auto arg : app_args.skip_back())
             if (auto v_arg = emit_unsafe(arg); !v_arg.empty()) args.emplace_back(convert(arg->type()) + " " + v_arg);
-        }
 
         if (app->args().back()->isa<Bot>()) {
             // TODO: Perhaps it'd be better to simply η-wrap this prior to the BE...

--- a/dialects/core/core.h
+++ b/dialects/core/core.h
@@ -99,7 +99,7 @@ namespace thorin {
 /// @name is_commutative/is_associative
 ///@{
 // clang-format off
-constexpr bool is_commutative(core::nop    ) { return true; }
+constexpr bool is_commutative(core::nat    ) { return true; }
 constexpr bool is_commutative(core::wrap id) { return id == core::wrap::add || id == core::wrap::mul; }
 constexpr bool is_commutative(core::ncmp id) { return id == core::ncmp::  e || id == core::ncmp:: ne; }
 constexpr bool is_commutative(core::icmp id) { return id == core::icmp::  e || id == core::icmp:: ne; }

--- a/dialects/core/core.h
+++ b/dialects/core/core.h
@@ -21,23 +21,11 @@ inline Ref mode(World& w, VMode m) {
     return w.lit_nat(std::get<Mode>(m));
 }
 
-/// @name fn - these guys yield the final function to be invoked for the various operations
-///@{
-inline Ref fn_bitcast(Ref dst_t, Ref src_t) {
-    World& w = dst_t->world();
-    return w.app(w.ax<bitcast>(), {dst_t, src_t});
-}
-///@}
-
 /// @name op - these guys build the final function application for the various operations
 ///@{
 inline Ref op(trait o, Ref type) {
     World& w = type->world();
     return w.app(w.ax(o), type);
-}
-inline Ref op_bitcast(Ref dst_t, Ref src) {
-    World& w = dst_t->world();
-    return w.app(fn_bitcast(dst_t, src->type()), src);
 }
 inline Ref op(pe o, Ref def) {
     World& w = def->world();

--- a/dialects/core/core.thorin
+++ b/dialects/core/core.thorin
@@ -49,7 +49,7 @@
 /// | id     | x | o | identity                     |
 /// | t      | x | x | always true                  |
 ///
-.ax %core.bit1(f, neg, id, t): Π.[s: .Nat][.Idx s] -> .Idx s, normalize_bit1;
+.ax %core.bit1(f, neg, id, t): Π.[s: .Nat][.Nat][.Idx s] -> .Idx s, normalize_bit1;
 ///
 /// ### %core.bit2
 ///
@@ -76,7 +76,7 @@
 ///
 .ax %core.bit2( f,      nor, nciff, nfst, niff, nsnd, xor_, nand,
                 and_,  nxor,   snd,  iff,  fst, ciff,  or_,    t):
-    Π.[s: .Nat][«2; .Idx s»] -> .Idx s , normalize_bit2;
+    Π.[s: .Nat][.Nat][«2; .Idx s»] -> .Idx s , normalize_bit2;
 ///
 /// ### %core.shr
 ///

--- a/dialects/core/core.thorin
+++ b/dialects/core/core.thorin
@@ -189,7 +189,7 @@
 /// Bitcast to reinterpret a value as another type.
 /// Can be used for pointer / integer conversions as well as integer / nat conversions.
 ///
-.ax %core.bitcast: Π [D: *, S: *][S] -> D, normalize_bitcast;
+.ax %core.bitcast: Π.[S: *][D: *][S] -> D, normalize_bitcast;
 ///
 /// ## Other Operations
 ///

--- a/dialects/core/core.thorin
+++ b/dialects/core/core.thorin
@@ -8,11 +8,11 @@
 ///
 /// ## Nat Operations
 ///
-/// ### %core.nop
+/// ### %core.nat
 ///
 /// Standard arithmetic operations on `.Nat`s.
 ///
-.ax %core.nop(add, mul): «2; .Nat» -> .Nat, normalize_nop;
+.ax %core.nat(add, mul): «2; .Nat» -> .Nat, normalize_nat;
 ///
 /// ### %core.ncmp
 ///

--- a/dialects/core/normalizers.cpp
+++ b/dialects/core/normalizers.cpp
@@ -241,17 +241,20 @@ template<bit1 id>
 Ref normalize_bit1(Ref type, Ref c, Ref a) {
     auto& world = type->world();
     auto callee = c->as<App>();
-    auto l      = isa_lit(a);
+    // TODO cope with wrap around
 
-    if (auto ls = isa_lit(callee->arg())) {
+    if constexpr (id == bit1::id) return a;
+
+    if (auto ls = isa_lit(callee->decurry()->arg())) {
         switch (id) {
             case bit1::f: return world.lit_idx(*ls, 0);
             case bit1::t: return world.lit_idx(*ls, *ls - 1_u64);
-            case bit1::id: return a;
+            case bit1::id: unreachable();
             default: break;
         }
 
-        if (l) return world.lit_idx_mod(*ls, ~*l);
+        assert(id == bit1::neg);
+        if (auto la = isa_lit(a)) return world.lit_idx_mod(*ls, ~*la);
     }
 
     return world.raw_app(type, callee, a);
@@ -289,7 +292,8 @@ Ref normalize_bit2(Ref type, Ref c, Ref arg) {
     auto& world = type->world();
     auto callee = c->as<App>();
     auto [a, b] = arg->projs<2>();
-    auto ls     = isa_lit(callee->arg());
+    auto ls     = isa_lit(callee->decurry()->arg());
+    // TODO cope with wrap around
 
     commute(id, a, b);
 

--- a/dialects/core/normalizers.cpp
+++ b/dialects/core/normalizers.cpp
@@ -540,12 +540,13 @@ Ref normalize_conv(Ref dst_t, Ref c, Ref x) {
 
 Ref normalize_bitcast(Ref dst_t, Ref callee, Ref src) {
     auto& world = dst_t->world();
+    auto src_t  = src->type();
 
     if (src->isa<Bot>()) return world.bot(dst_t);
-    if (src->type() == dst_t) return src;
+    if (src_t == dst_t) return src;
 
     if (auto other = match<bitcast>(src))
-        return other->arg()->type() == dst_t ? other->arg() : *op_bitcast(dst_t, other->arg());
+        return other->arg()->type() == dst_t ? other->arg() : world.call<bitcast>(dst_t, other->arg());
 
     if (auto lit = src->isa<Lit>()) {
         if (dst_t->isa<Nat>()) return world.lit(dst_t, lit->get());

--- a/dialects/core/normalizers.cpp
+++ b/dialects/core/normalizers.cpp
@@ -173,8 +173,8 @@ static Ref reassociate(Id id, World& world, [[maybe_unused]] const App* ab, Ref 
     return nullptr;
 }
 
-template<nop id>
-Ref normalize_nop(Ref type, Ref callee, Ref arg) {
+template<nat id>
+Ref normalize_nat(Ref type, Ref callee, Ref arg) {
     auto& world = type->world();
     auto [a, b] = arg->projs<2>();
     commute(id, a, b);
@@ -182,8 +182,8 @@ Ref normalize_nop(Ref type, Ref callee, Ref arg) {
     if (auto la = isa_lit(a)) {
         if (auto lb = isa_lit(b)) {
             switch (id) {
-                case nop::add: return world.lit_nat(*la + *lb);
-                case nop::mul: return world.lit_nat(*la * *lb);
+                case nat::add: return world.lit_nat(*la + *lb);
+                case nat::mul: return world.lit_nat(*la * *lb);
             }
         }
     }
@@ -604,7 +604,7 @@ Ref normalize_trait(Ref nat, Ref callee, Ref type) {
     } else if (auto arr = type->isa_structural<Arr>()) {
         auto align = op(trait::align, arr->body());
         if constexpr (id == trait::align) return align;
-        if (auto b = op(trait::size, arr->body())->isa<Lit>()) return world.call(core::nop::mul, Defs{arr->shape(), b});
+        if (auto b = op(trait::size, arr->body())->isa<Lit>()) return world.call(nat::mul, Defs{arr->shape(), b});
     } else if (auto join = type->isa<Join>()) {
         if (auto sigma = convert(join)) return core::op(id, sigma);
     }

--- a/gtest/restricted_dep_types.cpp
+++ b/gtest/restricted_dep_types.cpp
@@ -54,37 +54,37 @@ TEST(RestrictedDependentTypes, join_singleton) {
             cases;
         cases.emplace_back([](World& w, auto R, auto, auto Exp, auto exp_lam, auto DT, auto RW, auto i32_t, auto) {
             EXPECT_NO_THROW( // no type error
-                w.app(exp_lam,
-                      {i32_t, R, core::op_bitcast(w.app(Exp, {w.vel(DT, i32_t), w.vel(RW, R)}), w.lit(i32_t, 1000)),
-                       w.nom_lam(w.cn(i32_t))}));
+                w.app(exp_lam, {i32_t, R,
+                                w.call<core::bitcast>(w.app(Exp, {w.vel(DT, i32_t), w.vel(RW, R)}), w.lit(i32_t, 1000)),
+                                w.nom_lam(w.cn(i32_t))}));
         });
         cases.emplace_back([](World& w, auto, auto W, auto Exp, auto exp_lam, auto DT, auto RW, auto i32_t, auto) {
             EXPECT_NO_THROW( // no type error
-                w.app(exp_lam,
-                      {i32_t, W, core::op_bitcast(w.app(Exp, {w.vel(DT, i32_t), w.vel(RW, W)}), w.lit(i32_t, 1000)),
-                       w.nom_lam(w.cn(i32_t))}));
+                w.app(exp_lam, {i32_t, W,
+                                w.call<core::bitcast>(w.app(Exp, {w.vel(DT, i32_t), w.vel(RW, W)}), w.lit(i32_t, 1000)),
+                                w.nom_lam(w.cn(i32_t))}));
         });
-        cases.emplace_back(
-            [](World& w, auto R, auto, auto Exp, auto exp_lam, auto DT, auto RW, auto i32_t, auto i64_t) {
-                EXPECT_NO_THROW( // no type error
-                    w.app(exp_lam,
-                          {i64_t, R, core::op_bitcast(w.app(Exp, {w.vel(DT, i64_t), w.vel(RW, R)}), w.lit(i32_t, 1000)),
-                           w.nom_lam(w.cn(i64_t))}));
-            });
-        cases.emplace_back(
-            [](World& w, auto, auto W, auto Exp, auto exp_lam, auto DT, auto RW, auto i32_t, auto i64_t) {
-                EXPECT_NO_THROW( // no type error
-                    w.app(exp_lam,
-                          {i64_t, W, core::op_bitcast(w.app(Exp, {w.vel(DT, i64_t), w.vel(RW, W)}), w.lit(i32_t, 1000)),
-                           w.nom_lam(w.cn(i64_t))}));
-            });
+        cases.emplace_back([](World& w, auto R, auto, auto Exp, auto exp_lam, auto DT, auto RW, auto i32_t,
+                              auto i64_t) {
+            EXPECT_NO_THROW( // no type error
+                w.app(exp_lam, {i64_t, R,
+                                w.call<core::bitcast>(w.app(Exp, {w.vel(DT, i64_t), w.vel(RW, R)}), w.lit(i32_t, 1000)),
+                                w.nom_lam(w.cn(i64_t))}));
+        });
+        cases.emplace_back([](World& w, auto, auto W, auto Exp, auto exp_lam, auto DT, auto RW, auto i32_t,
+                              auto i64_t) {
+            EXPECT_NO_THROW( // no type error
+                w.app(exp_lam, {i64_t, W,
+                                w.call<core::bitcast>(w.app(Exp, {w.vel(DT, i64_t), w.vel(RW, W)}), w.lit(i32_t, 1000)),
+                                w.nom_lam(w.cn(i64_t))}));
+        });
         cases.emplace_back([](World& w, auto R, auto, auto Exp, auto exp_lam, auto DT, auto RW, auto i32_t, auto) {
             EXPECT_NONFATAL_FAILURE( // disable until we have vel type checking..
                 {
                     EXPECT_THROW( // float
                         w.app(exp_lam, {math::type_f32(w), R,
-                                        core::op_bitcast(w.app(Exp, {w.vel(DT, math::type_f32(w)), w.vel(RW, R)}),
-                                                         w.lit(i32_t, 1000)),
+                                        w.call<core::bitcast>(w.app(Exp, {w.vel(DT, math::type_f32(w)), w.vel(RW, R)}),
+                                                              w.lit(i32_t, 1000)),
                                         w.nom_lam(w.cn(math::type_f32(w)))}),
                         std::logic_error);
                 },
@@ -95,8 +95,8 @@ TEST(RestrictedDependentTypes, join_singleton) {
                 {
                     EXPECT_THROW( // float
                         w.app(exp_lam, {math::type_f32(w), W,
-                                        core::op_bitcast(w.app(Exp, {w.vel(DT, math::type_f32(w)), w.vel(RW, W)}),
-                                                         w.lit(i32_t, 1000)),
+                                        w.call<core::bitcast>(w.app(Exp, {w.vel(DT, math::type_f32(w)), w.vel(RW, W)}),
+                                                              w.lit(i32_t, 1000)),
                                         w.nom_lam(w.cn(math::type_f32(w)))}),
                         std::logic_error);
                 },
@@ -106,10 +106,10 @@ TEST(RestrictedDependentTypes, join_singleton) {
             EXPECT_NONFATAL_FAILURE( // disable until we have vel type checking..
                 {
                     EXPECT_THROW( // RW fail
-                        w.app(exp_lam,
-                              {i32_t, i32_t,
-                               core::op_bitcast(w.app(Exp, {w.vel(DT, i32_t), w.vel(RW, i32_t)}), w.lit(i32_t, 1000)),
-                               w.nom_lam(w.cn(i32_t))}),
+                        w.app(exp_lam, {i32_t, i32_t,
+                                        w.call<core::bitcast>(w.app(Exp, {w.vel(DT, i32_t), w.vel(RW, i32_t)}),
+                                                              w.lit(i32_t, 1000)),
+                                        w.nom_lam(w.cn(i32_t))}),
                         std::logic_error);
                 },
                 "std::logic_error");
@@ -118,10 +118,10 @@ TEST(RestrictedDependentTypes, join_singleton) {
             EXPECT_NONFATAL_FAILURE( // disable until we have vel type checking..
                 {
                     EXPECT_THROW( // RW fail
-                        w.app(exp_lam,
-                              {i64_t, i64_t,
-                               core::op_bitcast(w.app(Exp, {w.vel(DT, i64_t), w.vel(RW, i64_t)}), w.lit(i32_t, 1000)),
-                               w.nom_lam(w.cn(i64_t))}),
+                        w.app(exp_lam, {i64_t, i64_t,
+                                        w.call<core::bitcast>(w.app(Exp, {w.vel(DT, i64_t), w.vel(RW, i64_t)}),
+                                                              w.lit(i32_t, 1000)),
+                                        w.nom_lam(w.cn(i64_t))}),
                         std::logic_error);
                 },
                 "std::logic_error");
@@ -142,7 +142,7 @@ TEST(RestrictedDependentTypes, join_singleton) {
 
                 auto exp_lam_pi = w.cn(exp_sig);
                 auto exp_lam    = w.nom_lam(exp_lam_pi);
-                exp_lam->app(false, exp_lam->var(3), core::op_bitcast(exp_lam->var(0_s), exp_lam->var(2_s)));
+                exp_lam->app(false, exp_lam->var(3), w.call<core::bitcast>(exp_lam->var(0_s), exp_lam->var(2_s)));
                 test(w, R, W, Exp, exp_lam, DT, RW, i32_t, i64_t);
             });
         }
@@ -154,13 +154,13 @@ TEST(RestrictedDependentTypes, join_singleton) {
         cases.emplace_back([](World& w, auto R, auto, auto Exp, auto exp_lam, auto DT, auto RW, auto i32_t, auto) {
             EXPECT_NO_THROW( // no type error
                 w.app(exp_lam,
-                      {i32_t, core::op_bitcast(w.app(Exp, {w.vel(DT, i32_t), w.vel(RW, R)}), w.lit(i32_t, 1000)),
+                      {i32_t, w.call<core::bitcast>(w.app(Exp, {w.vel(DT, i32_t), w.vel(RW, R)}), w.lit(i32_t, 1000)),
                        w.nom_lam(w.cn(i32_t))}));
         });
         cases.emplace_back([](World& w, auto R, auto, auto Exp, auto exp_lam, auto DT, auto RW, auto, auto i64_t) {
             EXPECT_NO_THROW( // no type error
                 w.app(exp_lam,
-                      {i64_t, core::op_bitcast(w.app(Exp, {w.vel(DT, i64_t), w.vel(RW, R)}), w.lit(i64_t, 1000)),
+                      {i64_t, w.call<core::bitcast>(w.app(Exp, {w.vel(DT, i64_t), w.vel(RW, R)}), w.lit(i64_t, 1000)),
                        w.nom_lam(w.cn(i64_t))}));
         });
         cases.emplace_back([](World& w, auto R, auto, auto Exp, auto exp_lam, auto DT, auto RW, auto i32_t, auto) {
@@ -168,8 +168,8 @@ TEST(RestrictedDependentTypes, join_singleton) {
                 {
                     EXPECT_THROW( // float type error
                         w.app(exp_lam, {math::type_f32(w),
-                                        core::op_bitcast(w.app(Exp, {w.vel(DT, math::type_f32(w)), w.vel(RW, R)}),
-                                                         w.lit(i32_t, 1000)),
+                                        w.call<core::bitcast>(w.app(Exp, {w.vel(DT, math::type_f32(w)), w.vel(RW, R)}),
+                                                              w.lit(i32_t, 1000)),
                                         w.nom_lam(w.cn(math::type_f32(w)))}),
                         std::logic_error);
                 },
@@ -178,21 +178,21 @@ TEST(RestrictedDependentTypes, join_singleton) {
         cases.emplace_back([](World& w, auto, auto W, auto Exp, auto exp_lam, auto DT, auto RW, auto i32_t, auto) {
             EXPECT_ANY_THROW( // W type error
                 w.app(exp_lam,
-                      {i32_t, core::op_bitcast(w.app(Exp, {w.vel(DT, i32_t), w.vel(RW, W)}), w.lit(i32_t, 1000)),
+                      {i32_t, w.call<core::bitcast>(w.app(Exp, {w.vel(DT, i32_t), w.vel(RW, W)}), w.lit(i32_t, 1000)),
                        w.nom_lam(w.cn(i32_t))}));
         });
-        cases.emplace_back(
-            [](World& w, auto, auto W, auto Exp, auto exp_lam, auto DT, auto RW, auto i32_t, auto i64_t) {
-                EXPECT_ANY_THROW( // W type error
-                    w.app(exp_lam,
-                          {i64_t, core::op_bitcast(w.app(Exp, {w.vel(DT, i64_t), w.vel(RW, W)}), w.lit(i32_t, 1000)),
-                           w.nom_lam(w.cn(i64_t))}));
-            });
+        cases.emplace_back([](World& w, auto, auto W, auto Exp, auto exp_lam, auto DT, auto RW, auto i32_t,
+                              auto i64_t) {
+            EXPECT_ANY_THROW( // W type error
+                w.app(exp_lam,
+                      {i64_t, w.call<core::bitcast>(w.app(Exp, {w.vel(DT, i64_t), w.vel(RW, W)}), w.lit(i32_t, 1000)),
+                       w.nom_lam(w.cn(i64_t))}));
+        });
         cases.emplace_back([](World& w, auto, auto W, auto Exp, auto exp_lam, auto DT, auto RW, auto, auto) {
             EXPECT_ANY_THROW( // float + W type error (note, the float is not yet what triggers the issue..)
                 w.app(exp_lam, {math::type_f32(w),
-                                core::op_bitcast(w.app(Exp, {w.vel(DT, math::type_f32(w)), w.vel(RW, W)}),
-                                                 w.lit(math::type_f32(w), 1000)),
+                                w.call<core::bitcast>(w.app(Exp, {w.vel(DT, math::type_f32(w)), w.vel(RW, W)}),
+                                                      w.lit(math::type_f32(w), 1000)),
                                 w.nom_lam(w.cn(math::type_f32(w)))}));
         });
 
@@ -210,7 +210,7 @@ TEST(RestrictedDependentTypes, join_singleton) {
 
                 auto exp_lam_pi = w.cn(exp_sig);
                 auto exp_lam    = w.nom_lam(exp_lam_pi);
-                exp_lam->app(false, exp_lam->var(2_s), core::op_bitcast(exp_lam->var(0_s), exp_lam->var(1_s)));
+                exp_lam->app(false, exp_lam->var(2_s), w.call<core::bitcast>(exp_lam->var(0_s), exp_lam->var(1_s)));
                 test(w, R, W, Exp, exp_lam, DT, RW, i32_t, i64_t);
             });
         }
@@ -255,10 +255,11 @@ TEST(RestrictedDependentTypes, ll) {
 
         auto exp_lam_pi = w.cn(exp_sig);
         auto exp_lam    = w.nom_lam(exp_lam_pi);
-        auto bc         = core::op_bitcast(i32_t, exp_lam->var(3_s));
+        auto bc         = w.call<core::bitcast>(i32_t, exp_lam->var(3_s));
         exp_lam->app(false, exp_lam->var(4), {exp_lam->var(0_s), bc});
 
-        main->app(false, exp_lam, {main->var(0_s), i32_t, R, core::op_bitcast(app_exp, main->var(1)), main->var(3)});
+        main->app(false, exp_lam,
+                  {main->var(0_s), i32_t, R, w.call<core::bitcast>(app_exp, main->var(1)), main->var(3)});
     }
 
     optimize(w);

--- a/lit/affine/for_over_mem.thorin.disabled_extract
+++ b/lit/affine/for_over_mem.thorin.disabled_extract
@@ -12,7 +12,7 @@
 .con .extern main [mem : %mem.M, argc : I32, argv : %mem.Ptr (%mem.Ptr (I32, 0), 0), return : .Cn [%mem.M, I32]] = {
     // .let arr_size = 16;
     .let arr_size = ⊤:.Nat;
-    .let (alloc_mem, ptr) = %mem.alloc (<<%core.bitcast (.Nat, I32) argc; I32>>, 0) (mem);
+    .let (alloc_mem, ptr) = %mem.alloc (<<%core.bitcast .Nat argc; I32>>, 0) (mem);
     .con for_exit acc :: [mem : %mem.M, I32, I32] = {
         .let lea = %mem.lea (arr_size, <arr_size; I32>, 0) (ptr, %core.conv.u arr_size (%core.wrap.sub 0 (argc, 4:I32)));
         .let (load_mem, val) = %mem.load (mem, lea);

--- a/lit/autodiff/general/tangent_type_cast.thorin
+++ b/lit/autodiff/general/tangent_type_cast.thorin
@@ -14,12 +14,12 @@
 .con .extern main [mem : %mem.M, argc : I32, argv : %mem.Ptr (%mem.Ptr (.Idx 256, 0), 0), return : .Cn [%mem.M, I32]] = {
 
     .con ret_cont r::[%autodiff.Tangent I32] = {
-        .let r2=%core.bitcast (I32,(%autodiff.Tangent I32)) r;
+        .let r2=%core.bitcast I32 r;
         return (mem, r2)
     };
 
     .con ret_wrap r::[I32] = {
-        .let r2=%core.bitcast ((%autodiff.Tangent I32),I32) r;
+        .let r2=%core.bitcast (%autodiff.Tangent I32) r;
         ret_cont r2
     };
 

--- a/lit/clos/array.thorin
+++ b/lit/clos/array.thorin
@@ -28,8 +28,8 @@
 
     .let arr_size = ⊤:.Nat;
 
-    .let (alloc_pb_mem, pb_arr) = %mem.alloc (<<%core.bitcast (.Nat, I32) 4:I32; pb_type>>, 0) (mem);
-    .let (alloc_mem, a_arr) = %mem.alloc (<<%core.bitcast (.Nat, I32) 4:I32; I32>>, 0) (alloc_pb_mem);
+    .let (alloc_pb_mem, pb_arr) = %mem.alloc (<<%core.bitcast .Nat 4:I32; pb_type>>, 0) (mem);
+    .let (alloc_mem, a_arr) = %mem.alloc (<<%core.bitcast .Nat 4:I32; I32>>, 0) (alloc_pb_mem);
 
     .let lea_0 = %mem.lea (arr_size, <arr_size; pb_type>, 0) (pb_arr, 0:I32);
     .let mem2 = %mem.store (alloc_mem, lea_0, f);

--- a/lit/clos/bind.thorin
+++ b/lit/clos/bind.thorin
@@ -35,7 +35,7 @@
         println_i32( mem, i , next )
     };
 
-    .let condition = %core.icmp.ul (i, %core.bitcast (i32, .Nat) size);
+    .let condition = %core.icmp.ul (i, %core.bitcast i32 size);
     .let target = (exit, loop_body)#condition;
     target ( mem )
 };

--- a/lit/clos/loopDiff.thorin
+++ b/lit/clos/loopDiff.thorin
@@ -36,7 +36,7 @@
             printNL (mem, return)
         };
 
-        .let condition = %core.icmp.ul (i, %core.bitcast (i32, .Nat) size);
+        .let condition = %core.icmp.ul (i, %core.bitcast i32 size);
         .let target = (exit, enter)#condition;
         target ( mem )
     };
@@ -63,7 +63,7 @@
             loop_body ( mem, i, yield )
         };
 
-        .let condition = %core.icmp.ul (i, %core.bitcast (i32, .Nat) size);
+        .let condition = %core.icmp.ul (i, %core.bitcast i32 size);
         .let target = (return, enter)#condition;
         target ( mem )
     };
@@ -91,7 +91,7 @@
             loop_body ( mem, i, yield )
         };
 
-        .let condition = %core.icmp.ul (i, %core.bitcast (i32, .Nat) size);
+        .let condition = %core.icmp.ul (i, %core.bitcast i32 size);
         .let target = (return, enter)#condition;
         target ( mem )
     };
@@ -117,11 +117,7 @@
 
     .let pb_type = .Cn [%mem.M, .Cn [%mem.M]];
     .let (alloc_pb_mem, pb_ptr) = %mem.malloc (pb_type, 0) (alloc_mem_cd, 32); // besser slot
-
-    .let pb_arr = %core.bitcast (
-       %mem.Ptr («⊤:.Nat; pb_type», 0),
-       %mem.Ptr (pb_type, 0)) pb_ptr;
-
+    .let pb_arr = %core.bitcast (%mem.Ptr («⊤:.Nat; pb_type», 0)) pb_ptr;
     .let lea_pb = %mem.lea (⊤:.Nat, <⊤:.Nat; pb_type>, 0) (pb_arr, 0:i32);
     .let mem_assign_pb_anchor = %mem.store (alloc_pb_mem, lea_pb, end);
 
@@ -217,7 +213,7 @@
                 loop_body ( mem, i, yield )
             };
 
-            .let condition = %core.icmp.ul (i, %core.bitcast (i32, .Nat) size);
+            .let condition = %core.icmp.ul (i, %core.bitcast i32 size);
             .let target = (exit, enter)#condition;
             target ( mem )
         // .con yield [mem: %mem.M] = {

--- a/lit/clos/loopDiff2.thorin
+++ b/lit/clos/loopDiff2.thorin
@@ -37,7 +37,7 @@
             printNL (mem, return)
         };
 
-        .let condition = %core.icmp.ul (i, %core.bitcast (i32, .Nat) size);
+        .let condition = %core.icmp.ul (i, %core.bitcast i32 size);
         .let target = (exit, enter)#condition;
         target ( mem )
     };
@@ -64,7 +64,7 @@
             loop_body ( mem, i, yield )
         };
 
-        .let condition = %core.icmp.ul (i, %core.bitcast (i32, .Nat) size);
+        .let condition = %core.icmp.ul (i, %core.bitcast i32 size);
         .let target = (return, enter)#condition;
         target ( mem )
     };
@@ -92,7 +92,7 @@
             loop_body ( mem, i, yield )
         };
 
-        .let condition = %core.icmp.ul (i, %core.bitcast (i32, .Nat) size);
+        .let condition = %core.icmp.ul (i, %core.bitcast i32 size);
         .let target = (return, enter)#condition;
         target ( mem )
     };
@@ -115,11 +115,7 @@
 
     .let pb_type = .Cn [%mem.M, i32, .Cn [%mem.M]];
     .let (alloc_pb_mem, pb_ptr) = %mem.alloc (<<size; pb_type>>, 0) (alloc_mem_cd);
-
-    .let pb_arr = %core.bitcast (
-       %mem.Ptr («⊤:.Nat; pb_type», 0),
-       %mem.Ptr (<<size; pb_type>>, 0)) pb_ptr;
-
+    .let pb_arr = %core.bitcast (%mem.Ptr («⊤:.Nat; pb_type», 0)) pb_ptr;
     .let finish_mem = alloc_pb_mem;
 
     .con loop_body [mem: %mem.M, i : i32, return : .Cn %mem.M] = {
@@ -215,7 +211,7 @@
                 backward_pass ( backward_pass_mem, 1:i32, yield )
             };
 
-            .let condition = %core.icmp.ul (i, %core.bitcast (i32, .Nat) size);
+            .let condition = %core.icmp.ul (i, %core.bitcast i32 size);
             .let target = (timer, enter)#condition;
             target ( mem )
         };
@@ -234,7 +230,7 @@
                 loop_body ( mem, i, yield )
             };
 
-            .let condition = %core.icmp.ul (i, %core.bitcast (i32, .Nat) size);
+            .let condition = %core.icmp.ul (i, %core.bitcast i32 size);
             .let target = (exit, enter)#condition;
             target ( mem )
         };

--- a/lit/clos/loopDiffSave.thorin
+++ b/lit/clos/loopDiffSave.thorin
@@ -41,13 +41,13 @@
 
     .let arr_size = ⊤:.Nat;
 
-    .let (alloc_mem_a, a_arr) = %mem.alloc (<<%core.bitcast (.Nat, i32) 4:i32; i32>>, 0) (mem);
-    .let (alloc_mem_b, b_arr) = %mem.alloc (<<%core.bitcast (.Nat, i32) 4:i32; i32>>, 0) (alloc_mem_a);
-    .let (alloc_mem_c, c_arr) = %mem.alloc (<<%core.bitcast (.Nat, i32) 4:i32; i32>>, 0) (alloc_mem_b);
+    .let (alloc_mem_a, a_arr) = %mem.alloc (<<4; i32>>, 0) (mem);
+    .let (alloc_mem_b, b_arr) = %mem.alloc (<<4; i32>>, 0) (alloc_mem_a);
+    .let (alloc_mem_c, c_arr) = %mem.alloc (<<4; i32>>, 0) (alloc_mem_b);
 
-    .let (alloc_mem_ad, ad_arr) = %mem.alloc (<<%core.bitcast (.Nat, i32) 4:i32; i32>>, 0) (alloc_mem_c);
-    .let (alloc_mem_bd, bd_arr) = %mem.alloc (<<%core.bitcast (.Nat, i32) 4:i32; i32>>, 0) (alloc_mem_ad);
-    .let (alloc_mem_cd, cd_arr) = %mem.alloc (<<%core.bitcast (.Nat, i32) 4:i32; i32>>, 0) (alloc_mem_bd);
+    .let (alloc_mem_ad, ad_arr) = %mem.alloc (<<4; i32>>, 0) (alloc_mem_c);
+    .let (alloc_mem_bd, bd_arr) = %mem.alloc (<<4; i32>>, 0) (alloc_mem_ad);
+    .let (alloc_mem_cd, cd_arr) = %mem.alloc (<<4; i32>>, 0) (alloc_mem_bd);
 
     .con finish_pb_trace [mem: %mem.M, return : .Cn %mem.M] = {
             // TODO: check if fix is correct
@@ -57,10 +57,7 @@
     .let pb_type = .Cn [%mem.M, .Cn [%mem.M]];
     .let (alloc_pb_mem, pb_ptr) = %mem.malloc (pb_type, 0) (mem, 32);
 
-    .let pb_arr = %core.bitcast (
-       %mem.Ptr («⊤:.Nat; .Cn [%mem.M, .Cn [%mem.M]]», 0),
-       %mem.Ptr (.Cn [%mem.M, .Cn [%mem.M]], 0)) pb_ptr;
-
+    .let pb_arr = %core.bitcast (%mem.Ptr («⊤:.Nat; .Cn [%mem.M, .Cn [%mem.M]]», 0)) pb_ptr;
     .let lea_pb = %mem.lea (⊤:.Nat, <⊤:.Nat; pb_type>, 0) (pb_arr, 0:i32);
     .let mem_assign_pb_anchor = %mem.store (alloc_pb_mem, lea_pb, finish_pb_trace);
 

--- a/lit/clos/malloc.thorin
+++ b/lit/clos/malloc.thorin
@@ -28,32 +28,22 @@
     .let arr_size = ⊤:.Nat;
 
     .let (alloc_pb_mem, pb_ptr) = %mem.malloc Tas (mem, 32);
-
-    .let pb_arr = %core.bitcast (
-       %mem.Ptr («⊤:.Nat; .Cn [%mem.M, (.Idx 4294967296), .Cn [%mem.M, (.Idx 4294967296)]]», 0),
-       %mem.Ptr (.Cn [%mem.M, (.Idx 4294967296), .Cn [%mem.M, (.Idx 4294967296)]], 0)) pb_ptr;
-
-    .let (alloc_mem, a_arr) = %mem.alloc (<<%core.bitcast (.Nat, I32) 4:I32; I32>>, 0) (alloc_pb_mem);
+    .let pb_arr = %core.bitcast (%mem.Ptr («⊤:.Nat; .Cn [%mem.M, (.Idx 4294967296), .Cn [%mem.M, (.Idx 4294967296)]]», 0)) pb_ptr;
+    .let (alloc_mem, a_arr) = %mem.alloc (<<4; I32>>, 0) (alloc_pb_mem);
 
     .let lea_0 = %mem.lea (arr_size, <arr_size; pb_type>, 0) (pb_arr, 0:I32);
-    .let mem2 = %mem.store (alloc_mem, lea_0, f);
+    .let mem2  = %mem.store (alloc_mem, lea_0, f);
     .let lea_1 = %mem.lea (arr_size, <arr_size; pb_type>, 0) (pb_arr, 1:I32);
-    .let mem3 = %mem.store (mem2, lea_1, g);
+    .let mem3  = %mem.store (mem2, lea_1, g);
     .let lea_2 = %mem.lea (arr_size, <arr_size; pb_type>, 0) (pb_arr, 2:I32);
-    .let mem4 = %mem.store (mem3, lea_2, h);
-
-    .let lea = %mem.lea (arr_size, <arr_size; I32>, 0) (a_arr, 0:I32);
-
+    .let mem4  = %mem.store (mem3, lea_2, h);
+    .let lea   = %mem.lea (arr_size, <arr_size; I32>, 0) (a_arr, 0:I32);
     .let mem5 = %mem.store (mem4, lea, 10:I32);
-
     .let fn_lea = %mem.lea (arr_size, <arr_size; pb_type>, 0) (pb_arr, 2:I32);
     .let load = %mem.load (mem5, fn_lea);
-
     .let load_mem = load#0:(.Idx 2);
     .let load2 = %mem.load (load_mem, lea);
-
     .let func = load#1:(.Idx 2);
-
     .let load2_mem = load2#0:(.Idx 2);
     .let load2_val = load2#1:(.Idx 2);
 

--- a/lit/clos/malloc.thorin
+++ b/lit/clos/malloc.thorin
@@ -5,51 +5,39 @@
 
 .let I32 = .Idx 4294967296;
 
-.con f [mem: %mem.M, x : I32, return : .Cn [%mem.M, I32]] = {
+.con f [mem: %mem.M, x: I32, return: .Cn [%mem.M, I32]] = {
     return (mem, %core.wrap.add 0 (x, 42:I32))
 };
 
-.con g [mem: %mem.M, x : I32, return : .Cn [%mem.M, I32]] = {
+.con g [mem: %mem.M, x: I32, return: .Cn [%mem.M, I32]] = {
     return (mem, 1:I32)
 };
 
 
-.con .extern main [mem: %mem.M, argc: I32, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .Idx 256», 0)», 0), return : .Cn [%mem.M, I32]] = {
+.con .extern main [mem: %mem.M, argc: I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .Idx 256», 0)», 0), return: .Cn [%mem.M, I32]] = {
+    .con h(mem: %mem.M, x: I32, return: .Cn [%mem.M, I32]) = return (mem, %core.wrap.add 0 (x, argc));
 
-    .con h [mem: %mem.M, x : I32, return : .Cn [%mem.M, I32]] = {
-        return (mem, %core.wrap.add 0 (x, argc))
-    };
-
-    .let pb_type = .Cn [%mem.M, I32, .Cn [%mem.M, I32]];
-    .let Tas = (pb_type, 0);
-
-    .let real_arr_type = (I32, 0);
-
+    .let pb_type  = .Cn [%mem.M, I32, .Cn [%mem.M, I32]];
+    .let Tas      = (pb_type, 0);
     .let arr_size = ⊤:.Nat;
 
-    .let (alloc_pb_mem, pb_ptr) = %mem.malloc Tas (mem, 32);
-    .let pb_arr = %core.bitcast (%mem.Ptr («⊤:.Nat; .Cn [%mem.M, (.Idx 4294967296), .Cn [%mem.M, (.Idx 4294967296)]]», 0)) pb_ptr;
-    .let (alloc_mem, a_arr) = %mem.alloc (<<4; I32>>, 0) (alloc_pb_mem);
+    .let ('mem, pb_ptr) = %mem.malloc Tas (mem, 32);
+    .let pb_arr         = %core.bitcast (%mem.Ptr («⊤:.Nat; .Cn [%mem.M, I32, .Cn [%mem.M, I32]]», 0)) pb_ptr;
+    .let ('mem, a_arr)  = %mem.alloc (<<4; I32>>, 0) (mem);
 
-    .let lea_0 = %mem.lea (arr_size, <arr_size; pb_type>, 0) (pb_arr, 0:I32);
-    .let mem2  = %mem.store (alloc_mem, lea_0, f);
-    .let lea_1 = %mem.lea (arr_size, <arr_size; pb_type>, 0) (pb_arr, 1:I32);
-    .let mem3  = %mem.store (mem2, lea_1, g);
-    .let lea_2 = %mem.lea (arr_size, <arr_size; pb_type>, 0) (pb_arr, 2:I32);
-    .let mem4  = %mem.store (mem3, lea_2, h);
-    .let lea   = %mem.lea (arr_size, <arr_size; I32>, 0) (a_arr, 0:I32);
-    .let mem5 = %mem.store (mem4, lea, 10:I32);
-    .let fn_lea = %mem.lea (arr_size, <arr_size; pb_type>, 0) (pb_arr, 2:I32);
-    .let load = %mem.load (mem5, fn_lea);
-    .let load_mem = load#0:(.Idx 2);
-    .let load2 = %mem.load (load_mem, lea);
-    .let func = load#1:(.Idx 2);
-    .let load2_mem = load2#0:(.Idx 2);
-    .let load2_val = load2#1:(.Idx 2);
+    .let 'lea = %mem.lea (arr_size, <arr_size; pb_type>, 0) (pb_arr, 0:I32);
+    .let 'mem = %mem.store (mem, lea, f);
+    .let 'lea = %mem.lea (arr_size, <arr_size; pb_type>, 0) (pb_arr, 1:I32);
+    .let 'mem = %mem.store (mem, lea, g);
+    .let 'lea = %mem.lea (arr_size, <arr_size; pb_type>, 0) (pb_arr, 2:I32);
+    .let 'mem = %mem.store (mem, lea, h);
+    .let 'lea = %mem.lea (arr_size, <arr_size; I32>, 0) (a_arr, 0:I32);
+    .let 'mem = %mem.store (mem, lea, 10:I32);
+    .let 'lea = %mem.lea (arr_size, <arr_size; pb_type>, 0) (pb_arr, 2:I32);
+    .let ('mem, func) = %mem.load (mem, lea);
+    .let ('mem,  val) = %mem.load (load_mem, lea);
 
-    .con callback (mem: %mem.M, x : I32) = {
-        return (mem, x)
-    };
+    .con callback (mem: %mem.M, x: I32) = return (mem, x);
 
     func(mem, 1:I32, callback)
 };

--- a/lit/clos/malloc.thorin
+++ b/lit/clos/malloc.thorin
@@ -5,14 +5,8 @@
 
 .let I32 = .Idx 4294967296;
 
-.con f [mem: %mem.M, x: I32, return: .Cn [%mem.M, I32]] = {
-    return (mem, %core.wrap.add 0 (x, 42:I32))
-};
-
-.con g [mem: %mem.M, x: I32, return: .Cn [%mem.M, I32]] = {
-    return (mem, 1:I32)
-};
-
+.con f [mem: %mem.M, x: I32, return: .Cn [%mem.M, I32]] = return (mem, %core.wrap.add 0 (x, 42:I32));
+.con g [mem: %mem.M, x: I32, return: .Cn [%mem.M, I32]] = return (mem, 1:I32);
 
 .con .extern main [mem: %mem.M, argc: I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .Idx 256», 0)», 0), return: .Cn [%mem.M, I32]] = {
     .con h(mem: %mem.M, x: I32, return: .Cn [%mem.M, I32]) = return (mem, %core.wrap.add 0 (x, argc));
@@ -23,21 +17,19 @@
 
     .let ('mem, pb_ptr) = %mem.malloc Tas (mem, 32);
     .let pb_arr         = %core.bitcast (%mem.Ptr («⊤:.Nat; .Cn [%mem.M, I32, .Cn [%mem.M, I32]]», 0)) pb_ptr;
-    .let ('mem, a_arr)  = %mem.alloc (<<4; I32>>, 0) (mem);
+    .let ('mem, a_arr)  = %mem.alloc («4; I32», 0) (mem);
 
-    .let 'lea = %mem.lea (arr_size, <arr_size; pb_type>, 0) (pb_arr, 0:I32);
+    .let 'lea = %mem.lea (arr_size, ‹arr_size; pb_type›, 0) (pb_arr, 0:I32);
     .let 'mem = %mem.store (mem, lea, f);
-    .let 'lea = %mem.lea (arr_size, <arr_size; pb_type>, 0) (pb_arr, 1:I32);
+    .let 'lea = %mem.lea (arr_size, ‹arr_size; pb_type›, 0) (pb_arr, 1:I32);
     .let 'mem = %mem.store (mem, lea, g);
-    .let 'lea = %mem.lea (arr_size, <arr_size; pb_type>, 0) (pb_arr, 2:I32);
+    .let 'lea = %mem.lea (arr_size, ‹arr_size; pb_type›, 0) (pb_arr, 2:I32);
     .let 'mem = %mem.store (mem, lea, h);
-    .let 'lea = %mem.lea (arr_size, <arr_size; I32>, 0) (a_arr, 0:I32);
+    .let 'lea = %mem.lea (arr_size, ‹arr_size; I32›, 0) (a_arr, 0:I32);
     .let 'mem = %mem.store (mem, lea, 10:I32);
-    .let 'lea = %mem.lea (arr_size, <arr_size; pb_type>, 0) (pb_arr, 2:I32);
+    .let 'lea = %mem.lea (arr_size, ‹arr_size; pb_type›, 0) (pb_arr, 2:I32);
     .let ('mem, func) = %mem.load (mem, lea);
     .let ('mem,  val) = %mem.load (mem, lea);
 
-    .con callback (mem: %mem.M, x: I32) = return (mem, x);
-
-    func(mem, 1:I32, callback)
+    func(mem, 1:I32, .cn (mem: %mem.M, x: I32) = return (mem, x))
 };

--- a/lit/clos/malloc.thorin
+++ b/lit/clos/malloc.thorin
@@ -35,7 +35,7 @@
     .let 'mem = %mem.store (mem, lea, 10:I32);
     .let 'lea = %mem.lea (arr_size, <arr_size; pb_type>, 0) (pb_arr, 2:I32);
     .let ('mem, func) = %mem.load (mem, lea);
-    .let ('mem,  val) = %mem.load (load_mem, lea);
+    .let ('mem,  val) = %mem.load (mem, lea);
 
     .con callback (mem: %mem.M, x: I32) = return (mem, x);
 

--- a/lit/clos/pass_through_return.thorin
+++ b/lit/clos/pass_through_return.thorin
@@ -20,7 +20,7 @@
     };
 
     .let (alloc_pb_mem, pb_ptr) = %mem.malloc (pb_type, 0) (mem, 100);
-    .let pb_arr = %core.bitcast ( %mem.Ptr («⊤:.Nat; pb_type», 0), %mem.Ptr (pb_type, 0)) pb_ptr;
+    .let pb_arr = %core.bitcast (%mem.Ptr («⊤:.Nat; pb_type», 0)) pb_ptr;
     .let lea_pb = %mem.lea (⊤:.Nat, <⊤:.Nat; pb_type>, 0) (pb_arr, 0:i32);
     .let store_pb = %mem.store (alloc_pb_mem, lea_pb, end);
 

--- a/lit/clos/recursiveLoop.thorin
+++ b/lit/clos/recursiveLoop.thorin
@@ -36,7 +36,7 @@
         printIntegerNL( mem, i , next )
     };
 
-    .let condition = %core.icmp.ul (i, %core.bitcast (I32, .Nat) size);
+    .let condition = %core.icmp.ul (i, %core.bitcast I32 size);
     .let target = (exit, loop_body)#condition;
     target ( mem )
 };

--- a/lit/clos/return_cont_in_closure.thorin
+++ b/lit/clos/return_cont_in_closure.thorin
@@ -15,7 +15,7 @@
     };
 
     .let (alloc_pb_mem, pb_ptr) = %mem.malloc (pb_type, 0) (mem, 100);
-    .let pb_arr = %core.bitcast ( %mem.Ptr («⊤:.Nat; pb_type», 0), %mem.Ptr (pb_type, 0)) pb_ptr;
+    .let pb_arr = %core.bitcast (%mem.Ptr («⊤:.Nat; pb_type», 0)) pb_ptr;
     .let lea_pb = %mem.lea (⊤:.Nat, <⊤:.Nat; pb_type>, 0) (pb_arr, 0:i32);
     .let store_pb = %mem.store (alloc_pb_mem, lea_pb, end);
 

--- a/lit/clos/return_cont_in_closure2.thorin.disabled
+++ b/lit/clos/return_cont_in_closure2.thorin.disabled
@@ -20,7 +20,7 @@ thorin: /dialects/clos/phase/clos_conv.cpp:64: const thorin::Def* thorin::clos::
     };
 
     .let (alloc_pb_mem, pb_ptr) = %mem.malloc (pb_type, 0) (mem, 100);
-    .let pb_arr = %core.bitcast ( %mem.Ptr («⊤:.Nat; pb_type», 0), %mem.Ptr (pb_type, 0)) pb_ptr;
+    .let pb_arr = %core.bitcast %mem.Ptr («⊤:.Nat; pb_type», 0) pb_ptr;
     .let lea_pb = %mem.lea (⊤:.Nat, <⊤:.Nat; pb_type>, 0) (pb_arr, 0:i32);
     .let store_pb = %mem.store (alloc_pb_mem, lea_pb, end);
 

--- a/lit/clos/return_higher_order.thorin.disabled
+++ b/lit/clos/return_higher_order.thorin.disabled
@@ -18,9 +18,7 @@ thorin: /dialects/clos/phase/clos_conv.cpp:64: const thorin::Def* thorin::clos::
     .let pb_type = .Cn [%mem.M];
     .let (alloc_pb_mem, pb_ptr) = %mem.malloc (pb_type, 0) (mem, 32);
 
-    .let pb_arr = %core.bitcast (
-       %mem.Ptr («⊤:.Nat; pb_type», 0),
-       %mem.Ptr (pb_type, 0)) pb_ptr;
+    .let pb_arr = %core.bitcast %mem.Ptr («⊤:.Nat; pb_type», 0) pb_ptr;
 
     .let lea_pb = %mem.lea (⊤:.Nat, <⊤:.Nat; pb_type>, 0) (pb_arr, 0:i32);
     .let store_return_mem = %mem.store (alloc_pb_mem, lea_pb, return);

--- a/lit/clos/return_higher_order2.thorin.disabled
+++ b/lit/clos/return_higher_order2.thorin.disabled
@@ -20,7 +20,7 @@ thorin: /dialects/clos/phase/clos_conv.cpp:64: const thorin::Def* thorin::clos::
 
     .let (alloc_pb_mem, pb_ptr) = %mem.malloc (pb_type, 0) (mem, 1);
 
-    .let pb_arr = %core.bitcast (%mem.Ptr («⊤:.Nat; pb_type», 0), %mem.Ptr (pb_type, 0)) pb_ptr;
+    .let pb_arr = %core.bitcast %mem.Ptr («⊤:.Nat; pb_type», 0) pb_ptr;
 
     .let lea_pb = %mem.lea (⊤:.Nat, <⊤:.Nat; pb_type>, 0) (pb_arr, 0:i32);
     .let store_return_mem = %mem.store (alloc_pb_mem, lea_pb, callback);

--- a/lit/clos/using_c_function.thorin
+++ b/lit/clos/using_c_function.thorin
@@ -25,7 +25,7 @@
 
     .con init22 [mem: %mem.M] = {
         .let (alloc_pb_mem, pb_ptr) = %mem.malloc (pb_type, 0) (mem, 100);
-        .let pb_arr = %core.bitcast ( %mem.Ptr («⊤:.Nat; pb_type», 0), %mem.Ptr (pb_type, 0)) pb_ptr;
+        .let pb_arr = %core.bitcast (%mem.Ptr («⊤:.Nat; pb_type», 0)) pb_ptr;
         .let lea_pb = %mem.lea (⊤:.Nat, <⊤:.Nat; pb_type>, 0) (pb_arr, 0:i32);
         .let store_pb = %mem.store (alloc_pb_mem, lea_pb, end);
 

--- a/lit/core/normalize_and_ff.thorin
+++ b/lit/core/normalize_and_ff.thorin
@@ -4,7 +4,7 @@
 .plugin core;
 
 .con .extern and_ff [i :.Idx 2, return : .Cn .Idx 2] = {
-    return (%core.bit2.and_ (i, .ff))
+    return (%core.bit2.and_ 0 (i, .ff))
 };
 
 // CHECK-DAG: .con .extern and_ff _{{[0-9_]+}}::[.Idx 2, return_[[retId:[0-9_]+]]: .Cn .Idx 2]

--- a/lit/core/normalize_and_ff_tt.thorin
+++ b/lit/core/normalize_and_ff_tt.thorin
@@ -4,7 +4,7 @@
 .plugin core;
 
 .con .extern and_lit_ff_tt [return : .Cn .Idx 2] = {
-    return (%core.bit2.and_ (.ff, .tt))
+    return (%core.bit2.and_ 0 (.ff, .tt))
 };
 
 // CHECK-DAG: and_lit_ff_tt _[[retId_ff_tt:[0-9_]+]]: .Cn .Idx 2

--- a/lit/core/normalize_and_icmps.thorin
+++ b/lit/core/normalize_and_icmps.thorin
@@ -4,7 +4,7 @@
 .plugin core;
 
 .con .extern and (a b: .Bool, return : .Cn .Bool) = {
-    return (%core.bit2.and_ (%core.icmp.uge (a, b), %core.icmp.ug (a, b)))
+    return (%core.bit2.and_ 0 (%core.icmp.uge (a, b), %core.icmp.ug (a, b)))
 };
 
 // CHECK-DAG: .con .extern and _{{[0-9_]+}}::[a_[[aId:[0-9_]+]]: .Idx 2, b_[[bId:[0-9_]+]]: .Idx 2, return_[[retId:[0-9_]+]]: .Cn .Idx 2]

--- a/lit/core/normalize_and_icmps_lit.thorin
+++ b/lit/core/normalize_and_icmps_lit.thorin
@@ -4,7 +4,7 @@
 .plugin core;
 
 .con .extern and_lit [return : .Cn .Idx 2] = {
-    return (%core.bit2.and_ (%core.icmp.uge (.tt, .ff), %core.icmp.ug (.tt, .ff)))
+    return (%core.bit2.and_ 0 (%core.icmp.uge (.tt, .ff), %core.icmp.ug (.tt, .ff)))
 };
 
 // CHECK-DAG: and_lit _[[retId:[0-9_]+]]: .Cn .Idx 2

--- a/lit/core/normalize_and_tree.thorin
+++ b/lit/core/normalize_and_tree.thorin
@@ -5,13 +5,13 @@
 
 .con .extern and_lit [return : .Cn .Idx 2] = {
     return
-    (%core.bit2.and_
-        (%core.bit2.and_
-            (%core.bit2.and_ (.tt, .tt),
-             %core.bit2.and_ (.ff, .ff)),
-         %core.bit2.and_
-            (%core.bit2.and_ (.ff, .tt),
-             %core.bit2.and_ (.tt, .ff))))
+    (%core.bit2.and_ 0
+        (%core.bit2.and_ 0
+            (%core.bit2.and_ 0 (.tt, .tt),
+             %core.bit2.and_ 0 (.ff, .ff)),
+         %core.bit2.and_ 0
+            (%core.bit2.and_ 0 (.ff, .tt),
+             %core.bit2.and_ 0 (.tt, .ff))))
 };
 
 // CHECK-DAG: .con .extern and_lit _[[retId:[0-9_]+]]: .Cn .Idx 2{{(@.*)?}}= {

--- a/lit/core/normalize_and_tt.thorin
+++ b/lit/core/normalize_and_tt.thorin
@@ -4,7 +4,7 @@
 .plugin core;
 
 .con .extern and_tt [i :.Idx 2, return : .Cn .Idx 2] = {
-    return (%core.bit2.and_ (i, .tt))
+    return (%core.bit2.and_ 0 (i, .tt))
 };
 
 // CHECK-DAG: and_tt _{{[0-9_]+}}::[i_[[valId_tt:[0-9_]+]]: .Idx 2, return_[[retId_tt:[0-9_]+]]: .Cn .Idx 2]{{(@.*)?}}= {

--- a/lit/core/normalize_and_tt_tt.thorin
+++ b/lit/core/normalize_and_tt_tt.thorin
@@ -4,7 +4,7 @@
 .plugin core;
 
 .con .extern and_lit_tt_tt [return : .Cn .Idx 2] = {
-    return (%core.bit2.and_ (.tt, .tt))
+    return (%core.bit2.and_ 0 (.tt, .tt))
 };
 
 // CHECK-DAG: .con .extern and_lit_tt_tt _[[retId:[0-9_]+]]: .Cn .Idx 2{{(@.*)?}}= {

--- a/lit/core/normalize_bitcast.thorin
+++ b/lit/core/normalize_bitcast.thorin
@@ -4,12 +4,13 @@
 
 .plugin core;
 
-.con .extern bitcast_bitcast [i : %mem.Ptr (.Idx 256, 0), return : .Cn .Idx 4294967296] = {
-    return (%core.bitcast (.Idx 4294967296, .Nat) (%core.bitcast (.Nat, %mem.Ptr (.Idx 256, 0)) i))
+.con .extern bitcast_bitcast(i : %mem.Ptr (.Idx 256, 0), return: .Cn .Idx 4294967296) = {
+    return (%core.bitcast (.Idx 4294967296) (%core.bitcast .Nat i))
 };
 
+// TODO parenthesis in output broken for bitcast
 // CHECK-DAG: bitcast_bitcast _{{[0-9_]+}}::[i_[[valId:[0-9_]+]]: %mem.Ptr (.Idx 256, 0), return_[[retId:[0-9_]+]]: .Cn .Idx 4294967296]{{(@.*)?}}= {
-// CHECK-DAG: .let _[[castedId:[0-9_]+]]: .Idx 4294967296 = %core.bitcast (.Idx 4294967296, %mem.Ptr (.Idx 256, 0)) i_[[valId]];
+// CHECK-DAG: .let _[[castedId:[0-9_]+]]: .Idx 4294967296 = %core.bitcast %mem.Ptr (.Idx 256, 0) .Idx 4294967296 i_[[valId]];
 // CHECK-DAG: return_[[etaId:[0-9_]+]] _[[castedId]]
 
 // CHECK-DAG: return_[[etaId]] _[[etaVar:[0-9_]+]]: .Idx 4294967296{{(@.*)?}}= {

--- a/lit/core/ret_and.thorin
+++ b/lit/core/ret_and.thorin
@@ -11,7 +11,7 @@
 .con .extern main [mem : %mem.M, argc : .Idx 4294967296, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .Idx 256», 0)», 0), return : .Cn [%mem.M, .Idx 4294967296]] = {
     .con atoi_cont_a [mem : %mem.M, a : .Idx 4294967296] = {
         .con atoi_cont_b [mem : %mem.M, b : .Idx 4294967296] = {
-                return (mem, %core.bit2.and_ (a, b))
+                return (mem, %core.bit2.and_ 0 (a, b))
         };
 
         .let argv_ptr_b = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .Idx 256», 0)›, 0) (argv, 2:(.Idx 4294967296));
@@ -29,4 +29,4 @@
 // CHECK-DAG: atoi_cont_a_[[aContId:[0-9_]+]] _{{[0-9_]+}}::[mem_{{[0-9]+}}: %mem.M, a_[[aId:[0-9_]+]]: .Idx 4294967296]
 
 // CHECK-DAG: atoi_cont_b_[[bContId:[0-9_]+]] _{{[0-9_]+}}::[mem_{{[0-9]+}}: %mem.M, b_[[bId:[0-9_]+]]: .Idx 4294967296]
-// CHECK-DAG: %core.bit2.and_ 4294967296 (a_[[aId]], b_[[bId]])
+// CHECK-DAG: %core.bit2.and_ 4294967296 0 (a_[[aId]], b_[[bId]])

--- a/lit/core/ret_nand.thorin
+++ b/lit/core/ret_nand.thorin
@@ -13,7 +13,7 @@
 .con .extern main [mem: %mem.M, argc: I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .Idx 256», 0)», 0), return: .Cn [%mem.M, I32]] = {
     .con atoi_cont_a [mem: %mem.M, a: I32] = {
         .con atoi_cont_b [mem: %mem.M, b: I32] = {
-                return (mem, %core.bit2.and_ (0b00000000000000000000000000001111:I32, %core.bit2.nand (a, b)))
+            return (mem, %core.bit2.and_ 0 (0b00000000000000000000000000001111:I32, %core.bit2.nand 0 (a, b)))
         };
 
         .let argv_ptr_b = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .Idx 256», 0)›, 0) (argv, 2:I32);
@@ -22,6 +22,6 @@
     };
 
     .let argv_ptr_a = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .Idx 256», 0)›, 0) (argv, 1:I32);
-    .let argv_load_a = %mem.load (mem, argv_ptr_a);
-    atoi (argv_load_a#.ff, argv_load_a#.tt, atoi_cont_a)
+    .let ('mem, val) = %mem.load (mem, argv_ptr_a);
+    atoi (mem, val, atoi_cont_a)
 };

--- a/lit/refly/refine.thorin
+++ b/lit/refly/refine.thorin
@@ -13,7 +13,7 @@
     .let exp = %refly.reify <<4; .Nat>> (0, 1, 2, 3);
     .let new = %refly.refine (exp, 1, %refly.reify .Nat 42);
     .let tup = %refly.reflect <<4; .Nat>> new;
-    .let x   = %core.bitcast (I64, .Nat) tup#1_4;
+    .let x   = %core.bitcast I64 tup#1_4;
     return (mem, %core.conv.u _32 x)
 };
 


### PR DESCRIPTION
# Changes

* `%core.nop` -> `%core.nat`: 
    `nop` usually means sth entirely differently.
* Use **implicit** `D`st type for `%core.bitcast`:
    `.ax %core.bitcast: Π [D: *, S: *][S] -> D` -> `.ax %core.bitcast: Π.[S: *][D: *][S] -> D`
* showcasing some of the newer features of Thorin in `lit/clos/malloc.thorin`
* adds wrap around parameter to deal with non-power of two `.Idx` in `core::bit1` & `core::bit2`
    See Discord discussion. Instead of casting to `bit_floor` or adding proof certificates, I just added the solution we already have for `%core::wrap`: add another (`.Nat`) flag that determines the overflow behavior. Rn, however, nobody is really doing anything with this flag. This is sth for future work.