### PR TITLE
always use "lib" as prefix

### DIFF
--- a/cmake/Thorin.cmake
+++ b/cmake/Thorin.cmake
@@ -119,6 +119,7 @@ function(add_thorin_plugin)
             CXX_VISIBILITY_PRESET hidden
             VISIBILITY_INLINES_HIDDEN 1
             WINDOWS_EXPORT_ALL_SYMBOLS OFF
+            PREFIX "lib" # always use "lib" as prefix regardless of OS/compiler
             LIBRARY_OUTPUT_DIRECTORY ${THORIN_LIB_DIR}
     )
 

--- a/thorin/driver.cpp
+++ b/thorin/driver.cpp
@@ -9,7 +9,7 @@ namespace thorin {
 static std::vector<fs::path> get_plugin_name_variants(std::string_view name) {
     std::vector<fs::path> names;
     names.push_back(name); // if the user gives "libthorin_foo.so"
-    names.push_back(fmt("{}thorin_{}{}", dl::prefix(), name, dl::extension()));
+    names.push_back(fmt("libthorin_{}{}", name, dl::extension()));
     return names;
 }
 

--- a/thorin/driver.cpp
+++ b/thorin/driver.cpp
@@ -1,6 +1,7 @@
 #include "thorin/driver.h"
 
 #include "thorin/plugin.h"
+
 #include "thorin/util/dl.h"
 #include "thorin/util/sys.h"
 
@@ -39,9 +40,8 @@ Driver::Driver()
 }
 
 const fs::path* Driver::add_import(fs::path path, Sym sym) {
-    for (const auto& [p, _] : imports_) {
+    for (const auto& [p, _] : imports_)
         if (fs::equivalent(p, path)) return nullptr;
-    }
 
     imports_.emplace_back(std::pair(std::move(path), sym));
     return &imports_.back().first;

--- a/thorin/util/dl.cpp
+++ b/thorin/util/dl.cpp
@@ -14,14 +14,6 @@
 
 namespace thorin::dl {
 
-std::string_view prefix() {
-#ifdef _WIN32
-    return "";
-#else
-    return "lib";
-#endif
-}
-
 std::string_view extension() {
 #ifdef _WIN32
     return ".dll";

--- a/thorin/util/dl.cpp
+++ b/thorin/util/dl.cpp
@@ -32,14 +32,12 @@ void* open(const std::string& file) {
             file, GetLastError());
     }
 #else
-    if (void* handle = dlopen(file.c_str(), RTLD_NOW)) {
+    if (void* handle = dlopen(file.c_str(), RTLD_NOW))
         return handle;
-    } else {
-        if (char* error = dlerror())
-            err("could not load plugin '{}' due to error '{}'\n", file, error);
-        else
-            err("could not load plugin '{}'\n", file);
-    }
+    else if (char* error = dlerror())
+        err("could not load plugin '{}' due to error '{}'\n", file, error);
+    else
+        err("could not load plugin '{}'\n", file);
 #endif
 }
 
@@ -55,11 +53,10 @@ void* get(void* handle, const std::string& symbol) {
 #else
     dlerror(); // clear error state
     void* addr = dlsym(handle, symbol.c_str());
-    if (char* error = dlerror()) {
+    if (char* error = dlerror())
         err("could not find symbol '{}' in plugin due to error '{}' \n", symbol, error);
-    } else {
+    else
         return addr;
-    }
 #endif
 }
 

--- a/thorin/util/dl.h
+++ b/thorin/util/dl.h
@@ -11,7 +11,6 @@ public:
         : std::runtime_error(what_arg) {}
 };
 
-std::string_view prefix();    ///< `"lib"` or `""`
 std::string_view extension(); ///< `".dll"` or `".so"`
 
 void* open(const std::string& filename);


### PR DESCRIPTION
MinGW + Win uses lib as prefix which breaks our assumption in `dl::prefix`. This patch simply overrides the prefix to always use "lib" regardless of OS/compiler.