### PR TITLE
Refactor/mut

### DIFF
--- a/dialects/affine/passes/lower_for.cpp
+++ b/dialects/affine/passes/lower_for.cpp
@@ -12,18 +12,18 @@ const Def* LowerFor::rewrite(const Def* def) {
 
     if (auto for_ax = match<affine::For>(def)) {
         auto& w = world();
-        w.DLOG("rewriting for axiom: {} within {}", for_ax, curr_nom());
+        w.DLOG("rewriting for axiom: {} within {}", for_ax, curr_mut());
 
         auto for_pi = for_ax->callee_type();
         DefArray for_dom{for_pi->num_doms() - 2, [&](size_t i) { return for_pi->dom(i); }};
-        auto for_lam = w.nom_lam(w.cn(for_dom))->set("for");
+        auto for_lam = w.mut_lam(w.cn(for_dom))->set("for");
 
         auto body = for_ax->arg(for_ax->num_args() - 2)->set("body");
         auto brk  = for_ax->arg(for_ax->num_args() - 1)->set("break");
 
         auto body_type = body->type()->as<Pi>();
         auto yield_pi  = body_type->doms().back()->as<Pi>();
-        auto yield_lam = w.nom_lam(yield_pi)->set("yield");
+        auto yield_lam = w.mut_lam(yield_pi)->set("yield");
 
         { // construct yield
             auto [iter, end, step, acc] = for_lam->vars<4>();
@@ -40,13 +40,13 @@ const Def* LowerFor::rewrite(const Def* def) {
             auto [iter, end, step, acc] = for_lam->vars<4>();
 
             // reduce the body to remove the cn parameter
-            auto nom_body = body->as_nom<Lam>();
-            auto new_body = nom_body->stub(w, w.cn(acc->type()))->set(body->dbg());
-            new_body->set(nom_body->reduce(w.tuple({iter, new_body->var(), yield_lam})));
+            auto mut_body = body->as_mut<Lam>();
+            auto new_body = mut_body->stub(w, w.cn(acc->type()))->set(body->dbg());
+            new_body->set(mut_body->reduce(w.tuple({iter, new_body->var(), yield_lam})));
 
             // break
             auto if_else_cn = w.cn(acc->type());
-            auto if_else    = w.nom_lam(if_else_cn);
+            auto if_else    = w.mut_lam(if_else_cn);
             if_else->app(false, brk, if_else->var());
 
             auto cmp = w.call(core::icmp::ul, Defs{iter, end});

--- a/dialects/affine/passes/lower_for.cpp
+++ b/dialects/affine/passes/lower_for.cpp
@@ -7,7 +7,7 @@
 
 namespace thorin::affine {
 
-const Def* LowerFor::rewrite(const Def* def) {
+Ref LowerFor::rewrite(Ref def) {
     if (auto i = rewritten_.find(def); i != rewritten_.end()) return i->second;
 
     if (auto for_ax = match<affine::For>(def)) {

--- a/dialects/affine/passes/lower_for.h
+++ b/dialects/affine/passes/lower_for.h
@@ -11,7 +11,7 @@ public:
     LowerFor(PassMan& man)
         : RWPass(man, "lower_affine_for") {}
 
-    const Def* rewrite(const Def*) override;
+    Ref rewrite(Ref) override;
 
 private:
     Def2Def rewritten_;

--- a/dialects/autodiff/auxiliary/autodiff_aux.cpp
+++ b/dialects/autodiff/auxiliary/autodiff_aux.cpp
@@ -13,7 +13,7 @@ namespace thorin::autodiff {
 const Def* id_pullback(const Def* A) {
     auto& world       = A->world();
     auto arg_pb_ty    = pullback_type(A, A);
-    auto id_pb        = world.nom_lam(arg_pb_ty)->set("id_pb");
+    auto id_pb        = world.mut_lam(arg_pb_ty)->set("id_pb");
     auto id_pb_scalar = id_pb->var(0_s)->set("s");
     id_pb->app(true,
                id_pb->var(1), // can not use ret_var as the result might be higher order
@@ -26,7 +26,7 @@ const Def* zero_pullback(const Def* E, const Def* A) {
     auto& world    = A->world();
     auto A_tangent = tangent_type_fun(A);
     auto pb_ty     = pullback_type(E, A);
-    auto pb        = world.nom_lam(pb_ty)->set("zero_pb");
+    auto pb        = world.mut_lam(pb_ty)->set("zero_pb");
     world.DLOG("zero_pullback for {} resp. {} (-> {})", E, A, A_tangent);
     pb->app(true, pb->var(1), op_zero(A_tangent));
     return pb;
@@ -105,7 +105,7 @@ const Def* autodiff_type_fun(const Def* ty) {
         return world.arr(shape, body_ad);
     }
     if (auto sig = ty->isa<Sigma>()) {
-        // TODO: nom sigma
+        // TODO: mut sigma
         DefArray ops(sig->ops(), [&](const Def* op) { return autodiff_type_fun(op); });
         world.DLOG("ops: {,}", ops);
         return world.sigma(ops);
@@ -236,8 +236,8 @@ const Def* compose_continuation(const Def* f, const Def* g) {
     auto H     = world.cn({A, world.cn(C)});
     auto Hcont = world.cn(B);
 
-    auto h     = world.nom_lam(H)->set("comp_"s + *f->sym() + "_"s + *g->sym());
-    auto hcont = world.nom_lam(Hcont)->set("comp_"s + *f->sym() + "_"s + *g->sym() + "_cont"s);
+    auto h     = world.mut_lam(H)->set("comp_"s + *f->sym() + "_"s + *g->sym());
+    auto hcont = world.mut_lam(Hcont)->set("comp_"s + *f->sym() + "_"s + *g->sym() + "_cont"s);
 
     h->app(true, g, {h->var((nat_t)0), hcont});
 

--- a/dialects/autodiff/auxiliary/autodiff_aux.cpp
+++ b/dialects/autodiff/auxiliary/autodiff_aux.cpp
@@ -92,10 +92,10 @@ const Pi* autodiff_type_fun_pi(const Pi* pi) {
 const Def* autodiff_type_fun(const Def* ty) {
     auto& world = ty->world();
     // TODO: handle DS (operators)
-    if (auto pi = ty->isa<Pi>()) { return autodiff_type_fun_pi(pi); }
+    if (auto pi = ty->isa<Pi>()) return autodiff_type_fun_pi(pi);
     // Also handles autodiff call from axiom declaration => abstract => leave it.
     world.DLOG("AutoDiff on type: {} <{}>", ty, ty->node_name());
-    if (Idx::size(ty)) { return ty; }
+    if (Idx::size(ty)) return ty;
     if (ty == world.type_nat()) return ty;
     if (auto arr = ty->isa<Arr>()) {
         auto shape   = arr->shape();
@@ -156,7 +156,7 @@ const Def* op_sum(const Def* T, DefArray defs) {
 namespace thorin {
 
 bool is_continuation_type(const Def* E) {
-    if (auto pi = E->isa<Pi>()) { return pi->codom()->isa<Bot>(); }
+    if (auto pi = E->isa<Pi>()) return pi->codom()->isa<Bot>();
     return false;
 }
 
@@ -185,7 +185,7 @@ bool is_direct_style_function(const Def* e) {
 const Def* continuation_dom(const Def* E) {
     auto pi = E->as<Pi>();
     assert(pi != NULL);
-    if (pi->num_doms() == 0) { return pi->dom(); }
+    if (pi->num_doms() == 0) return pi->dom();
     return pi->dom(0);
 }
 

--- a/dialects/autodiff/auxiliary/autodiff_rewrite_inner.cpp
+++ b/dialects/autodiff/auxiliary/autodiff_rewrite_inner.cpp
@@ -64,7 +64,7 @@ const Def* AutoDiffEval::augment_lam(Lam* lam, Lam* f, Lam* f_diff) {
         world.DLOG("pb type is {}", pb_ty);
         auto aug_ty = world.cn({aug_dom, pb_ty});
         world.DLOG("augmented type is {}", aug_ty);
-        auto aug_lam              = world.nom_lam(aug_ty)->set("aug_"s + *lam->sym());
+        auto aug_lam              = world.mut_lam(aug_ty)->set("aug_"s + *lam->sym());
         auto aug_var              = aug_lam->var((nat_t)0);
         augmented[lam->var()]     = aug_var;
         augmented[lam]            = aug_lam; // TODO: only one of these two
@@ -117,7 +117,7 @@ const Def* AutoDiffEval::augment_extract(const Extract* ext, Lam* f, Lam* f_diff
         assert(partial_pullback.count(aug_tuple));
         auto tuple_pb = partial_pullback[aug_tuple];
         auto pb_ty    = pullback_type(ext->type(), f_arg_ty);
-        auto pb_fun   = world.nom_lam(pb_ty)->set("extract_pb");
+        auto pb_fun   = world.mut_lam(pb_ty)->set("extract_pb");
         world.DLOG("Pullback: {} : {}", pb_fun, pb_fun->type());
         auto pb_tangent = pb_fun->var(0_s)->set("s");
         auto tuple_tan  = world.insert(op_zero(aug_tuple->type()), aug_index, pb_tangent)->set("tup_s");
@@ -154,7 +154,7 @@ const Def* AutoDiffEval::augment_tuple(const Tuple* tup, Lam* f, Lam* f_diff) {
     //      ((cps2ds e0*) (s#0), ..., (cps2ds em*) (s#m))
     // ```
     auto pb_ty = pullback_type(tup->type(), f_arg_ty);
-    auto pb    = world.nom_lam(pb_ty)->set("tup_pb");
+    auto pb    = world.mut_lam(pb_ty)->set("tup_pb");
     world.DLOG("Augmented tuple: {} : {}", aug_tup, aug_tup->type());
     world.DLOG("Tuple Pullback: {} : {}", pb, pb->type());
     world.DLOG("shadow pb: {} : {}", shadow_pb, shadow_pb->type());
@@ -190,12 +190,12 @@ const Def* AutoDiffEval::augment_pack(const Pack* pack, Lam* f, Lam* f_diff) {
     world.DLOG("shadow pb of pack: {} : {}", pb_pack, pb_pack->type());
 
     auto pb_type = pullback_type(pack->type(), f_arg_ty);
-    auto pb      = world.nom_lam(pb_type)->set("pack_pb");
+    auto pb      = world.mut_lam(pb_type)->set("pack_pb");
 
     world.DLOG("pb of pack: {} : {}", pb, pb_type);
 
     auto f_arg_ty_diff = tangent_type_fun(f_arg_ty);
-    auto app_pb        = world.nom_pack(world.arr(aug_shape, f_arg_ty_diff));
+    auto app_pb        = world.mut_pack(world.arr(aug_shape, f_arg_ty_diff));
 
     // TODO: special case for const width (special tuple)
 
@@ -307,7 +307,7 @@ const Def* AutoDiffEval::augment_app(const App* app, Lam* f, Lam* f_diff) {
         world.DLOG("ret_g_deriv_ty: {} ", ret_g_deriv_ty);
         auto c1_ty = ret_g_deriv_ty->as<Pi>();
         world.DLOG("c1_ty: (cn[X, cn[X+, cn E+]]) {}", c1_ty);
-        auto c1   = world.nom_lam(c1_ty)->set("c1");
+        auto c1   = world.mut_lam(c1_ty)->set("c1");
         auto res  = c1->var((nat_t)0);
         auto r_pb = c1->var(1);
         c1->app(true, aug_cont, {res, compose_continuation(e_pb, r_pb)});
@@ -343,12 +343,12 @@ const Def* AutoDiffEval::augment_(const Def* def, Lam* f, Lam* f_diff) {
     } else if (auto var = def->isa<Var>()) {
         world.DLOG("Augment variable: {}", var);
         return augment_var(var, f, f_diff);
-    } else if (auto lam = def->isa_nom<Lam>()) {
-        world.DLOG("Augment nom lambda: {}", lam);
+    } else if (auto lam = def->isa_mut<Lam>()) {
+        world.DLOG("Augment mut lambda: {}", lam);
         return augment_lam(lam, f, f_diff);
     } else if (auto lam = def->isa<Lam>()) {
         world.ELOG("Augment lambda: {}", lam);
-        assert(false && "can not handle non-nominal lambdas");
+        assert(false && "can not handle non-mutable lambdas");
     } else if (auto lit = def->isa<Lit>()) {
         world.DLOG("Augment literal: {}", def);
         return augment_lit(lit, f, f_diff);
@@ -356,7 +356,7 @@ const Def* AutoDiffEval::augment_(const Def* def, Lam* f, Lam* f_diff) {
         world.DLOG("Augment tuple: {}", def);
         return augment_tuple(tup, f, f_diff);
     } else if (auto pack = def->isa<Pack>()) {
-        // TODO: handle nom packs (dependencies in the pack) (=> see paper about vectors)
+        // TODO: handle mut packs (dependencies in the pack) (=> see paper about vectors)
         auto shape = pack->arity(); // TODO: arity vs shape
         auto body  = pack->body();
         world.DLOG("Augment pack: {} : {} with {}", shape, shape->type(), body);

--- a/dialects/autodiff/auxiliary/autodiff_rewrite_toplevel.cpp
+++ b/dialects/autodiff/auxiliary/autodiff_rewrite_toplevel.cpp
@@ -20,7 +20,7 @@ Ref AutoDiffEval::derive_(Ref def) {
 
     auto [arg_ty, ret_pi] = lam->type()->doms<2>();
     auto deriv_all_args   = deriv->var();
-    Ref deriv_arg  = deriv->var(0_s)->set("arg");
+    Ref deriv_arg         = deriv->var(0_s)->set("arg");
 
     // We generate the shadow pullbacks dynamically to save work and avoid code duplication.
     // Only the toplevel pullback for arguments and return continuation is special cased.

--- a/dialects/autodiff/auxiliary/autodiff_rewrite_toplevel.cpp
+++ b/dialects/autodiff/auxiliary/autodiff_rewrite_toplevel.cpp
@@ -7,10 +7,10 @@ namespace thorin::autodiff {
 /// Additionally to the derivation, the pullback is registered and the maps are initialized.
 const Def* AutoDiffEval::derive_(const Def* def) {
     auto& world = def->world();
-    auto lam    = def->as_nom<Lam>(); // TODO check if nominal
+    auto lam    = def->as_mut<Lam>(); // TODO check if mutable
     world.DLOG("Derive lambda: {}", def);
     auto deriv_ty = autodiff_type_fun_pi(lam->type());
-    auto deriv    = world.nom_lam(deriv_ty)->set(*lam->sym() + "_deriv");
+    auto deriv    = world.mut_lam(deriv_ty)->set(*lam->sym() + "_deriv");
 
     // We first pre-register the derivatives.
     // This knowledge is needed for recursion.

--- a/dialects/autodiff/auxiliary/autodiff_rewrite_toplevel.cpp
+++ b/dialects/autodiff/auxiliary/autodiff_rewrite_toplevel.cpp
@@ -5,7 +5,7 @@
 namespace thorin::autodiff {
 
 /// Additionally to the derivation, the pullback is registered and the maps are initialized.
-const Def* AutoDiffEval::derive_(const Def* def) {
+Ref AutoDiffEval::derive_(Ref def) {
     auto& world = def->world();
     auto lam    = def->as_mut<Lam>(); // TODO check if mutable
     world.DLOG("Derive lambda: {}", def);
@@ -20,7 +20,7 @@ const Def* AutoDiffEval::derive_(const Def* def) {
 
     auto [arg_ty, ret_pi] = lam->type()->doms<2>();
     auto deriv_all_args   = deriv->var();
-    const Def* deriv_arg  = deriv->var(0_s)->set("arg");
+    Ref deriv_arg  = deriv->var(0_s)->set("arg");
 
     // We generate the shadow pullbacks dynamically to save work and avoid code duplication.
     // Only the toplevel pullback for arguments and return continuation is special cased.

--- a/dialects/autodiff/normalizers.cpp
+++ b/dialects/autodiff/normalizers.cpp
@@ -66,7 +66,7 @@ Ref normalize_add(Ref type, Ref callee, Ref arg) {
     } else if (auto arr = T->isa<Arr>()) {
         // TODO: is this working for non-lit (non-tuple) or do we need a loop?
         world.DLOG("add arrays {} {} {}", T, a, b);
-        auto pack      = world.nom_pack(T);
+        auto pack      = world.mut_pack(T);
         auto body_type = arr->body();
         world.DLOG("body type {}", body_type);
         pack->set(world.app(world.app(world.ax<add>(), body_type),

--- a/dialects/autodiff/normalizers.cpp
+++ b/dialects/autodiff/normalizers.cpp
@@ -99,7 +99,7 @@ Ref normalize_sum(Ref type, Ref callee, Ref arg) {
         DefArray args = arg->projs(val);
         auto sum      = world.app(world.ax<zero>(), T);
         // This special case would also be handled by add zero
-        if (val >= 1) { sum = args[0]; }
+        if (val >= 1) sum = args[0];
         for (size_t i = 1; i < val; ++i) sum = world.app(world.app(world.ax<add>(), T), {sum, args[i]});
         return sum;
     }

--- a/dialects/autodiff/passes/autodiff_eval.cpp
+++ b/dialects/autodiff/passes/autodiff_eval.cpp
@@ -33,7 +33,7 @@ Ref AutoDiffEval::rewrite(Ref def) {
         auto arg = ad_app->arg();
         world().DLOG("found a autodiff::autodiff of {}", arg);
 
-        if (arg->isa<Lam>()) { return derive(arg); }
+        if (arg->isa<Lam>()) return derive(arg);
 
         // TODO: handle operators analogous
 

--- a/dialects/autodiff/passes/autodiff_eval.cpp
+++ b/dialects/autodiff/passes/autodiff_eval.cpp
@@ -13,19 +13,19 @@
 namespace thorin::autodiff {
 
 // TODO: maybe use template (https://codereview.stackexchange.com/questions/141961/memoization-via-template) to memoize
-const Def* AutoDiffEval::augment(const Def* def, Lam* f, Lam* f_diff) {
+Ref AutoDiffEval::augment(Ref def, Lam* f, Lam* f_diff) {
     if (auto i = augmented.find(def); i != augmented.end()) return i->second;
     augmented[def] = augment_(def, f, f_diff);
     return augmented[def];
 }
 
-const Def* AutoDiffEval::derive(const Def* def) {
+Ref AutoDiffEval::derive(Ref def) {
     if (auto i = derived.find(def); i != derived.end()) return i->second;
     derived[def] = derive_(def);
     return derived[def];
 }
 
-const Def* AutoDiffEval::rewrite(const Def* def) {
+Ref AutoDiffEval::rewrite(Ref def) {
     if (auto ad_app = match<ad>(def); ad_app) {
         // callee = autodiff T
         // arg = function of type T

--- a/dialects/autodiff/passes/autodiff_eval.h
+++ b/dialects/autodiff/passes/autodiff_eval.h
@@ -13,13 +13,13 @@ public:
         : RWPass(man, "autodiff_eval") {}
 
     /// Detect autodiff calls.
-    const Def* rewrite(const Def*) override;
+    Ref rewrite(Ref) override;
 
     /// Acts on toplevel autodiff on closed terms:
     /// * Replaces lambdas, operators with the appropriate derivatives.
     /// * Creates new lambda, calls associate variables, init maps, calls augment.
-    const Def* derive(const Def*);
-    const Def* derive_(const Def*);
+    Ref derive(Ref);
+    Ref derive_(Ref);
 
     /// Applies to (open) expressions in a functional context.
     /// Returns the rewritten expressions and augments the partial and modular pullbacks.
@@ -27,16 +27,16 @@ public:
     /// Otherwise, only pullbacks are added.
     /// To do so, some calls (e.g. axioms) are replaced by their derivatives.
     /// This transformation can be seen as an augmentation with a dual computation that generates the derivatives.
-    const Def* augment(const Def*, Lam*, Lam*);
-    const Def* augment_(const Def*, Lam*, Lam*);
+    Ref augment(Ref, Lam*, Lam*);
+    Ref augment_(Ref, Lam*, Lam*);
     /// helper functions for augment
-    const Def* augment_var(const Var*, Lam*, Lam*);
-    const Def* augment_lam(Lam*, Lam*, Lam*);
-    const Def* augment_extract(const Extract*, Lam*, Lam*);
-    const Def* augment_app(const App*, Lam*, Lam*);
-    const Def* augment_lit(const Lit*, Lam*, Lam*);
-    const Def* augment_tuple(const Tuple*, Lam*, Lam*);
-    const Def* augment_pack(const Pack* pack, Lam* f, Lam* f_diff);
+    Ref augment_var(const Var*, Lam*, Lam*);
+    Ref augment_lam(Lam*, Lam*, Lam*);
+    Ref augment_extract(const Extract*, Lam*, Lam*);
+    Ref augment_app(const App*, Lam*, Lam*);
+    Ref augment_lit(const Lit*, Lam*, Lam*);
+    Ref augment_tuple(const Tuple*, Lam*, Lam*);
+    Ref augment_pack(const Pack* pack, Lam* f, Lam* f_diff);
 
 private:
     /// Transforms closed terms (lambda, operator) to derived expressions.

--- a/dialects/autodiff/passes/autodiff_zero.cpp
+++ b/dialects/autodiff/passes/autodiff_zero.cpp
@@ -12,7 +12,7 @@
 
 namespace thorin::autodiff {
 
-const Def* AutoDiffZero::rewrite(const Def* def) {
+Ref AutoDiffZero::rewrite(Ref def) {
     if (auto zero_app = match<zero>(def); zero_app) {
         // callee = zero
         // arg = type T

--- a/dialects/autodiff/passes/autodiff_zero.h
+++ b/dialects/autodiff/passes/autodiff_zero.h
@@ -11,7 +11,7 @@ public:
     AutoDiffZero(PassMan& man)
         : RWPass(man, "autodiff_zero") {}
 
-    const Def* rewrite(const Def*) override;
+    Ref rewrite(Ref) override;
 };
 
 } // namespace thorin::autodiff

--- a/dialects/autodiff/passes/autodiff_zero_cleanup.cpp
+++ b/dialects/autodiff/passes/autodiff_zero_cleanup.cpp
@@ -11,7 +11,7 @@
 
 namespace thorin::autodiff {
 
-const Def* AutoDiffZeroCleanup::rewrite(const Def* def) {
+Ref AutoDiffZeroCleanup::rewrite(Ref def) {
     // Ideally this code segment is never reached.
     // (all zeros are resolved before)
     if (auto zero_app = match<zero>(def); zero_app) {

--- a/dialects/autodiff/passes/autodiff_zero_cleanup.h
+++ b/dialects/autodiff/passes/autodiff_zero_cleanup.h
@@ -11,7 +11,7 @@ public:
     AutoDiffZeroCleanup(PassMan& man)
         : RWPass(man, "autodiff_zero_cleanup") {}
 
-    const Def* rewrite(const Def*) override;
+    Ref rewrite(Ref) override;
 };
 
 } // namespace thorin::autodiff

--- a/dialects/clos/clos.cpp
+++ b/dialects/clos/clos.cpp
@@ -37,7 +37,7 @@ Ref ClosLit::fnc() {
 Lam* ClosLit::fnc_as_lam() {
     auto f = fnc();
     if (auto a = match<attr>(f)) f = a->arg();
-    return f->isa_nom<Lam>();
+    return f->isa_mut<Lam>();
 }
 
 Ref ClosLit::env_var() { return fnc_as_lam()->var(Clos_Env_Param); }
@@ -91,7 +91,7 @@ Ref clos_apply(Ref closure, Ref args) {
 
 const Sigma* isa_clos_type(Ref def) {
     auto& w  = def->world();
-    auto sig = def->isa_nom<Sigma>();
+    auto sig = def->isa_mut<Sigma>();
     if (!sig || sig->num_ops() < 3 || sig->op(0_u64) != w.type()) return nullptr;
     auto var = sig->var(0_u64);
     if (sig->op(2_u64) != var) return nullptr;
@@ -99,7 +99,7 @@ const Sigma* isa_clos_type(Ref def) {
     return (pi && pi->is_cn() && pi->num_ops() > 1_u64 && pi->dom(Clos_Env_Param) == var) ? sig : nullptr;
 }
 
-Sigma* clos_type(const Pi* pi) { return ctype(pi->world(), pi->doms(), nullptr)->as_nom<Sigma>(); }
+Sigma* clos_type(const Pi* pi) { return ctype(pi->world(), pi->doms(), nullptr)->as_mut<Sigma>(); }
 
 const Pi* clos_type_to_pi(Ref ct, Ref new_env_type) {
     assert(isa_clos_type(ct));
@@ -121,7 +121,7 @@ Ref clos_remove_env(size_t i, std::function<Ref(size_t)> f) { return f(skip_env(
 
 Ref ctype(World& w, Defs doms, Ref env_type) {
     if (!env_type) {
-        auto sigma = w.nom_sigma(w.type(), 3_u64)->set("Clos");
+        auto sigma = w.mut_sigma(w.type(), 3_u64)->set("Clos");
         sigma->set(0_u64, w.type());
         sigma->set(1_u64, ctype(w, doms, sigma->var(0_u64)));
         sigma->set(2_u64, sigma->var(0_u64));

--- a/dialects/clos/clos.h
+++ b/dialects/clos/clos.h
@@ -93,12 +93,12 @@ inline Ref apply_closure(Ref closure, Defs args) {
 }
 
 // TODO: rename this
-/// Checks is def is the variable of a nom of type N.
+/// Checks is def is the variable of a mut of type N.
 template<class N>
 std::tuple<const Extract*, N*> ca_isa_var(Ref def) {
     if (auto proj = def->isa<Extract>()) {
-        if (auto var = proj->tuple()->isa<Var>(); var && var->nom()->isa<N>())
-            return std::tuple(proj, var->nom()->as<N>());
+        if (auto var = proj->tuple()->isa<Var>(); var && var->mut()->isa<N>())
+            return std::tuple(proj, var->mut()->as<N>());
     }
     return {nullptr, nullptr};
 }

--- a/dialects/clos/pass/fp/lower_typed_clos_prep.cpp
+++ b/dialects/clos/pass/fp/lower_typed_clos_prep.cpp
@@ -8,7 +8,7 @@
 namespace thorin::clos {
 
 static bool interesting_type(const Def* type, DefSet& visited) {
-    if (type->isa_nom()) visited.insert(type);
+    if (type->isa_mut()) visited.insert(type);
     if (isa_clos_type(type)) return true;
     if (auto sigma = type->isa<Sigma>())
         return std::any_of(sigma->ops().begin(), sigma->ops().end(),
@@ -52,7 +52,7 @@ undo_t LowerTypedClosPrep::set_esc(const Def* def) {
     auto undo = No_Undo;
     for (auto d : split(def, false)) {
         if (is_esc(d)) continue;
-        if (auto lam = d->isa_nom<Lam>())
+        if (auto lam = d->isa_mut<Lam>())
             undo = std::min(undo, undo_visit(lam));
         else if (auto [var, lam] = ca_isa_var<Lam>(d); var && lam)
             undo = std::min(undo, undo_visit(lam));
@@ -88,7 +88,7 @@ undo_t LowerTypedClosPrep::analyze(const Def* def) {
         for (auto i = 0_u64; i < app->num_args(); i++) {
             if (!interesting_type(app->arg(i))) continue;
             if (std::any_of(callees.begin(), callees.end(), [&](const Def* callee) {
-                    if (auto lam = callee->isa_nom<Lam>()) return is_esc(lam->var(i));
+                    if (auto lam = callee->isa_mut<Lam>()) return is_esc(lam->var(i));
                     return true;
                 }))
                 undo = std::min(undo, set_esc(app->arg(i)));

--- a/dialects/clos/pass/fp/lower_typed_clos_prep.h
+++ b/dialects/clos/pass/fp/lower_typed_clos_prep.h
@@ -13,14 +13,14 @@ public:
         : FPPass<LowerTypedClosPrep, Lam>(man, "lower_typed_clos_prep") {}
 
 private:
-    const Def* rewrite(const Def*) override;
-    undo_t analyze(const Def*) override;
+    Ref rewrite(Ref) override;
+    undo_t analyze(Ref) override;
 
-    bool is_esc(const Def* def) {
+    bool is_esc(Ref def) {
         if (auto [_, lam] = ca_isa_var<Lam>(def); lam && !lam->is_set()) return true;
         return esc_.contains(def);
     }
-    undo_t set_esc(const Def*);
+    undo_t set_esc(Ref);
 
     DefSet esc_;
 };

--- a/dialects/clos/pass/rw/branch_clos_elim.cpp
+++ b/dialects/clos/pass/rw/branch_clos_elim.cpp
@@ -9,12 +9,11 @@ static std::tuple<std::vector<ClosLit>, Ref> isa_branch(Ref callee) {
         auto inner_proj = closure_proj->tuple()->isa<Extract>();
         if (inner_proj && inner_proj->tuple()->isa<Tuple>() && isa_clos_type(inner_proj->type())) {
             auto branches = std::vector<ClosLit>();
-            for (auto op : inner_proj->tuple()->ops()) {
+            for (auto op : inner_proj->tuple()->ops())
                 if (auto c = isa_clos_lit(op))
                     branches.push_back(std::move(c));
                 else
                     return {};
-            }
             return {branches, inner_proj->index()};
         }
     }

--- a/dialects/clos/pass/rw/branch_clos_elim.cpp
+++ b/dialects/clos/pass/rw/branch_clos_elim.cpp
@@ -4,7 +4,7 @@
 
 namespace thorin::clos {
 
-static std::tuple<std::vector<ClosLit>, const Def*> isa_branch(const Def* callee) {
+static std::tuple<std::vector<ClosLit>, Ref> isa_branch(Ref callee) {
     if (auto closure_proj = callee->isa<Extract>()) {
         auto inner_proj = closure_proj->tuple()->isa<Extract>();
         if (inner_proj && inner_proj->tuple()->isa<Tuple>() && isa_clos_type(inner_proj->type())) {
@@ -21,7 +21,7 @@ static std::tuple<std::vector<ClosLit>, const Def*> isa_branch(const Def* callee
     return {};
 }
 
-const Def* BranchClosElim::rewrite(const Def* def) {
+Ref BranchClosElim::rewrite(Ref def) {
     auto& w  = world();
     auto app = def->isa<App>();
     if (!app || !app->callee_type()->is_cn()) return def;

--- a/dialects/clos/pass/rw/branch_clos_elim.h
+++ b/dialects/clos/pass/rw/branch_clos_elim.h
@@ -15,7 +15,7 @@ public:
         : RWPass(man, "unbox_closures")
         , branch2dropped_() {}
 
-    const Def* rewrite(const Def*) override;
+    Ref rewrite(Ref) override;
 
 private:
     DefMap<Lam*> branch2dropped_;

--- a/dialects/clos/pass/rw/clos2sjlj.cpp
+++ b/dialects/clos/pass/rw/clos2sjlj.cpp
@@ -144,7 +144,8 @@ void Clos2SJLJ::enter() {
         auto env             = w.tuple(body->args().skip_front());
         auto new_callee      = w.mut_lam(w.cn({mem::type_mem(w), env->type()}))->set("sjlj_wrap");
         auto [m, env_var, _] = split(new_callee->var());
-        auto new_args = DefArray(env->num_projs() + 1, [&](auto i) -> const Def* { return (i == 0) ? *m : env_var->proj(i - 1); });
+        auto new_args =
+            DefArray(env->num_projs() + 1, [&](auto i) -> const Def* { return (i == 0) ? *m : env_var->proj(i - 1); });
         new_callee->app(false, body->callee(), new_args);
         branches[0] = clos_pack(env, new_callee, branch_type);
     }

--- a/dialects/clos/pass/rw/clos2sjlj.h
+++ b/dialects/clos/pass/rw/clos2sjlj.h
@@ -17,29 +17,29 @@ public:
         , ignore_() {}
 
     void enter() override;
-    const Def* rewrite(const Def*) override;
+    Ref rewrite(Ref) override;
 
 private:
-    const Def* void_ptr() { return mem::type_ptr(world().type_int(8)); }
-    const Def* jb_type() { return void_ptr(); }
-    const Def* rb_type() { return mem::type_ptr(void_ptr()); }
-    const Def* tag_type() { return world().type_int(32); }
+    Ref void_ptr() { return mem::type_ptr(world().type_int(8)); }
+    Ref jb_type() { return void_ptr(); }
+    Ref rb_type() { return mem::type_ptr(void_ptr()); }
+    Ref tag_type() { return world().type_int(32); }
 
-    Lam* get_throw(const Def* res_type);
-    Lam* get_lpad(Lam* lam, const Def* rb);
+    Lam* get_throw(Ref res_type);
+    Lam* get_lpad(Lam* lam, Ref rb);
 
     void get_exn_closures();
-    void get_exn_closures(const Def* def, DefSet& visited);
+    void get_exn_closures(Ref def, DefSet& visited);
 
     // clang-format off
-    LamMap<std::pair<int, const Def*>> lam2tag_;
+    LamMap<std::pair<int, Ref>> lam2tag_;
     DefMap<Lam*> dom2throw_;
     DefMap<Lam*> lam2lpad_;
     LamSet ignore_;
     // clang-format on
 
-    const Def* cur_rbuf_ = nullptr;
-    const Def* cur_jbuf_ = nullptr;
+    Ref cur_rbuf_ = nullptr;
+    Ref cur_jbuf_ = nullptr;
 };
 
 } // namespace thorin::clos

--- a/dialects/clos/pass/rw/clos_conv_prep.cpp
+++ b/dialects/clos/pass/rw/clos_conv_prep.cpp
@@ -7,22 +7,22 @@
 namespace thorin::clos {
 
 // FIXME: these guys do not work if another pass rewrites curr_mut()'s body
-static bool isa_cont(const App* body, const Def* def, size_t i) {
+static bool isa_cont(const App* body, Ref def, size_t i) {
     return body->callee_type()->is_returning() && body->arg() == def && i == def->num_ops() - 1;
 }
 
-static const Def* isa_br(const App* body, const Def* def) {
+static Ref isa_br(const App* body, Ref def) {
     if (!body->callee_type()->is_cn()) return nullptr;
     auto proj = body->callee()->isa<Extract>();
     return (proj && proj->tuple() == def && proj->tuple()->isa<Tuple>()) ? proj->tuple() : nullptr;
 }
 
-static bool isa_callee_br(const App* body, const Def* def, size_t i) {
+static bool isa_callee_br(const App* body, Ref def, size_t i) {
     if (!body->callee_type()->is_cn()) return false;
     return isa_callee(def, i) || isa_br(body, def);
 }
 
-static Lam* isa_retvar(const Def* def) {
+static Lam* isa_retvar(Ref def) {
     if (auto [var, lam] = ca_isa_var<Lam>(def); var && lam && var == lam->ret_var()) return lam;
     return nullptr;
 }
@@ -60,8 +60,8 @@ const App* ClosConvPrep::rewrite_arg(const App* app) {
     for (auto i = 0u; i < arg->num_projs(); i++) {
         auto op = arg->proj(i);
 
-        auto refine = [&](const Def* new_op) {
-            const Def* args;
+        auto refine = [&](Ref new_op) {
+            Ref args;
             if (arg == op)
                 args = new_op;
             else
@@ -127,7 +127,7 @@ const App* ClosConvPrep::rewrite_callee(const App* app) {
     return app;
 }
 
-const Def* ClosConvPrep::rewrite(const Def* def) {
+Ref ClosConvPrep::rewrite(Ref def) {
     if (ignore_ || match<attr>(def)) return def;
 
     if (auto app = def->isa<App>(); app) {

--- a/dialects/clos/pass/rw/clos_conv_prep.cpp
+++ b/dialects/clos/pass/rw/clos_conv_prep.cpp
@@ -62,11 +62,10 @@ const App* ClosConvPrep::rewrite_arg(const App* app) {
 
         auto refine = [&](const Def* new_op) {
             const Def* args;
-            if (arg == op) {
+            if (arg == op)
                 args = new_op;
-            } else {
+            else
                 args = arg->refine(i, new_op);
-            }
             return app->refine(1, args)->as<App>();
         };
 

--- a/dialects/clos/pass/rw/clos_conv_prep.cpp
+++ b/dialects/clos/pass/rw/clos_conv_prep.cpp
@@ -6,7 +6,7 @@
 
 namespace thorin::clos {
 
-// FIXME: these guys do not work if another pass rewrites curr_nom()'s body
+// FIXME: these guys do not work if another pass rewrites curr_mut()'s body
 static bool isa_cont(const App* body, const Def* def, size_t i) {
     return body->callee_type()->is_returning() && body->arg() == def && i == def->num_ops() - 1;
 }
@@ -33,22 +33,22 @@ Lam* ClosConvPrep::scope(Lam* lam) {
 }
 
 void ClosConvPrep::enter() {
-    if (curr_nom()->type()->is_returning()) {
-        lam2fscope_[curr_nom()] = curr_nom();
-        world().DLOG("scope {} -> {}", curr_nom(), curr_nom());
-        scope_ = std::make_unique<Scope>(curr_nom());
+    if (curr_mut()->type()->is_returning()) {
+        lam2fscope_[curr_mut()] = curr_mut();
+        world().DLOG("scope {} -> {}", curr_mut(), curr_mut());
+        scope_ = std::make_unique<Scope>(curr_mut());
         for (auto def : scope_->bound()) {
             assert(def);
-            if (auto bb_lam = def->isa_nom<Lam>(); bb_lam && bb_lam->is_basicblock()) {
-                world().DLOG("scope {} -> {}", bb_lam, curr_nom());
-                lam2fscope_[bb_lam] = curr_nom();
+            if (auto bb_lam = def->isa_mut<Lam>(); bb_lam && bb_lam->is_basicblock()) {
+                world().DLOG("scope {} -> {}", bb_lam, curr_mut());
+                lam2fscope_[bb_lam] = curr_mut();
             }
         }
     }
 
-    auto body = curr_nom()->body()->isa<App>();
-    // Skip if the nominal is already wrapped or the body is undefined/no continuation.
-    ignore_ = !(body && body->callee_type()->is_cn()) || wrapper_.contains(curr_nom());
+    auto body = curr_mut()->body()->isa<App>();
+    // Skip if the mutable is already wrapped or the body is undefined/no continuation.
+    ignore_ = !(body && body->callee_type()->is_cn()) || wrapper_.contains(curr_mut());
 }
 
 const App* ClosConvPrep::rewrite_arg(const App* app) {
@@ -74,14 +74,14 @@ const App* ClosConvPrep::rewrite_arg(const App* app) {
             w.DLOG("found return var from enclosing scope: {}", op);
             return refine(eta_wrap(op, attr::freeBB)->set("free_ret"));
         }
-        if (auto bb_lam = op->isa_nom<Lam>(); bb_lam && bb_lam->is_basicblock() && from_outer_scope(bb_lam)) {
+        if (auto bb_lam = op->isa_mut<Lam>(); bb_lam && bb_lam->is_basicblock() && from_outer_scope(bb_lam)) {
             w.DLOG("found BB from enclosing scope {}", op);
             return refine(thorin::clos::op(attr::freeBB, op));
         }
         if (isa_cont(app, arg, i)) {
             if (match<attr>(attr::ret, op) || isa_retvar(op)) {
                 return app;
-            } else if (auto contlam = op->isa_nom<Lam>()) {
+            } else if (auto contlam = op->isa_mut<Lam>()) {
                 return refine(thorin::clos::op(attr::ret, contlam));
             } else {
                 auto wrapper = eta_wrap(op, attr::ret)->set("eta_cont");
@@ -91,7 +91,7 @@ const App* ClosConvPrep::rewrite_arg(const App* app) {
         }
 
         if (!isa_callee_br(app, arg, i)) {
-            if (auto bb_lam = op->isa_nom<Lam>(); bb_lam && bb_lam->is_basicblock()) {
+            if (auto bb_lam = op->isa_mut<Lam>(); bb_lam && bb_lam->is_basicblock()) {
                 w.DLOG("found firstclass use of BB: {}", bb_lam);
                 return refine(thorin::clos::op(attr::fstclassBB, bb_lam));
             }
@@ -114,7 +114,7 @@ const App* ClosConvPrep::rewrite_callee(const App* app) {
             // Eta-Expand branches
             if (branches->isa<Tuple>() && branches->type()->isa<Arr>()) {
                 for (auto i = 0u; i < branches->num_ops(); i++) {
-                    if (!branches->op(i)->isa_nom<Lam>()) {
+                    if (!branches->op(i)->isa_mut<Lam>()) {
                         auto wrapper = eta_wrap(branches->op(i), attr::bot)->set("eta_br");
                         w.DLOG("eta wrap branch: {} -> {}", branches->op(i), wrapper);
                         branches = branches->refine(i, wrapper);

--- a/dialects/clos/pass/rw/clos_conv_prep.h
+++ b/dialects/clos/pass/rw/clos_conv_prep.h
@@ -20,7 +20,7 @@ public:
         , lam2fscope_() {}
 
     void enter() override;
-    const Def* rewrite(const Def*) override;
+    Ref rewrite(Ref) override;
     const App* rewrite_arg(const App* app);
     const App* rewrite_callee(const App* app);
 
@@ -31,9 +31,9 @@ public:
         return scope(lam) && scope(lam) != scope(curr_mut());
     }
 
-    bool from_outer_scope(const Def* lam) { return scope_->free_defs().contains(lam); }
+    bool from_outer_scope(Ref lam) { return scope_->free_defs().contains(lam); }
 
-    const Def* eta_wrap(const Def* def, attr a) {
+    Ref eta_wrap(Ref def, attr a) {
         auto& w                = world();
         auto [entry, inserted] = old2wrapper_.emplace(def, nullptr);
         auto& wrapper          = entry->second;

--- a/dialects/clos/pass/rw/clos_conv_prep.h
+++ b/dialects/clos/pass/rw/clos_conv_prep.h
@@ -28,7 +28,7 @@ public:
 
     bool from_outer_scope(Lam* lam) {
         // return scope_.free_defs().contains(lam);
-        return scope(lam) && scope(lam) != scope(curr_nom());
+        return scope(lam) && scope(lam) != scope(curr_mut());
     }
 
     bool from_outer_scope(const Def* lam) { return scope_->free_defs().contains(lam); }
@@ -38,9 +38,9 @@ public:
         auto [entry, inserted] = old2wrapper_.emplace(def, nullptr);
         auto& wrapper          = entry->second;
         if (inserted) {
-            wrapper = w.nom_lam(def->type()->as<Pi>());
+            wrapper = w.mut_lam(def->type()->as<Pi>());
             wrapper->app(false, def, wrapper->var());
-            lam2fscope_[wrapper] = scope(curr_nom());
+            lam2fscope_[wrapper] = scope(curr_mut());
             wrapper_.emplace(wrapper);
         }
         return op(a, wrapper);

--- a/dialects/clos/phase/clos_conv.h
+++ b/dialects/clos/phase/clos_conv.h
@@ -22,10 +22,10 @@ public:
         , lam2nodes_() {}
 
     /// FreeDefAna::run will compute free defs (FD) that appear in @p lam%s body.
-    /// Nominal Def%s are only considered free if they are annotated with Clos::freeBB or
+    /// Mutable Def%s are only considered free if they are annotated with Clos::freeBB or
     /// Clos::fstclassBB.
-    /// Otherwise, we add a nom's free defs in order to build a closure for it.
-    /// Structural Def%s containing nominals are broken up if necessary.
+    /// Otherwise, we add a mut's free defs in order to build a closure for it.
+    /// Structural Def%s containing mutable are broken up if necessary.
     DefSet& run(Lam* lam);
 
 private:
@@ -35,10 +35,10 @@ private:
     using NodeQueue = std::queue<Node*>;
     using Nodes     = std::vector<Node*>;
 
-    /// In order to avoid recomputing FDs sets, sets are computed for the subgraph reachable from nom and memorized.
+    /// In order to avoid recomputing FDs sets, sets are computed for the subgraph reachable from mut and memorized.
     /// `pass_id` determines if the node has been initialized.
     struct Node {
-        Def* nom;
+        Def* mut;
         DefSet fvs;
         Nodes preds;
         Nodes succs;
@@ -63,7 +63,7 @@ private:
     /// Split a free Def. This may create more Nodes as more reachable nodes are discovered.
     void split_fd(Node* node, const Def* fv, bool& is_init, NodeQueue& worklist);
 
-    std::pair<Node*, bool> build_node(Def* nom, NodeQueue& worklist);
+    std::pair<Node*, bool> build_node(Def* mut, NodeQueue& worklist);
     void run(NodeQueue& worklist);
 
     World& world() { return world_; }
@@ -114,7 +114,7 @@ private:
     /// @{
     void rewrite_body(Lam* lam, Def2Def& subst);
     const Def* rewrite(const Def* old_def, Def2Def& subst);
-    Def* rewrite_nom(Def* nom, const Def* new_type, Def2Def& subst);
+    Def* rewrite_mut(Def* mut, const Def* new_type, Def2Def& subst);
     const Pi* rewrite_type_cn(const Pi*, Def2Def& subst);
     const Def* type_clos(const Pi* pi, Def2Def& subst, const Def* ent_type = nullptr);
     /// @}
@@ -122,10 +122,10 @@ private:
     FreeDefAna fva_;
     DefMap<Stub> closures_;
 
-    // Noms that must be re rewritten uniformly across the whole module:
+    // Muts that must be re rewritten uniformly across the whole module:
     // Currently, this includes globals and closure types (for typechecking to go through).
-    // Such noms must not depend on defs that live inside the scope of a continuation!
-    Def2Def glob_noms_;
+    // Such muts must not depend on defs that live inside the scope of a continuation!
+    Def2Def glob_muts_;
 
     std::queue<const Def*> worklist_;
 };

--- a/dialects/clos/phase/clos_conv.h
+++ b/dialects/clos/phase/clos_conv.h
@@ -25,7 +25,7 @@ public:
     /// Mutable Def%s are only considered free if they are annotated with Clos::freeBB or
     /// Clos::fstclassBB.
     /// Otherwise, we add a mut's free defs in order to build a closure for it.
-    /// Structural Def%s containing mutable are broken up if necessary.
+    /// Immutables containing mutables are broken up if necessary.
     DefSet& run(Lam* lam);
 
 private:

--- a/dialects/compile/passes/debug_print.cpp
+++ b/dialects/compile/passes/debug_print.cpp
@@ -7,7 +7,7 @@
 namespace thorin::compile {
 
 void DebugPrint::enter() {
-    if (level >= 2) { world().DLOG("L{}: enter {}", level, curr_nom()); }
+    if (level >= 2) { world().DLOG("L{}: enter {}", level, curr_mut()); }
 }
 
 } // namespace thorin::compile

--- a/dialects/compile/passes/debug_print.cpp
+++ b/dialects/compile/passes/debug_print.cpp
@@ -7,7 +7,7 @@
 namespace thorin::compile {
 
 void DebugPrint::enter() {
-    if (level >= 2) { world().DLOG("L{}: enter {}", level, curr_mut()); }
+    if (level >= 2) world().DLOG("L{}: enter {}", level, curr_mut());
 }
 
 } // namespace thorin::compile

--- a/dialects/compile/passes/internal_cleanup.cpp
+++ b/dialects/compile/passes/internal_cleanup.cpp
@@ -7,7 +7,7 @@
 namespace thorin::compile {
 
 void InternalCleanup::enter() {
-    Lam* lam = curr_nom();
+    Lam* lam = curr_mut();
     if (lam->sym()->starts_with(prefix_)) {
         lam->make_internal();
         world().DLOG("internalized {}", lam);

--- a/dialects/core/normalizers.cpp
+++ b/dialects/core/normalizers.cpp
@@ -601,7 +601,7 @@ Ref normalize_trait(Ref nat, Ref callee, Ref type) {
             case trait::align: return world.lit_nat(align);
             case trait::size: return world.lit_nat(size);
         }
-    } else if (auto arr = type->isa_structural<Arr>()) {
+    } else if (auto arr = type->isa_imm<Arr>()) {
         auto align = op(trait::align, arr->body());
         if constexpr (id == trait::align) return align;
         if (auto b = op(trait::size, arr->body())->isa<Lit>()) return world.call(core::nop::mul, Defs{arr->shape(), b});

--- a/dialects/direct/direct.h
+++ b/dialects/direct/direct.h
@@ -17,12 +17,12 @@ inline const Def* op_cps2ds_dep(const Def* f) {
     world.DLOG("T: {}", T);
     world.DLOG("U: {}", U);
 
-    auto Uf = world.nom_lam(world.pi(T, world.type()))->set("Uf");
+    auto Uf = world.mut_lam(world.pi(T, world.type()))->set("Uf");
     world.DLOG("Uf: {} : {}", Uf, Uf->type());
 
     const Def* rewritten_codom;
 
-    if (auto f_ty_sig = f_ty->dom()->isa_nom<Sigma>()) {
+    if (auto f_ty_sig = f_ty->dom()->isa_mut<Sigma>()) {
         auto dom_var = f_ty_sig->var((nat_t)0);
         world.DLOG("dom_var: {}", dom_var);
         Scope r_scope{f_ty_sig};

--- a/dialects/direct/passes/cps2ds.cpp
+++ b/dialects/direct/passes/cps2ds.cpp
@@ -161,11 +161,8 @@ const Def* CPS2DS::rewrite_body_(const Def* def) {
     }
 
     DefArray new_ops{def->ops(), [&](const Def* op) { return rewrite_body(op); }};
-
     world.DLOG("def {} : {} [{}]", def, def->type(), def->node_name());
 
-    // TODO: where does this come from?
-    // example: ./build/bin/thorin -d matrix -d affine -d direct lit/matrix/read_transpose.thorin -o - -VVVV
     if (def->isa<Infer>()) {
         world.WLOG("infer node {} : {} [{}]", def, def->type(), def->node_name());
         return def;

--- a/dialects/direct/passes/ds2cps.cpp
+++ b/dialects/direct/passes/ds2cps.cpp
@@ -8,7 +8,7 @@
 
 namespace thorin::direct {
 
-const Def* DS2CPS::rewrite(const Def* def) {
+Ref DS2CPS::rewrite(Ref def) {
     auto& world = def->world();
     if (auto app = def->isa<App>()) {
         auto callee = app->callee();
@@ -27,7 +27,7 @@ const Def* DS2CPS::rewrite(const Def* def) {
 
 /// This function generates the cps function `f_cps : cn [a:A, cn B]` for a ds function `f: Π a : A -> B`.
 /// The translation is associated in the `rewritten_` map.
-const Def* DS2CPS::rewrite_lam(Lam* lam) {
+Ref DS2CPS::rewrite_lam(Lam* lam) {
     if (auto i = rewritten_.find(lam); i != rewritten_.end()) return i->second;
 
     // only look at lambdas (ds not cps)

--- a/dialects/direct/passes/ds2cps.cpp
+++ b/dialects/direct/passes/ds2cps.cpp
@@ -12,7 +12,7 @@ const Def* DS2CPS::rewrite(const Def* def) {
     auto& world = def->world();
     if (auto app = def->isa<App>()) {
         auto callee = app->callee();
-        if (auto lam = callee->isa_nom<Lam>()) {
+        if (auto lam = callee->isa_mut<Lam>()) {
             world.DLOG("encountered lam app");
             auto new_lam = rewrite_lam(lam);
             world.DLOG("new lam: {} : {}", new_lam, new_lam->type());
@@ -46,12 +46,12 @@ const Def* DS2CPS::rewrite_lam(Lam* lam) {
     auto dom   = ty->dom();
     auto codom = ty->codom();
 
-    Sigma* sig = world().nom_sigma(2);
+    Sigma* sig = world().mut_sigma(2);
     sig->set(0, dom);
 
     // replace ds dom var with cps sigma var (cps dom)
-    Scope r_scope{ty->as_nom()};
-    auto dom_var         = ty->as_nom<Pi>()->var();
+    Scope r_scope{ty->as_mut()};
+    auto dom_var         = ty->as_mut<Pi>()->var();
     auto cps_dom_var     = sig->var((nat_t)0);
     auto rewritten_codom = thorin::rewrite(codom, dom_var, cps_dom_var, r_scope);
     sig->set(1, world().cn(rewritten_codom));
@@ -62,7 +62,7 @@ const Def* DS2CPS::rewrite_lam(Lam* lam) {
     auto cps_ty = world().cn(sig);
     world().DLOG("cps type: {}", cps_ty);
 
-    auto cps_lam = world().nom_lam(cps_ty)->set(*lam->sym() + "_cps");
+    auto cps_lam = world().mut_lam(cps_ty)->set(*lam->sym() + "_cps");
 
     // rewrite vars of new function
     // calls handled separately

--- a/dialects/direct/passes/ds2cps.cpp
+++ b/dialects/direct/passes/ds2cps.cpp
@@ -31,9 +31,9 @@ const Def* DS2CPS::rewrite_lam(Lam* lam) {
     if (auto i = rewritten_.find(lam); i != rewritten_.end()) return i->second;
 
     // only look at lambdas (ds not cps)
-    if (lam->type()->is_cn()) { return lam; }
+    if (lam->type()->is_cn()) return lam;
     // ignore ds on type level
-    if (lam->type()->codom()->isa<Type>()) { return lam; }
+    if (lam->type()->codom()->isa<Type>()) return lam;
     // ignore higher order function
     if (lam->type()->codom()->isa<Pi>()) {
         // We can not set the filter here as this causes segfaults.

--- a/dialects/direct/passes/ds2cps.h
+++ b/dialects/direct/passes/ds2cps.h
@@ -20,12 +20,12 @@ public:
     DS2CPS(PassMan& man)
         : RWPass(man, "ds2cps") {}
 
-    const Def* rewrite(const Def*) override;
+    Ref rewrite(Ref) override;
 
 private:
     Def2Def rewritten_;
 
-    const Def* rewrite_lam(Lam* lam);
+    Ref rewrite_lam(Lam* lam);
 };
 
 } // namespace thorin::direct

--- a/dialects/matrix/passes/lower_matrix_highlevel.cpp
+++ b/dialects/matrix/passes/lower_matrix_highlevel.cpp
@@ -20,14 +20,14 @@ void findAndReplaceAll(std::string& data, std::string toSearch, std::string repl
     }
 }
 
-const Def* LowerMatrixHighLevelMapRed::rewrite(const Def* def) {
+Ref LowerMatrixHighLevelMapRed::rewrite(Ref def) {
     if (auto i = rewritten.find(def); i != rewritten.end()) return i->second;
     auto new_def   = rewrite_(def);
     rewritten[def] = new_def;
     return rewritten[def];
 }
 
-std::optional<const Def*> internal_function_of_axiom(const Axiom* axiom, const Def* meta_args, const Def* args) {
+std::optional<Ref> internal_function_of_axiom(const Axiom* axiom, Ref meta_args, Ref args) {
     auto& world      = axiom->world();
     std::string name = *axiom->sym();
     findAndReplaceAll(name, ".", "_");
@@ -43,7 +43,7 @@ std::optional<const Def*> internal_function_of_axiom(const Axiom* axiom, const D
     return std::nullopt;
 }
 
-const Def* LowerMatrixHighLevelMapRed::rewrite_(const Def* def) {
+Ref LowerMatrixHighLevelMapRed::rewrite_(Ref def) {
     auto& world = def->world();
 
     if (auto mat_ax = match<matrix::prod>(def)) {

--- a/dialects/matrix/passes/lower_matrix_highlevel.h
+++ b/dialects/matrix/passes/lower_matrix_highlevel.h
@@ -17,8 +17,8 @@ public:
 
     /// custom rewrite function
     /// memoized version of rewrite_
-    const Def* rewrite(const Def*) override;
-    const Def* rewrite_(const Def*);
+    Ref rewrite(Ref) override;
+    Ref rewrite_(Ref);
 
 private:
     Def2Def rewritten;

--- a/dialects/matrix/passes/lower_matrix_lowlevel.cpp
+++ b/dialects/matrix/passes/lower_matrix_lowlevel.cpp
@@ -52,7 +52,7 @@ static Ref arrTyOfMatrixTy(Ref S, Ref T) {
     return arr_ty;
 }
 
-Ref LowerMatrixLowLevel::rewrite_structural(Ref def) {
+Ref LowerMatrixLowLevel::rewrite_imm(Ref def) {
     auto& world = def->world();
 
     assert(!match<matrix::map_reduce>(def) && "map_reduce should have been lowered to for loops by now");
@@ -145,7 +145,7 @@ Ref LowerMatrixLowLevel::rewrite_structural(Ref def) {
     // ignore unapplied axioms to avoid spurious type replacements
     if (def->isa<Axiom>()) return def;
 
-    return Rewriter::rewrite_structural(def); // continue recursive rewriting with everything else
+    return Rewriter::rewrite_imm(def); // continue recursive rewriting with everything else
 }
 
 } // namespace thorin::matrix

--- a/dialects/matrix/passes/lower_matrix_lowlevel.h
+++ b/dialects/matrix/passes/lower_matrix_lowlevel.h
@@ -18,7 +18,7 @@ public:
     LowerMatrixLowLevel(World& world)
         : RWPhase(world, "lower_matrix_lowlevel") {}
 
-    Ref rewrite_structural(Ref) override;
+    Ref rewrite_imm(Ref) override;
 
 private:
     Def2Def rewritten;

--- a/dialects/matrix/passes/lower_matrix_mediumlevel.cpp
+++ b/dialects/matrix/passes/lower_matrix_mediumlevel.cpp
@@ -21,8 +21,7 @@ Ref LowerMatrixMediumLevel::rewrite(Ref def) {
     return rewritten[def];
 }
 
-std::pair<Lam*, Ref>
-counting_for(Ref bound, DefArray acc, Ref exit, const char* name = "for_body") {
+std::pair<Lam*, Ref> counting_for(Ref bound, DefArray acc, Ref exit, const char* name = "for_body") {
     auto& world = bound->world();
     auto acc_ty = world.tuple(acc)->type();
     auto body   = world
@@ -87,11 +86,11 @@ Ref LowerMatrixMediumLevel::rewrite_(Ref def) {
         // return matrix
         // ```
 
-        absl::flat_hash_map<u64, Ref> dims;              // idx ↦ nat (size bound = dimension)
-        absl::flat_hash_map<u64, Ref> raw_iterator;      // idx ↦ I32
-        absl::flat_hash_map<u64, Ref> iterator;          // idx ↦ %Idx (S/NI#i)
-        std::vector<u64> out_indices;                    // output indices 0..n-1
-        std::vector<u64> in_indices;                     // input indices ≥ n
+        absl::flat_hash_map<u64, Ref> dims;         // idx ↦ nat (size bound = dimension)
+        absl::flat_hash_map<u64, Ref> raw_iterator; // idx ↦ I32
+        absl::flat_hash_map<u64, Ref> iterator;     // idx ↦ %Idx (S/NI#i)
+        std::vector<u64> out_indices;               // output indices 0..n-1
+        std::vector<u64> in_indices;                // input indices ≥ n
 
         std::vector<Ref> output_dims;                    // i<n ↦ nat (dimension S#i)
         std::vector<std::vector<const Def*>> input_dims; // i<m ↦ j<NI#i ↦ nat (dimension SI#i#j)

--- a/dialects/matrix/passes/lower_matrix_mediumlevel.cpp
+++ b/dialects/matrix/passes/lower_matrix_mediumlevel.cpp
@@ -14,15 +14,15 @@
 
 namespace thorin::matrix {
 
-const Def* LowerMatrixMediumLevel::rewrite(const Def* def) {
+Ref LowerMatrixMediumLevel::rewrite(Ref def) {
     if (auto i = rewritten.find(def); i != rewritten.end()) return i->second;
     auto new_def   = rewrite_(def);
     rewritten[def] = new_def;
     return rewritten[def];
 }
 
-std::pair<Lam*, const Def*>
-counting_for(const Def* bound, DefArray acc, const Def* exit, const char* name = "for_body") {
+std::pair<Lam*, Ref>
+counting_for(Ref bound, DefArray acc, Ref exit, const char* name = "for_body") {
     auto& world = bound->world();
     auto acc_ty = world.tuple(acc)->type();
     auto body   = world
@@ -39,7 +39,7 @@ counting_for(const Def* bound, DefArray acc, const Def* exit, const char* name =
 // TODO: compare with other impala version (why is one easier than the other?)
 // TODO: replace sum_ptr by using sum as accumulator
 // TODO: extract inner loop into function (for read normalizer)
-const Def* LowerMatrixMediumLevel::rewrite_(const Def* def) {
+Ref LowerMatrixMediumLevel::rewrite_(Ref def) {
     auto& world = def->world();
 
     if (auto map_reduce_ax = match<matrix::map_reduce>(def); map_reduce_ax) {
@@ -87,13 +87,13 @@ const Def* LowerMatrixMediumLevel::rewrite_(const Def* def) {
         // return matrix
         // ```
 
-        absl::flat_hash_map<u64, const Def*> dims;         // idx ↦ nat (size bound = dimension)
-        absl::flat_hash_map<u64, const Def*> raw_iterator; // idx ↦ I32
-        absl::flat_hash_map<u64, const Def*> iterator;     // idx ↦ %Idx (S/NI#i)
-        std::vector<u64> out_indices;                      // output indices 0..n-1
-        std::vector<u64> in_indices;                       // input indices ≥ n
+        absl::flat_hash_map<u64, Ref> dims;              // idx ↦ nat (size bound = dimension)
+        absl::flat_hash_map<u64, Ref> raw_iterator;      // idx ↦ I32
+        absl::flat_hash_map<u64, Ref> iterator;          // idx ↦ %Idx (S/NI#i)
+        std::vector<u64> out_indices;                    // output indices 0..n-1
+        std::vector<u64> in_indices;                     // input indices ≥ n
 
-        std::vector<const Def*> output_dims;             // i<n ↦ nat (dimension S#i)
+        std::vector<Ref> output_dims;                    // i<n ↦ nat (dimension S#i)
         std::vector<std::vector<const Def*>> input_dims; // i<m ↦ j<NI#i ↦ nat (dimension SI#i#j)
         std::vector<u64> n_input;                        // i<m ↦ nat (number of dimensions of SI#i)
 

--- a/dialects/matrix/passes/lower_matrix_mediumlevel.h
+++ b/dialects/matrix/passes/lower_matrix_mediumlevel.h
@@ -49,8 +49,8 @@ public:
 
     /// custom rewrite function
     /// memoized version of rewrite_
-    const Def* rewrite(const Def*) override;
-    const Def* rewrite_(const Def*);
+    Ref rewrite(Ref) override;
+    Ref rewrite_(Ref);
 
 private:
     Def2Def rewritten;

--- a/dialects/mem/passes/fp/copy_prop.cpp
+++ b/dialects/mem/passes/fp/copy_prop.cpp
@@ -8,7 +8,7 @@
 namespace thorin::mem {
 
 const Def* CopyProp::rewrite(const Def* def) {
-    auto [app, var_lam] = isa_apped_nom_lam(def);
+    auto [app, var_lam] = isa_apped_mut_lam(def);
     if (!isa_workable(var_lam) || (bb_only_ && var_lam->is_returning())) return def;
 
     auto n = app->num_args();
@@ -92,7 +92,7 @@ const Def* CopyProp::rewrite(const Def* def) {
 
 undo_t CopyProp::analyze(const Proxy* proxy) {
     world().DLOG("found proxy: {}", proxy);
-    auto var_lam                        = proxy->op(0)->as_nom<Lam>();
+    auto var_lam                        = proxy->op(0)->as_mut<Lam>();
     auto& [lattice, prop_lam, old_args] = lam2info_[var_lam];
 
     if (proxy->tag() == Varxy) {

--- a/dialects/mem/passes/fp/copy_prop.cpp
+++ b/dialects/mem/passes/fp/copy_prop.cpp
@@ -7,7 +7,7 @@
 
 namespace thorin::mem {
 
-const Def* CopyProp::rewrite(const Def* def) {
+Ref CopyProp::rewrite(Ref def) {
     auto [app, var_lam] = isa_apped_mut_lam(def);
     if (!isa_workable(var_lam) || (bb_only_ && var_lam->is_returning())) return def;
 
@@ -69,7 +69,7 @@ const Def* CopyProp::rewrite(const Def* def) {
         if (eta_exp_) eta_exp_->new2old(prop_lam, var_lam);
 
         size_t j = 0;
-        DefArray new_vars(n, [&, prop_lam = prop_lam](size_t i) -> const Def* {
+        DefArray new_vars(n, [&, prop_lam = prop_lam](size_t i) -> Ref {
             switch (lattice[i]) {
                 case Lattice::Dead: return proxy(var_lam->var(i)->type(), {var_lam, world().lit_nat(i)}, Varxy);
                 case Lattice::Prop: return args[i];

--- a/dialects/mem/passes/fp/copy_prop.h
+++ b/dialects/mem/passes/fp/copy_prop.h
@@ -38,7 +38,7 @@ private:
 
     /// @name PassMan hooks
     ///@{
-    const Def* rewrite(const Def*) override;
+    Ref rewrite(Ref) override;
     undo_t analyze(const Proxy*) override;
     ///@}
 

--- a/dialects/mem/passes/fp/ssa_constr.cpp
+++ b/dialects/mem/passes/fp/ssa_constr.cpp
@@ -6,7 +6,7 @@
 
 namespace thorin::mem {
 
-static const Def* get_sloxy_type(const Proxy* sloxy) { return force<mem::Ptr>(sloxy->type())->arg(0); }
+static Ref get_sloxy_type(const Proxy* sloxy) { return force<mem::Ptr>(sloxy->type())->arg(0); }
 
 static std::tuple<const Proxy*, Lam*> split_phixy(const Proxy* phixy) {
     return {phixy->op(0)->as<Proxy>(), phixy->op(1)->as_mut<Lam>()};
@@ -14,7 +14,7 @@ static std::tuple<const Proxy*, Lam*> split_phixy(const Proxy* phixy) {
 
 void SSAConstr::enter() { lam2sloxy2val_[curr_mut()].clear(); }
 
-const Def* SSAConstr::rewrite(const Proxy* proxy) {
+Ref SSAConstr::rewrite(const Proxy* proxy) {
     if (proxy->tag() == Traxy) {
         world().DLOG("traxy '{}'", proxy);
         for (size_t i = 1, e = proxy->num_ops(); i != e; i += 2)
@@ -25,7 +25,7 @@ const Def* SSAConstr::rewrite(const Proxy* proxy) {
     return proxy;
 }
 
-const Def* SSAConstr::rewrite(const Def* def) {
+Ref SSAConstr::rewrite(Ref def) {
     if (auto slot = match<mem::slot>(def)) {
         auto [mem, id] = slot->args<2>();
         auto [_, ptr]  = slot->projs<2>();
@@ -60,7 +60,7 @@ const Def* SSAConstr::rewrite(const Def* def) {
     return def;
 }
 
-const Def* SSAConstr::get_val(Lam* lam, const Proxy* sloxy) {
+Ref SSAConstr::get_val(Lam* lam, const Proxy* sloxy) {
     auto& sloxy2val = lam2sloxy2val_[lam];
     if (auto i = sloxy2val.find(sloxy); i != sloxy2val.end()) {
         auto val = i->second;
@@ -80,12 +80,12 @@ const Def* SSAConstr::get_val(Lam* lam, const Proxy* sloxy) {
     }
 }
 
-const Def* SSAConstr::set_val(Lam* lam, const Proxy* sloxy, const Def* val) {
+Ref SSAConstr::set_val(Lam* lam, const Proxy* sloxy, Ref val) {
     world().DLOG("set_val: '{}': '{}': '{}'", sloxy, val, lam);
     return lam2sloxy2val_[lam][sloxy] = val;
 }
 
-const Def* SSAConstr::mem2phi(const App* app, Lam* mem_lam) {
+Ref SSAConstr::mem2phi(const App* app, Lam* mem_lam) {
     auto&& sloxys = lam2sloxys_[mem_lam];
     if (sloxys.empty()) return app;
 
@@ -155,7 +155,7 @@ undo_t SSAConstr::analyze(const Proxy* proxy) {
     return No_Undo;
 }
 
-undo_t SSAConstr::analyze(const Def* def) {
+undo_t SSAConstr::analyze(Ref def) {
     for (size_t i = 0, e = def->num_ops(); i != e; ++i) {
         if (auto succ_lam = isa_workable(def->op(i)->isa_mut<Lam>())) {
             auto& succ_info = data(succ_lam);

--- a/dialects/mem/passes/fp/ssa_constr.cpp
+++ b/dialects/mem/passes/fp/ssa_constr.cpp
@@ -161,9 +161,8 @@ undo_t SSAConstr::analyze(const Def* def) {
             auto& succ_info = data(succ_lam);
 
             // TODO this is a bit scruffy - maybe we can do better
-            if (succ_lam->is_basicblock() && succ_lam != curr_mut()) {
+            if (succ_lam->is_basicblock() && succ_lam != curr_mut())
                 for (auto writable = data(curr_mut()).writable; auto&& w : writable) succ_info.writable.insert(w);
-            }
 
             if (!isa_callee(def, i)) {
                 if (succ_info.pred) {

--- a/dialects/mem/passes/fp/ssa_constr.h
+++ b/dialects/mem/passes/fp/ssa_constr.h
@@ -32,17 +32,17 @@ private:
     /// @name PassMan hooks
     ///@{
     void enter() override;
-    const Def* rewrite(const Proxy*) override;
-    const Def* rewrite(const Def*) override;
+    Ref rewrite(const Proxy*) override;
+    Ref rewrite(Ref) override;
     undo_t analyze(const Proxy*) override;
-    undo_t analyze(const Def*) override;
+    undo_t analyze(Ref) override;
     ///@}
 
     /// @name SSA construction helpers - see paper
     ///@{
-    const Def* get_val(Lam*, const Proxy*);
-    const Def* set_val(Lam*, const Proxy*, const Def*);
-    const Def* mem2phi(const App*, Lam*);
+    Ref get_val(Lam*, const Proxy*);
+    Ref set_val(Lam*, const Proxy*, Ref);
+    Ref mem2phi(const App*, Lam*);
     ///@}
 
     EtaExp* eta_exp_;

--- a/dialects/mem/passes/rw/alloc2malloc.cpp
+++ b/dialects/mem/passes/rw/alloc2malloc.cpp
@@ -4,7 +4,7 @@
 
 namespace thorin::mem {
 
-const Def* Alloc2Malloc::rewrite(const Def* def) {
+Ref Alloc2Malloc::rewrite(Ref def) {
     if (auto alloc = match<mem::alloc>(def)) {
         auto [pointee, addr_space] = alloc->decurry()->args<2>();
         return op_malloc(pointee, alloc->arg());

--- a/dialects/mem/passes/rw/alloc2malloc.h
+++ b/dialects/mem/passes/rw/alloc2malloc.h
@@ -9,7 +9,7 @@ public:
     Alloc2Malloc(PassMan& man)
         : RWPass(man, "alloc2malloc") {}
 
-    const Def* rewrite(const Def*) override;
+    Ref rewrite(Ref) override;
 };
 
 } // namespace thorin::mem

--- a/dialects/mem/passes/rw/remem_elim.cpp
+++ b/dialects/mem/passes/rw/remem_elim.cpp
@@ -4,7 +4,7 @@
 
 namespace thorin::mem {
 
-const Def* RememElim::rewrite(const Def* def) {
+Ref RememElim::rewrite(Ref def) {
     if (auto remem = match<mem::remem>(def)) return remem->arg();
     return def;
 }

--- a/dialects/mem/passes/rw/remem_elim.h
+++ b/dialects/mem/passes/rw/remem_elim.h
@@ -9,7 +9,7 @@ public:
     RememElim(PassMan& man)
         : RWPass(man, "remem_elim") {}
 
-    const Def* rewrite(const Def*) override;
+    Ref rewrite(Ref) override;
 };
 
 } // namespace thorin::mem

--- a/dialects/mem/passes/rw/reshape.cpp
+++ b/dialects/mem/passes/rw/reshape.cpp
@@ -35,7 +35,7 @@ bool should_flatten(const Def* T) {
     // Problem with 2 Arr -> flatten
     // lea (2, <<2;I32>>, ...) -> lea (2, I32, I32, ...)
     if (auto lit = T->arity()->isa<Lit>(); lit && lit->get<u64>() <= 2) {
-        if (auto arr = T->isa<Arr>(); arr && arr->body()->isa<Pi>()) { return lit->get<u64>() > 1; }
+        if (auto arr = T->isa<Arr>(); arr && arr->body()->isa<Pi>()) return lit->get<u64>() > 1;
     }
     return false;
 }
@@ -52,7 +52,7 @@ const Def* Reshape::rewrite_def_(const Def* def) {
     }
 
     // ignore axioms
-    if (def->isa<Axiom>()) { return def; }
+    if (def->isa<Axiom>()) return def;
 
     // This is dead code for debugging purposes.
     // It allows for inspection of the current def.
@@ -61,7 +61,7 @@ const Def* Reshape::rewrite_def_(const Def* def) {
     std::string str = ss.str();
 
     // vars are handled by association.
-    if (def->isa<Var>()) { world().ELOG("Var: {}", def); }
+    if (def->isa<Var>()) world().ELOG("Var: {}", def);
     assert(!def->isa<Var>());
 
     auto& w = world();
@@ -181,9 +181,8 @@ const Def* Reshape::reshape_type(const Def* T) {
         if (mode_ == Mode::Flat) {
             const Def* mem = nullptr;
             // find mem
-            for (auto i = new_types.begin(); i != new_types.end(); i++) {
-                if (is_mem_ty(*i) && !mem) { mem = *i; }
-            }
+            for (auto i = new_types.begin(); i != new_types.end(); i++)
+                if (is_mem_ty(*i) && !mem) mem = *i;
             // filter out mems
             new_types.erase(std::remove_if(new_types.begin(), new_types.end(), is_mem_ty), new_types.end());
             // readd mem in the front
@@ -196,9 +195,8 @@ const Def* Reshape::reshape_type(const Def* T) {
             const Def* mem = nullptr;
             const Def* ret = nullptr;
             // find mem
-            for (auto i = new_types.begin(); i != new_types.end(); i++) {
-                if (is_mem_ty(*i) && !mem) { mem = *i; }
-            }
+            for (auto i = new_types.begin(); i != new_types.end(); i++)
+                if (is_mem_ty(*i) && !mem) mem = *i;
             // filter out mems
             new_types.erase(std::remove_if(new_types.begin(), new_types.end(), is_mem_ty), new_types.end());
             // TODO: more fine-grained test
@@ -208,8 +206,8 @@ const Def* Reshape::reshape_type(const Def* T) {
             }
             // Create the arg form `[[mem,args],ret]`
             const Def* args = w.sigma(vec2array(new_types));
-            if (mem) { args = w.sigma({mem, args}); }
-            if (ret) { args = w.sigma({args, ret}); }
+            if (mem) args = w.sigma({mem, args});
+            if (ret) args = w.sigma({args, ret});
             return args;
         }
     } else {
@@ -249,7 +247,7 @@ const Def* Reshape::reshape(std::vector<const Def*>& defs, const Def* T, const D
         }
         // For inner function types, we override the type
         if (!def->type()->isa<Pi>()) {
-            if (!world.checker().equiv(def->type(), T)) { world.ELOG("reconstruct T {} from def {}", T, def->type()); }
+            if (!world.checker().equiv(def->type(), T)) world.ELOG("reconstruct T {} from def {}", T, def->type());
             assert(world.checker().equiv(def->type(), T) && "Reshape: argument type mismatch");
         }
         return def;
@@ -261,9 +259,8 @@ const Def* Reshape::reshape(const Def* def, const Def* target) {
     auto flat_defs = flatten_def(def);
     const Def* mem = nullptr;
     // find mem
-    for (auto i = flat_defs.begin(); i != flat_defs.end(); i++) {
-        if (is_mem_ty((*i)->type()) && !mem) { mem = *i; }
-    }
+    for (auto i = flat_defs.begin(); i != flat_defs.end(); i++)
+        if (is_mem_ty((*i)->type()) && !mem) mem = *i;
     def->world().DLOG("mem: {}", mem);
     return reshape(flat_defs, target, mem);
 }
@@ -281,15 +278,14 @@ const Def* Reshape::reshape(const Def* def) {
     if (mode_ == Mode::Flat) {
         const Def* mem = nullptr;
         // find mem
-        for (auto i = flat_defs.begin(); i != flat_defs.end(); i++) {
-            if (is_mem_ty((*i)->type()) && !mem) { mem = *i; }
-        }
+        for (auto i = flat_defs.begin(); i != flat_defs.end(); i++)
+            if (is_mem_ty((*i)->type()) && !mem) mem = *i;
         // filter out mems
         flat_defs.erase(
             std::remove_if(flat_defs.begin(), flat_defs.end(), [](const Def* def) { return is_mem_ty(def->type()); }),
             flat_defs.end());
         // insert mem
-        if (mem) { flat_defs.insert(flat_defs.begin(), mem); }
+        if (mem) flat_defs.insert(flat_defs.begin(), mem);
         return w.tuple(vec2array(flat_defs));
     } else {
         // arg style
@@ -297,9 +293,8 @@ const Def* Reshape::reshape(const Def* def) {
         const Def* mem = nullptr;
         const Def* ret = nullptr;
         // find mem
-        for (auto i = flat_defs.begin(); i != flat_defs.end(); i++) {
-            if (is_mem_ty((*i)->type()) && !mem) { mem = *i; }
-        }
+        for (auto i = flat_defs.begin(); i != flat_defs.end(); i++)
+            if (is_mem_ty((*i)->type()) && !mem) mem = *i;
         // filter out mems
         flat_defs.erase(
             std::remove_if(flat_defs.begin(), flat_defs.end(), [](const Def* def) { return is_mem_ty(def->type()); }),

--- a/dialects/mem/passes/rw/reshape.cpp
+++ b/dialects/mem/passes/rw/reshape.cpp
@@ -13,7 +13,7 @@
 
 namespace thorin::mem {
 
-void Reshape::enter() { rewrite_def(curr_nom()); }
+void Reshape::enter() { rewrite_def(curr_mut()); }
 
 const Def* Reshape::rewrite_def(const Def* def) {
     if (auto i = old2new_.find(def); i != old2new_.end()) return i->second;
@@ -78,7 +78,7 @@ const Def* Reshape::rewrite_def_(const Def* def) {
         world().DLOG("into arg {} : {}", reshaped_arg, reshaped_arg->type());
         auto new_app = w.app(callee, reshaped_arg);
         return new_app;
-    } else if (auto lam = def->isa_nom<Lam>()) {
+    } else if (auto lam = def->isa_mut<Lam>()) {
         world().DLOG("rewrite_def lam {} : {}", def, def->type());
         auto new_lam = reshape_lam(lam);
         world().DLOG("rewrote lam {} : {}", def, def->type());
@@ -111,7 +111,7 @@ Lam* Reshape::reshape_lam(Lam* def) {
     if (name != "main") { // TODO I don't this is correct. we should check for def->is_external
         // TODO maybe use new_lam->debug_suff("_reshape"), instead?
         name          = name + "_reshape";
-        new_lam       = w.nom_lam(new_ty)->set((name));
+        new_lam       = w.mut_lam(new_ty)->set((name));
         old2new_[def] = new_lam;
     } else {
         new_lam = def;

--- a/dialects/mem/phases/rw/add_mem.cpp
+++ b/dialects/mem/phases/rw/add_mem.cpp
@@ -8,7 +8,7 @@
 
 namespace thorin::mem {
 
-static std::pair<const App*, Array<Lam*>> isa_apped_nom_lam_in_tuple(const Def* def) {
+static std::pair<const App*, Array<Lam*>> isa_apped_mut_lam_in_tuple(const Def* def) {
     if (auto app = def->isa<App>()) {
         std::vector<Lam*> lams;
         std::deque<const Def*> wl;
@@ -16,8 +16,8 @@ static std::pair<const App*, Array<Lam*>> isa_apped_nom_lam_in_tuple(const Def* 
         while (!wl.empty()) {
             auto elem = wl.front();
             wl.pop_front();
-            if (auto nom = elem->isa_nom<Lam>()) {
-                lams.push_back(nom);
+            if (auto mut = elem->isa_mut<Lam>()) {
+                lams.push_back(mut);
             } else if (auto extract = elem->isa<Extract>()) {
                 if (auto tuple = extract->tuple()->isa<Tuple>()) {
                     for (auto&& op : tuple->ops()) wl.push_back(op);
@@ -33,29 +33,29 @@ static std::pair<const App*, Array<Lam*>> isa_apped_nom_lam_in_tuple(const Def* 
     return {nullptr, {}};
 }
 
-// @pre isa_apped_nom_lam_in_tuple(def) valid
+// @pre isa_apped_mut_lam_in_tuple(def) valid
 template<class F, class H>
-static const Def* rewrite_nom_lam_in_tuple(const Def* def, F&& rewrite, H&& rewrite_idx) {
+static const Def* rewrite_mut_lam_in_tuple(const Def* def, F&& rewrite, H&& rewrite_idx) {
     auto& w = def->world();
-    if (auto nom = def->isa_nom<Lam>()) { return std::forward<F>(rewrite)(nom); }
+    if (auto mut = def->isa_mut<Lam>()) { return std::forward<F>(rewrite)(mut); }
 
     auto extract = def->as<Extract>();
     auto tuple   = extract->tuple()->as<Tuple>();
     DefArray new_ops{tuple->ops(), [&](const Def* op) {
-                         return rewrite_nom_lam_in_tuple(op, std::forward<F>(rewrite), std::forward<H>(rewrite_idx));
+                         return rewrite_mut_lam_in_tuple(op, std::forward<F>(rewrite), std::forward<H>(rewrite_idx));
                      }};
     return w.extract(w.tuple(new_ops), rewrite_idx(extract->index()));
 }
 
-// @pre isa_apped_nom_lam_in_tuple(def) valid
+// @pre isa_apped_mut_lam_in_tuple(def) valid
 template<class RewriteCallee, class RewriteArg, class RewriteIdx>
-static const Def* rewrite_apped_nom_lam_in_tuple(const Def* def,
+static const Def* rewrite_apped_mut_lam_in_tuple(const Def* def,
                                                  RewriteCallee&& rewrite_callee,
                                                  RewriteArg&& rewrite_arg,
                                                  RewriteIdx&& rewrite_idx) {
     auto& w     = def->world();
     auto app    = def->as<App>();
-    auto callee = rewrite_nom_lam_in_tuple(app->callee(), std::forward<RewriteCallee>(rewrite_callee),
+    auto callee = rewrite_mut_lam_in_tuple(app->callee(), std::forward<RewriteCallee>(rewrite_callee),
                                            std::forward<RewriteIdx>(rewrite_idx));
     auto arg    = std::forward<RewriteArg>(rewrite_arg)(app->arg());
     return app->rebuild(w, app->type(), {callee, arg});
@@ -63,8 +63,8 @@ static const Def* rewrite_apped_nom_lam_in_tuple(const Def* def,
 
 // Entry point of the phase.
 void AddMem::visit(const Scope& scope) {
-    if (auto entry = scope.entry()->isa_nom<Lam>()) {
-        scope.free_noms(); // cache this.
+    if (auto entry = scope.entry()->isa_mut<Lam>()) {
+        scope.free_muts(); // cache this.
         sched_ = Scheduler{scope};
         add_mem_to_lams(entry, entry);
     }
@@ -73,7 +73,7 @@ void AddMem::visit(const Scope& scope) {
 const Def* AddMem::mem_for_lam(Lam* lam) const {
     if (auto it = mem_rewritten_.find(lam); it != mem_rewritten_.end()) {
         // We created a new lambda. Therefore, we want to lookup the mem for the new lambda.
-        lam = it->second->as_nom<Lam>();
+        lam = it->second->as_mut<Lam>();
     }
     if (auto it = val2mem_.find(lam); it != val2mem_.end()) {
         lam->world().DLOG("found mem for {} in val2mem_ : {}", lam, it->second);
@@ -82,7 +82,7 @@ const Def* AddMem::mem_for_lam(Lam* lam) const {
     }
     // As a fallback, we lookup the memory in vars of the lambda.
     auto mem = mem::mem_var(lam);
-    assert(mem && "nom must have mem!");
+    assert(mem && "mut must have mem!");
     return mem;
 }
 
@@ -113,7 +113,7 @@ const Def* AddMem::add_mem_to_lams(Lam* curr_lam, const Def* def) {
 
     // world().DLOG("rewriting {} : {} in {}", def, def->type(), place);
 
-    if (auto nom_lam = def->isa_nom<Lam>(); nom_lam && !nom_lam->is_set()) return def;
+    if (auto mut_lam = def->isa_mut<Lam>(); mut_lam && !mut_lam->is_set()) return def;
     if (auto ax = def->isa<Axiom>()) return ax;
     if (auto it = mem_rewritten_.find(def); it != mem_rewritten_.end()) {
         auto tmp = it->second;
@@ -130,55 +130,55 @@ const Def* AddMem::add_mem_to_lams(Lam* curr_lam, const Def* def) {
     }
     if (match<mem::M>(def->type())) { world().DLOG("new mem {} in {}", def, curr_lam); }
 
-    auto rewrite_lam = [&](Lam* nom) -> const Def* {
-        auto pi      = nom->type()->as<Pi>();
-        auto new_nom = nom;
+    auto rewrite_lam = [&](Lam* mut) -> const Def* {
+        auto pi      = mut->type()->as<Pi>();
+        auto new_mut = mut;
 
-        if (auto it = mem_rewritten_.find(nom); it != mem_rewritten_.end()) {
-            if (curr_lam == nom) // i.e. we've stubbed this, but now we rewrite it
-                new_nom = it->second->as_nom<Lam>();
+        if (auto it = mem_rewritten_.find(mut); it != mem_rewritten_.end()) {
+            if (curr_lam == mut) // i.e. we've stubbed this, but now we rewrite it
+                new_mut = it->second->as_mut<Lam>();
             else if (auto pi = it->second->type()->as<Pi>(); pi->num_doms() > 0 && match<mem::M>(pi->dom(0_s)))
                 return it->second;
         }
 
-        if (!nom->is_set()) return nom;
-        world().DLOG("rewrite nom lam {}", nom);
+        if (!mut->is_set()) return mut;
+        world().DLOG("rewrite mut lam {}", mut);
 
-        bool is_bound = sched_.scope().bound(nom) || nom == curr_lam;
+        bool is_bound = sched_.scope().bound(mut) || mut == curr_lam;
 
-        if (new_nom == nom) // if not stubbed yet
-            if (auto new_pi = rewrite_pi(pi); new_pi != pi) { new_nom = nom->stub(world(), new_pi); }
+        if (new_mut == mut) // if not stubbed yet
+            if (auto new_pi = rewrite_pi(pi); new_pi != pi) { new_mut = mut->stub(world(), new_pi); }
 
         if (!is_bound) {
-            world().DLOG("free lam {}", nom);
-            mem_rewritten_[nom] = new_nom;
-            return new_nom;
+            world().DLOG("free lam {}", mut);
+            mem_rewritten_[mut] = new_mut;
+            return new_mut;
         }
 
-        auto var_offset = new_nom->num_doms() - nom->num_doms(); // have we added a mem var?
-        if (nom->num_vars() != 0) mem_rewritten_[nom->var()] = new_nom->var();
-        for (size_t i = 0; i < nom->num_vars() && new_nom->num_vars() > 1; ++i)
-            mem_rewritten_[nom->var(i)] = new_nom->var(i + var_offset);
+        auto var_offset = new_mut->num_doms() - mut->num_doms(); // have we added a mem var?
+        if (mut->num_vars() != 0) mem_rewritten_[mut->var()] = new_mut->var();
+        for (size_t i = 0; i < mut->num_vars() && new_mut->num_vars() > 1; ++i)
+            mem_rewritten_[mut->var(i)] = new_mut->var(i + var_offset);
 
-        mem_rewritten_[new_nom]           = new_nom;
-        mem_rewritten_[nom]               = new_nom;
-        val2mem_[new_nom]                 = new_nom->var(0_s);
-        val2mem_[nom]                     = new_nom->var(0_s);
-        mem_rewritten_[new_nom->var(0_s)] = new_nom->var(0_s);
-        for (size_t i = 0, n = new_nom->num_ops(); i < n; ++i) {
-            if (auto op = nom->op(i)) static_cast<Def*>(new_nom)->set(i, add_mem_to_lams(nom, op));
+        mem_rewritten_[new_mut]           = new_mut;
+        mem_rewritten_[mut]               = new_mut;
+        val2mem_[new_mut]                 = new_mut->var(0_s);
+        val2mem_[mut]                     = new_mut->var(0_s);
+        mem_rewritten_[new_mut->var(0_s)] = new_mut->var(0_s);
+        for (size_t i = 0, n = new_mut->num_ops(); i < n; ++i) {
+            if (auto op = mut->op(i)) static_cast<Def*>(new_mut)->set(i, add_mem_to_lams(mut, op));
         }
 
-        if (nom != new_nom && nom->is_external()) {
-            nom->make_internal();
-            new_nom->make_external();
+        if (mut != new_mut && mut->is_external()) {
+            mut->make_internal();
+            new_mut->make_external();
         }
-        return new_nom;
+        return new_mut;
     };
 
     // rewrite top-level lams
-    if (auto nom = def->isa_nom<Lam>()) { return rewrite_lam(nom); }
-    assert(!def->isa_nom());
+    if (auto mut = def->isa_mut<Lam>()) { return rewrite_lam(mut); }
+    assert(!def->isa_mut());
 
     if (auto pi = def->isa<Pi>()) return rewrite_pi(pi);
 
@@ -197,10 +197,10 @@ const Def* AddMem::add_mem_to_lams(Lam* curr_lam, const Def* def) {
         return arg->world().tuple(new_args);
     };
 
-    // call-site of a nominal lambda
-    if (auto apped_nom = isa_apped_nom_lam_in_tuple(def); apped_nom.first) {
+    // call-site of a mutable lambda
+    if (auto apped_mut = isa_apped_mut_lam_in_tuple(def); apped_mut.first) {
         return mem_rewritten_[def] =
-                   rewrite_apped_nom_lam_in_tuple(def, std::move(rewrite_lam), std::move(rewrite_arg),
+                   rewrite_apped_mut_lam_in_tuple(def, std::move(rewrite_lam), std::move(rewrite_arg),
                                                   [&](const Def* def) { return add_mem_to_lams(place, def); });
     }
 

--- a/dialects/refly/passes/remove_perm.cpp
+++ b/dialects/refly/passes/remove_perm.cpp
@@ -4,7 +4,7 @@
 
 namespace thorin::refly {
 
-const Def* RemoveDbgPerm::rewrite(const Def* def) {
+Ref RemoveDbgPerm::rewrite(Ref def) {
     if (auto dbg_perm = match(dbg::perm, def)) {
         auto e = dbg_perm->arg();
         world().DLOG("dbg_perm: {}", e);

--- a/dialects/refly/passes/remove_perm.h
+++ b/dialects/refly/passes/remove_perm.h
@@ -11,7 +11,7 @@ public:
     RemoveDbgPerm(PassMan& man)
         : RWPass(man, "remove_dbg_perm") {}
 
-    const Def* rewrite(const Def*) override;
+    Ref rewrite(Ref) override;
 };
 
 } // namespace thorin::refly

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -51,8 +51,8 @@ Each `Def` is a node in a graph which is maintained in the [World](@ref thorin::
 
 | **Immutable**                                                         | **Mutable**                                                                   |
 |-----------------------------------------------------------------------|-------------------------------------------------------------------------------|
-| must be `const`                                                       | maybe non-`const`                                                             |
 | immutable                                                             | mutable                                                                       |
+| *must be* `const`                                                     | *may be* **non**-`const`                                                      |
 | ops form [DAG](https://en.wikipedia.org/wiki/Directed_acyclic_graph)  | ops may be cyclic                                                             |
 | no recursion                                                          | may be recursive                                                              |
 | no [Var](@ref thorin::Var)                                            | has [Var](@ref thorin::Var); get with [Def::var](@ref thorin::Def::var)       |
@@ -66,7 +66,7 @@ Use [Def::isa_mut](@ref thorin::Def::isa_mut) to check whether a specific `Def` 
 void foo(const Def* def) {
     if (auto mut = def->isa_mut()) {
         // mut of type Def* - const has been removed!
-        // This gives give you access to the non-const methods that only make sense for mutable:
+        // This gives give you access to the non-const methods that only make sense for mutables:
         auto var = mut->var();
         auto stub = mut->stub(world, type, debug)
         // ...

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -19,7 +19,7 @@ Here is a small example that first constructs a `main` function and simply retur
 
     // Cn [mem, i32, Cn [mem, i32]]
     auto main_t = w.cn({mem_t, i32_t, argv_t, w.cn({mem_t, i32_t})});
-    auto main = w.nom_lam(main_t)->set("main");
+    auto main = w.mut_lam(main_t)->set("main");
     auto [mem, argc, argv, ret] = main->vars<4>();
     main->app(ret, {mem, argc});
     main->make_external();
@@ -47,9 +47,9 @@ TODO
 Each `Def` is a node in a graph which is maintained in the [World](@ref thorin::World).
 [Hash consing](https://en.wikipedia.org/wiki/Hash_consing) TODO
 
-## Structural vs. Nominal
+## Immutables vs. Mutables
 
-| Structural                                                            | Nominal                                                                       |
+| **Immutable**                                                         | **Mutable**                                                                   |
 |-----------------------------------------------------------------------|-------------------------------------------------------------------------------|
 | must be `const`                                                       | maybe non-`const`                                                             |
 | immutable                                                             | mutable                                                                       |
@@ -61,35 +61,35 @@ Each `Def` is a node in a graph which is maintained in the [World](@ref thorin::
 | [Def::rebuild](@ref thorin::Def::rebuild)                             | [Def::stub](@ref thorin::Def::stub)                                           |
 
 Usually, you will encounter `defs` as `const Def*`.
-Use [Def::isa_nom](@ref thorin::Def::isa_nom) to check whether a specific `Def` is in fact nominal to cast away the `const` or [Def::as_nom](@ref thorin::Def::as_nom) to force this cast (and assert if not possible):
+Use [Def::isa_mut](@ref thorin::Def::isa_mut) to check whether a specific `Def` is in fact mutable to cast away the `const` or [Def::as_mut](@ref thorin::Def::as_mut) to force this cast (and assert if not possible):
 ```cpp
 void foo(const Def* def) {
-    if (auto nom = def->isa_nom()) {
-        // nom of type Def* - const has been removed!
-        // This gives give you access to the non-const methods that only make sense for nominals:
-        auto var = nom->var();
-        auto stub = nom->stub(world, type, debug)
+    if (auto mut = def->isa_mut()) {
+        // mut of type Def* - const has been removed!
+        // This gives give you access to the non-const methods that only make sense for mutable:
+        auto var = mut->var();
+        auto stub = mut->stub(world, type, debug)
         // ...
     }
 
     // ...
 
-    if (auto lam = def->isa_nom<Lam>()) {
+    if (auto lam = def->isa_mut<Lam>()) {
         // lam of type Lam* - const has been removed!
     }
 }
 ```
-You can also check whether a specific `def` is really a structural:
+You can also check whether a specific `def` is really an *imm*utable:
 ```cpp
 void foo(const Def* def) {
-    if (auto s = def->isa_structural()) {
-        // s cannot be a nominal
+    if (auto s = def->isa_imm()) {
+        // s cannot be a mutable
     }
 
     // ...
 
-    if (auto sigma = def->isa_structural<Sigma>()) {
-        // sigma is of type const Sigma* and cannot be a nominal Sigma
+    if (auto sigma = def->isa_imm<Sigma>()) {
+        // sigma is of type const Sigma* and cannot be a mutable Sigma
     }
 }
 ```
@@ -103,8 +103,8 @@ It depends on what exactly you want to achieve and how much structure you need d
 The simplest way is to kick off with [World::externals](@ref thorin::World::externals) and recursively run over [Def::extended_ops](@ref thorin::Def::extended_ops) like this:
 ```cpp
     DefSet done;
-    for (const auto& [_, nom] : world.externals())
-        visit(done, nom);
+    for (const auto& [_, mut] : world.externals())
+        visit(done, mut);
 
     void visit(DefSet& done, const Def* def) {
         if (!done.emplace(def).second) return;

--- a/docs/langref.md
+++ b/docs/langref.md
@@ -37,18 +37,18 @@ In addition the following keywords are *terminals*:
 |-----------|-----------------------------------------------------------|
 | `.ax`     | axiom                                                     |
 | `.let`    | let expression                                            |
-| `.Pi`     | nominal thorin::Pi                                        |
+| `.Pi`     | mutable thorin::Pi                                        |
 | `.con`    | [continuation](@ref thorin::Lam) (declaration)            |
 | `.fun`    | [function](@ref thorin::Lam) (declaration - TODO)         |
 | `.lam`    | [lambda](@ref thorin::Lam) (declaration)                  |
 | `.cn`     | [continuation](@ref thorin::Lam) (expression)             |
 | `.fn`     | [function](@ref thorin::Lam) (expression - TODO)          |
 | `.cn`     | [lambda](@ref thorin::Lam) (expression)                   |
-| `.Arr`    | nominal thorin::Arr                                       |
-| `.pack`   | nominal thorin::Pack                                      |
-| `.Sigma`  | nominal thorin::Sigma                                     |
-| `.def`    | nominal definition                                        |
-| `.extern` | marks nominal as external                                 |
+| `.Arr`    | mutable thorin::Arr                                       |
+| `.pack`   | mutable thorin::Pack                                      |
+| `.Sigma`  | mutable thorin::Sigma                                     |
+| `.def`    | mutable definition                                        |
+| `.extern` | marks mutable as external                                 |
 | `.ins`    | thorin::Insert expression                                 |
 | `.insert` | alias for `.ins`                                          |
 | `.module` | starts a module                                           |
@@ -146,8 +146,8 @@ The following tables comprise all production rules:
 | d           | `.Arr` Sym ( `:` e<sub>type</sub> )? `,` e<sub>shape</sub> v? n   | array declaration                  | thorin::Arr   |
 | d           | `.pack` Sym ( `:` e<sub>type</sub> )? `,` e<sub>shape</sub> v? n  | pack declaration                   | thorin::Pack  |
 | d           | `.Sigma` Sym ( `:` e<sub>type</sub> )? `,` L<sub>arity</sub> v? n | sigma declaration                  | thorin::Sigma |
-| d           | `.def` Sym n                                                      | nominal definition                 | nominals      |
-| n           | `;` \| o                                                          | nominal definition                 | -             |
+| d           | `.def` Sym n                                                      | mutable definition                 | mutable      |
+| n           | `;` \| o                                                          | mutable definition                 | -             |
 | o           | `=` de `;`                                                        | operand of definition              | -             |
 | o           | `=` `{` e `,` ... `,` e  `}` `;`                                  | operands of definition<sup>s</sup> | -             |
 <sup>s</sup> opens new scope
@@ -207,7 +207,7 @@ For this reason there is no rule `b -> s (p, ..., p)`.
 An elided type of
 * a literal defaults to `.Nat`,
 * a bottom/top defaults to `*`,
-* a nominals defaults to `*`.
+* a mutable defaults to `*`.
 
 #### Precedence
 
@@ -219,10 +219,10 @@ Expressions nesting is disambiguated according to the following precedence table
 | e `#` e              | extract                             | left-to-right |
 | e e                  | application                         | left-to-right |
 | `Π` Sym `:` e        | domain of a dependent function type | -             |
-| `.fun` Sym Sym `:` e | nominal funciton declaration        | -             |
-| `.lam` Sym Sym `:` e | nominal continuation declaration    | -             |
-| `.fn` Sym `:` e      | nominal funciton expression         | -             |
-| `.lm` Sym `:` e      | nominal continuation expression     | -             |
+| `.fun` Sym Sym `:` e | mutable funciton declaration        | -             |
+| `.lam` Sym Sym `:` e | mutable continuation declaration    | -             |
+| `.fn` Sym `:` e      | mutable funciton expression         | -             |
+| `.lm` Sym `:` e      | mutable continuation expression     | -             |
 | e `→` e              | function type                       | right-to-left |
 
 Note that the domain of a dependent function type binds slightly stronger than `→`.
@@ -256,7 +256,7 @@ The names of axioms are special and live in a global namespace.
 
 ### Field Names of Sigmas
 
-Named elements of nominal sigmas are avaiable for extracts/inserts.
+Named elements of mutable sigmas are avaiable for extracts/inserts.
 These names take precedence over the usual scope.
 In the following example, `i` refers to the first element `i` of `X` and **not** to the `i` introduced via `.let`:
 ```

--- a/docs/langref.md
+++ b/docs/langref.md
@@ -146,7 +146,7 @@ The following tables comprise all production rules:
 | d           | `.Arr` Sym ( `:` e<sub>type</sub> )? `,` e<sub>shape</sub> v? n   | array declaration                  | thorin::Arr   |
 | d           | `.pack` Sym ( `:` e<sub>type</sub> )? `,` e<sub>shape</sub> v? n  | pack declaration                   | thorin::Pack  |
 | d           | `.Sigma` Sym ( `:` e<sub>type</sub> )? `,` L<sub>arity</sub> v? n | sigma declaration                  | thorin::Sigma |
-| d           | `.def` Sym n                                                      | mutable definition                 | mutable      |
+| d           | `.def` Sym n                                                      | mutable definition                 | mutables      |
 | n           | `;` \| o                                                          | mutable definition                 | -             |
 | o           | `=` de `;`                                                        | operand of definition              | -             |
 | o           | `=` `{` e `,` ... `,` e  `}` `;`                                  | operands of definition<sup>s</sup> | -             |

--- a/docs/passes.md
+++ b/docs/passes.md
@@ -30,8 +30,8 @@ There are two kind of passes in Thorin:
 ## Rewrite Pass
 
 In order to write a [rewrite pass](@ref thorin::RWPass), you have to inherit from [RWPass](@ref thorin::RWPass).
-Usually, you are only interested in looking for code patterns that only occur in specific mutable - typically [Lam](@ref thorin::Lam)bdas.
-You can filter for these mutable by passing it as template parameter to [RWPass](@ref thorin::RWPass) when inherting from it.
+Usually, you are only interested in looking for code patterns that only occur in specific mutables - typically [Lam](@ref thorin::Lam)bdas.
+You can filter for these mutables by passing it as template parameter to [RWPass](@ref thorin::RWPass) when inherting from it.
 The main hook to the [PassMan](@ref thorin::PassMan), is the [rewrite](@ref thorin::Pass::rewrite) method.
 As an example, let's have a look at the [Alloc2Malloc](@ref thorin::mem::Alloc2Malloc) pass.
 It rewrites `alloc`/`slot` calls into their more verbose siblings `malloc`/`mslot` that make the size of the alloc'ed type explicit:
@@ -90,7 +90,7 @@ The reason is that the very program you are constructing is the **only** way to 
 
 ### Creating Mutables
 
-Eventually, you will need to create mutable during a [fixed-point pass](@ref thorin::FPPass).
+Eventually, you will need to create mutables during a [fixed-point pass](@ref thorin::FPPass).
 You must be super cautious to remember in which exact context you created said mutable.
 If you ever come into the same situation again (due to backtracking) you have to make sure that you return the **very same** mutable.
-Otherwise, if you create a different mutable, the [PassMan](@ref thorin::PassMan) will most likely diverge as it will constantly backtrack while creating new mutable that the other passes don't know anything about.
+Otherwise, if you create a different mutable, the [PassMan](@ref thorin::PassMan) will most likely diverge as it will constantly backtrack while creating new mutables that the other passes don't know anything about.

--- a/docs/passes.md
+++ b/docs/passes.md
@@ -30,8 +30,8 @@ There are two kind of passes in Thorin:
 ## Rewrite Pass
 
 In order to write a [rewrite pass](@ref thorin::RWPass), you have to inherit from [RWPass](@ref thorin::RWPass).
-Usually, you are only interested in looking for code patterns that only occur in specific nominals - typically [Lam](@ref thorin::Lam)bdas.
-You can filter for these nominals by passing it as template parameter to [RWPass](@ref thorin::RWPass) when inherting from it.
+Usually, you are only interested in looking for code patterns that only occur in specific mutable - typically [Lam](@ref thorin::Lam)bdas.
+You can filter for these mutable by passing it as template parameter to [RWPass](@ref thorin::RWPass) when inherting from it.
 The main hook to the [PassMan](@ref thorin::PassMan), is the [rewrite](@ref thorin::Pass::rewrite) method.
 As an example, let's have a look at the [Alloc2Malloc](@ref thorin::mem::Alloc2Malloc) pass.
 It rewrites `alloc`/`slot` calls into their more verbose siblings `malloc`/`mslot` that make the size of the alloc'ed type explicit:
@@ -88,9 +88,9 @@ It is important to always construct a valid program.
 Otherwise, bad things might happen as soon as you toss other passes into the mix.
 The reason is that the very program you are constructing is the **only** way to communicate with the other passes without directly sharing information.
 
-### Creating Nominals
+### Creating Mutables
 
-Eventually, you will need to create nominals during a [fixed-point pass](@ref thorin::FPPass).
-You must be super cautious to remember in which exact context you created said nominal.
-If you ever come into the same situation again (due to backtracking) you have to make sure that you return the **very same** nominal.
-Otherwise, if you create a different nominal, the [PassMan](@ref thorin::PassMan) will most likely diverge as it will constantly backtrack while creating new nominals that the other passes don't know anything about.
+Eventually, you will need to create mutable during a [fixed-point pass](@ref thorin::FPPass).
+You must be super cautious to remember in which exact context you created said mutable.
+If you ever come into the same situation again (due to backtracking) you have to make sure that you return the **very same** mutable.
+Otherwise, if you create a different mutable, the [PassMan](@ref thorin::PassMan) will most likely diverge as it will constantly backtrack while creating new mutable that the other passes don't know anything about.

--- a/gtest/restricted_dep_types.cpp
+++ b/gtest/restricted_dep_types.cpp
@@ -42,7 +42,7 @@ TEST(RestrictedDependentTypes, join_singleton) {
         auto RW = w.join({w.singleton(R), w.singleton(W)})->set("RW");
         auto DT = w.join({w.singleton(i32_t), w.singleton(i64_t)})->set("DT");
 
-        auto exp_pi = w.nom_pi(w.type<1>())->set_dom({DT, RW});
+        auto exp_pi = w.mut_pi(w.type<1>())->set_dom({DT, RW});
         exp_pi->set_codom(w.type());
         auto Exp = w.axiom(exp_pi)->set("exp");
 
@@ -56,27 +56,27 @@ TEST(RestrictedDependentTypes, join_singleton) {
             EXPECT_NO_THROW( // no type error
                 w.app(exp_lam,
                       {i32_t, R, core::op_bitcast(w.app(Exp, {w.vel(DT, i32_t), w.vel(RW, R)}), w.lit(i32_t, 1000)),
-                       w.nom_lam(w.cn(i32_t))}));
+                       w.mut_lam(w.cn(i32_t))}));
         });
         cases.emplace_back([](World& w, auto, auto W, auto Exp, auto exp_lam, auto DT, auto RW, auto i32_t, auto) {
             EXPECT_NO_THROW( // no type error
                 w.app(exp_lam,
                       {i32_t, W, core::op_bitcast(w.app(Exp, {w.vel(DT, i32_t), w.vel(RW, W)}), w.lit(i32_t, 1000)),
-                       w.nom_lam(w.cn(i32_t))}));
+                       w.mut_lam(w.cn(i32_t))}));
         });
         cases.emplace_back(
             [](World& w, auto R, auto, auto Exp, auto exp_lam, auto DT, auto RW, auto i32_t, auto i64_t) {
                 EXPECT_NO_THROW( // no type error
                     w.app(exp_lam,
                           {i64_t, R, core::op_bitcast(w.app(Exp, {w.vel(DT, i64_t), w.vel(RW, R)}), w.lit(i32_t, 1000)),
-                           w.nom_lam(w.cn(i64_t))}));
+                           w.mut_lam(w.cn(i64_t))}));
             });
         cases.emplace_back(
             [](World& w, auto, auto W, auto Exp, auto exp_lam, auto DT, auto RW, auto i32_t, auto i64_t) {
                 EXPECT_NO_THROW( // no type error
                     w.app(exp_lam,
                           {i64_t, W, core::op_bitcast(w.app(Exp, {w.vel(DT, i64_t), w.vel(RW, W)}), w.lit(i32_t, 1000)),
-                           w.nom_lam(w.cn(i64_t))}));
+                           w.mut_lam(w.cn(i64_t))}));
             });
         cases.emplace_back([](World& w, auto R, auto, auto Exp, auto exp_lam, auto DT, auto RW, auto i32_t, auto) {
             EXPECT_NONFATAL_FAILURE( // disable until we have vel type checking..
@@ -85,7 +85,7 @@ TEST(RestrictedDependentTypes, join_singleton) {
                         w.app(exp_lam, {math::type_f32(w), R,
                                         core::op_bitcast(w.app(Exp, {w.vel(DT, math::type_f32(w)), w.vel(RW, R)}),
                                                          w.lit(i32_t, 1000)),
-                                        w.nom_lam(w.cn(math::type_f32(w)))}),
+                                        w.mut_lam(w.cn(math::type_f32(w)))}),
                         std::logic_error);
                 },
                 "std::logic_error");
@@ -97,7 +97,7 @@ TEST(RestrictedDependentTypes, join_singleton) {
                         w.app(exp_lam, {math::type_f32(w), W,
                                         core::op_bitcast(w.app(Exp, {w.vel(DT, math::type_f32(w)), w.vel(RW, W)}),
                                                          w.lit(i32_t, 1000)),
-                                        w.nom_lam(w.cn(math::type_f32(w)))}),
+                                        w.mut_lam(w.cn(math::type_f32(w)))}),
                         std::logic_error);
                 },
                 "std::logic_error");
@@ -109,7 +109,7 @@ TEST(RestrictedDependentTypes, join_singleton) {
                         w.app(exp_lam,
                               {i32_t, i32_t,
                                core::op_bitcast(w.app(Exp, {w.vel(DT, i32_t), w.vel(RW, i32_t)}), w.lit(i32_t, 1000)),
-                               w.nom_lam(w.cn(i32_t))}),
+                               w.mut_lam(w.cn(i32_t))}),
                         std::logic_error);
                 },
                 "std::logic_error");
@@ -121,7 +121,7 @@ TEST(RestrictedDependentTypes, join_singleton) {
                         w.app(exp_lam,
                               {i64_t, i64_t,
                                core::op_bitcast(w.app(Exp, {w.vel(DT, i64_t), w.vel(RW, i64_t)}), w.lit(i32_t, 1000)),
-                               w.nom_lam(w.cn(i64_t))}),
+                               w.mut_lam(w.cn(i64_t))}),
                         std::logic_error);
                 },
                 "std::logic_error");
@@ -134,14 +134,14 @@ TEST(RestrictedDependentTypes, join_singleton) {
                 auto RW    = w.join({w.singleton(R), w.singleton(W)})->set("RW");
                 auto DT    = w.join({w.singleton(i32_t), w.singleton(i64_t)})->set("DT");
 
-                auto exp_sig = w.nom_sigma(4);
+                auto exp_sig = w.mut_sigma(4);
                 exp_sig->set(0, w.type());
                 exp_sig->set(1, w.type());
                 exp_sig->set(2, w.app(Exp, {w.vel(DT, exp_sig->var(0_s)), w.vel(RW, exp_sig->var(1_s))}));
                 exp_sig->set(3, w.cn(exp_sig->var(0_s)));
 
                 auto exp_lam_pi = w.cn(exp_sig);
-                auto exp_lam    = w.nom_lam(exp_lam_pi);
+                auto exp_lam    = w.mut_lam(exp_lam_pi);
                 exp_lam->app(false, exp_lam->var(3), core::op_bitcast(exp_lam->var(0_s), exp_lam->var(2_s)));
                 test(w, R, W, Exp, exp_lam, DT, RW, i32_t, i64_t);
             });
@@ -155,13 +155,13 @@ TEST(RestrictedDependentTypes, join_singleton) {
             EXPECT_NO_THROW( // no type error
                 w.app(exp_lam,
                       {i32_t, core::op_bitcast(w.app(Exp, {w.vel(DT, i32_t), w.vel(RW, R)}), w.lit(i32_t, 1000)),
-                       w.nom_lam(w.cn(i32_t))}));
+                       w.mut_lam(w.cn(i32_t))}));
         });
         cases.emplace_back([](World& w, auto R, auto, auto Exp, auto exp_lam, auto DT, auto RW, auto, auto i64_t) {
             EXPECT_NO_THROW( // no type error
                 w.app(exp_lam,
                       {i64_t, core::op_bitcast(w.app(Exp, {w.vel(DT, i64_t), w.vel(RW, R)}), w.lit(i64_t, 1000)),
-                       w.nom_lam(w.cn(i64_t))}));
+                       w.mut_lam(w.cn(i64_t))}));
         });
         cases.emplace_back([](World& w, auto R, auto, auto Exp, auto exp_lam, auto DT, auto RW, auto i32_t, auto) {
             EXPECT_NONFATAL_FAILURE( // disable until we have vel type checking..
@@ -170,7 +170,7 @@ TEST(RestrictedDependentTypes, join_singleton) {
                         w.app(exp_lam, {math::type_f32(w),
                                         core::op_bitcast(w.app(Exp, {w.vel(DT, math::type_f32(w)), w.vel(RW, R)}),
                                                          w.lit(i32_t, 1000)),
-                                        w.nom_lam(w.cn(math::type_f32(w)))}),
+                                        w.mut_lam(w.cn(math::type_f32(w)))}),
                         std::logic_error);
                 },
                 "std::logic_error");
@@ -179,21 +179,21 @@ TEST(RestrictedDependentTypes, join_singleton) {
             EXPECT_ANY_THROW( // W type error
                 w.app(exp_lam,
                       {i32_t, core::op_bitcast(w.app(Exp, {w.vel(DT, i32_t), w.vel(RW, W)}), w.lit(i32_t, 1000)),
-                       w.nom_lam(w.cn(i32_t))}));
+                       w.mut_lam(w.cn(i32_t))}));
         });
         cases.emplace_back(
             [](World& w, auto, auto W, auto Exp, auto exp_lam, auto DT, auto RW, auto i32_t, auto i64_t) {
                 EXPECT_ANY_THROW( // W type error
                     w.app(exp_lam,
                           {i64_t, core::op_bitcast(w.app(Exp, {w.vel(DT, i64_t), w.vel(RW, W)}), w.lit(i32_t, 1000)),
-                           w.nom_lam(w.cn(i64_t))}));
+                           w.mut_lam(w.cn(i64_t))}));
             });
         cases.emplace_back([](World& w, auto, auto W, auto Exp, auto exp_lam, auto DT, auto RW, auto, auto) {
             EXPECT_ANY_THROW( // float + W type error (note, the float is not yet what triggers the issue..)
                 w.app(exp_lam, {math::type_f32(w),
                                 core::op_bitcast(w.app(Exp, {w.vel(DT, math::type_f32(w)), w.vel(RW, W)}),
                                                  w.lit(math::type_f32(w), 1000)),
-                                w.nom_lam(w.cn(math::type_f32(w)))}));
+                                w.mut_lam(w.cn(math::type_f32(w)))}));
         });
 
         for (auto&& test : cases) {
@@ -203,13 +203,13 @@ TEST(RestrictedDependentTypes, join_singleton) {
                 auto RW    = w.join({w.singleton(R), w.singleton(W)})->set("RW");
                 auto DT    = w.join({w.singleton(i32_t), w.singleton(i64_t)})->set("DT");
 
-                auto exp_sig = w.nom_sigma(3);
+                auto exp_sig = w.mut_sigma(3);
                 exp_sig->set(0, w.type());
                 exp_sig->set(1, w.app(Exp, {w.vel(DT, exp_sig->var(0_s)), w.vel(RW, R)}));
                 exp_sig->set(2, w.cn(exp_sig->var(0_s)));
 
                 auto exp_lam_pi = w.cn(exp_sig);
-                auto exp_lam    = w.nom_lam(exp_lam_pi);
+                auto exp_lam    = w.mut_lam(exp_lam_pi);
                 exp_lam->app(false, exp_lam->var(2_s), core::op_bitcast(exp_lam->var(0_s), exp_lam->var(1_s)));
                 test(w, R, W, Exp, exp_lam, DT, RW, i32_t, i64_t);
             });
@@ -229,7 +229,7 @@ TEST(RestrictedDependentTypes, ll) {
 
     // Cn [mem, i32, ptr(ptr(i32, 0), 0) Cn [mem, i32]]
     auto main_t = w.cn({mem_t, i32_t, argv_t, w.cn({mem_t, i32_t})});
-    auto main   = w.nom_lam(main_t)->set("main");
+    auto main   = w.mut_lam(main_t)->set("main");
     main->make_external();
 
     auto R = w.axiom(w.type())->set("R");
@@ -238,7 +238,7 @@ TEST(RestrictedDependentTypes, ll) {
     auto RW = w.join({w.singleton(R), w.singleton(W)})->set("RW");
 
     auto DT     = w.join({w.singleton(i32_t), w.singleton(math::type_f32(w))})->set("DT");
-    auto exp_pi = w.nom_pi(w.type<1>())->set_dom({DT, RW});
+    auto exp_pi = w.mut_pi(w.type<1>())->set_dom({DT, RW});
     exp_pi->set_codom(w.type());
 
     auto Exp = w.axiom(exp_pi)->set("exp");
@@ -246,7 +246,7 @@ TEST(RestrictedDependentTypes, ll) {
     auto app_exp = w.app(Exp, {w.vel(DT, i32_t), w.vel(RW, R)});
 
     {
-        auto exp_sig = w.nom_sigma(5);
+        auto exp_sig = w.mut_sigma(5);
         exp_sig->set(0, mem_t);
         exp_sig->set(1, w.type());
         exp_sig->set(2, w.type());
@@ -254,7 +254,7 @@ TEST(RestrictedDependentTypes, ll) {
         exp_sig->set(4, w.cn({mem_t, i32_t}));
 
         auto exp_lam_pi = w.cn(exp_sig);
-        auto exp_lam    = w.nom_lam(exp_lam_pi);
+        auto exp_lam    = w.mut_lam(exp_lam_pi);
         auto bc         = core::op_bitcast(i32_t, exp_lam->var(3_s));
         exp_lam->app(false, exp_lam->var(4), {exp_lam->var(0_s), bc});
 

--- a/gtest/test.cpp
+++ b/gtest/test.cpp
@@ -41,9 +41,9 @@ TEST(World, simplify_one_tuple) {
 
     ASSERT_EQ(w.lit_ff(), w.tuple({w.lit_ff()})) << "constant fold (false) -> false";
 
-    auto type = w.nom_sigma(w.type(), 2);
+    auto type = w.mut_sigma(w.type(), 2);
     type->set(Defs{w.type_nat(), w.type_nat()});
-    ASSERT_EQ(type, w.sigma({type})) << "constant fold [nom] -> nom";
+    ASSERT_EQ(type, w.sigma({type})) << "constant fold [mut] -> mut";
 
     auto v = w.tuple(type, {w.lit_idx(42), w.lit_idx(1337)});
     ASSERT_EQ(v, w.tuple({v})) << "constant fold ({42, 1337}) -> {42, 1337}";
@@ -53,7 +53,7 @@ TEST(World, dependent_extract) {
     Driver driver;
     World& w = driver.world();
 
-    auto sig = w.nom_sigma(w.type<1>(), 2); // sig = [T: *, T]
+    auto sig = w.mut_sigma(w.type<1>(), 2); // sig = [T: *, T]
     sig->set(0, w.type<0>());
     sig->set(1, sig->var(0_u64));
     auto a = w.axiom(sig);
@@ -123,7 +123,7 @@ TEST(Axiom, curry) {
         //           ^         |
         //           |         |
         //           +---------+
-        auto rec = w.nom_pi(w.type())->set_dom(nat);
+        auto rec = w.mut_pi(w.type())->set_dom(nat);
         rec->set_codom(w.pi(nat, w.pi(nat, rec)));
         auto pi = w.pi(nat, w.pi(nat, rec));
 
@@ -145,7 +145,7 @@ TEST(Axiom, curry) {
         EXPECT_EQ(os.str(), "%test_5_3 0 1 2 3 42 5 6 42 8 9 42\n");
     }
     {
-        auto rec = w.nom_pi(w.type())->set_dom(nat);
+        auto rec = w.mut_pi(w.type())->set_dom(nat);
         rec->set_codom(rec);
 
         auto [curry, trip] = Axiom::infer_curry_and_trip(rec);

--- a/roadmap.md
+++ b/roadmap.md
@@ -6,7 +6,7 @@
 - [x] remove extra data from subclasses of `Def`
 - [x] remove RTTI
 - [x] `Lam` and `App` instead of `Continuation`
-- [x] make analyses work with all nominals, not just `Lam`s
+- [x] make analyses work with all mutables, not just `Lam`s
 - [x] remove `Type` and make it a `Def`
 - [x] PTS calculus of constructions style IR (mostly done)
 - [x] remove arg/param lists

--- a/thorin/analyses/cfg.cpp
+++ b/thorin/analyses/cfg.cpp
@@ -22,7 +22,7 @@ void CFNode::link(const CFNode* other) const {
     other->preds_.emplace(this);
 }
 
-std::ostream& operator<<(std::ostream& os, const CFNode* n) { return os << n->nom(); }
+std::ostream& operator<<(std::ostream& os, const CFNode* n) { return os << n->mut(); }
 
 //------------------------------------------------------------------------------
 
@@ -31,10 +31,10 @@ CFA::CFA(const Scope& scope)
     , entry_(node(scope.entry()))
     , exit_(node(scope.exit())) {
     std::queue<Def*> cfg_queue;
-    NomSet cfg_done;
+    MutSet cfg_done;
 
-    auto cfg_enqueue = [&](Def* nom) {
-        if (nom->is_set() && cfg_done.emplace(nom).second) cfg_queue.push(nom);
+    auto cfg_enqueue = [&](Def* mut) {
+        if (mut->is_set() && cfg_done.emplace(mut).second) cfg_queue.push(mut);
     };
 
     cfg_enqueue(scope.entry());
@@ -48,7 +48,7 @@ CFA::CFA(const Scope& scope)
             if (def->isa<Var>()) return;
             // TODO maybe optimize a little bit by using the order
             if (scope.bound(def) && done.emplace(def).second) {
-                if (auto dst = def->isa_nom()) {
+                if (auto dst = def->isa_mut()) {
                     cfg_enqueue(dst);
                     node(src)->link(node(dst));
                 } else
@@ -68,9 +68,9 @@ CFA::CFA(const Scope& scope)
     verify();
 }
 
-const CFNode* CFA::node(Def* nom) {
-    auto&& n = nodes_[nom];
-    if (n == nullptr) n = new CFNode(nom);
+const CFNode* CFA::node(Def* mut) {
+    auto&& n = nodes_[mut];
+    if (n == nullptr) n = new CFNode(mut);
     return n;
 }
 
@@ -142,7 +142,7 @@ void CFA::verify() {
     for (const auto& p : nodes()) {
         auto in = p.second;
         if (in != entry() && in->preds_.size() == 0) {
-            world().VLOG("missing predecessors: {}", in->nom());
+            world().VLOG("missing predecessors: {}", in->mut());
             error = true;
         }
     }

--- a/thorin/analyses/cfg.cpp
+++ b/thorin/analyses/cfg.cpp
@@ -100,9 +100,8 @@ void CFA::link_to_exit() {
 
         enqueue(n);
 
-        while (!queue.empty()) {
+        while (!queue.empty())
             for (auto pred : pop(queue)->preds()) enqueue(pred);
-        }
     };
 
     std::stack<const CFNode*> stack;
@@ -168,9 +167,8 @@ size_t CFG<forward>::post_order_visit(const CFNode* n, size_t i) {
     auto& n_index = forward ? n->f_index_ : n->b_index_;
     n_index       = size_t(-2);
 
-    for (auto succ : succs(n)) {
+    for (auto succ : succs(n))
         if (index(succ) == size_t(-1)) i = post_order_visit(succ, i);
-    }
 
     n_index = i - 1;
     rpo_[n] = n;

--- a/thorin/analyses/cfg.h
+++ b/thorin/analyses/cfg.h
@@ -23,12 +23,12 @@ using CFNodes = GIDSet<const CFNode*>;
 /// Managed by CFA.
 class CFNode {
 public:
-    CFNode(Def* nom)
-        : nom_(nom)
+    CFNode(Def* mut)
+        : mut_(mut)
         , gid_(gid_counter_++) {}
 
     uint64_t gid() const { return gid_; }
-    Def* nom() const { return nom_; }
+    Def* mut() const { return mut_; }
 
 private:
     const CFNodes& preds() const { return preds_; }
@@ -38,7 +38,7 @@ private:
     mutable size_t f_index_ = -1; ///< RPO index in a **forward** CFG.
     mutable size_t b_index_ = -1; ///< RPO index in a **backwards** CFG.
 
-    Def* nom_;
+    Def* mut_;
     size_t gid_;
     static uint64_t gid_counter_;
     mutable CFNodes preds_;
@@ -65,24 +65,24 @@ public:
     const Scope& scope() const { return scope_; }
     World& world() const { return scope().world(); }
     size_t size() const { return nodes().size(); }
-    const NomMap<const CFNode*>& nodes() const { return nodes_; }
+    const MutMap<const CFNode*>& nodes() const { return nodes_; }
     const F_CFG& f_cfg() const;
     const B_CFG& b_cfg() const;
-    const CFNode* operator[](Def* nom) const {
-        auto i = nodes_.find(nom);
+    const CFNode* operator[](Def* mut) const {
+        auto i = nodes_.find(mut);
         return i == nodes_.end() ? nullptr : i->second;
     }
 
 private:
     void link_to_exit();
     void verify();
-    const CFNodes& preds(Def* nom) const {
-        auto cn = nodes_.find(nom)->second;
+    const CFNodes& preds(Def* mut) const {
+        auto cn = nodes_.find(mut)->second;
         assert(cn);
         return cn->preds();
     }
-    const CFNodes& succs(Def* nom) const {
-        auto cn = nodes_.find(nom)->second;
+    const CFNodes& succs(Def* mut) const {
+        auto cn = nodes_.find(mut)->second;
         assert(cn);
         return cn->succs();
     }
@@ -91,7 +91,7 @@ private:
     const CFNode* node(Def*);
 
     const Scope& scope_;
-    NomMap<const CFNode*> nodes_;
+    MutMap<const CFNode*> nodes_;
     const CFNode* entry_;
     const CFNode* exit_;
     mutable std::unique_ptr<const F_CFG> f_cfg_;
@@ -125,12 +125,12 @@ public:
     size_t size() const { return cfa().size(); }
     const CFNodes& preds(const CFNode* n) const;
     const CFNodes& succs(const CFNode* n) const;
-    const CFNodes& preds(Def* nom) const { return preds(cfa()[nom]); }
-    const CFNodes& succs(Def* nom) const { return succs(cfa()[nom]); }
+    const CFNodes& preds(Def* mut) const { return preds(cfa()[mut]); }
+    const CFNodes& succs(Def* mut) const { return succs(cfa()[mut]); }
     size_t num_preds(const CFNode* n) const { return preds(n).size(); }
     size_t num_succs(const CFNode* n) const { return succs(n).size(); }
-    size_t num_preds(Def* nom) const { return num_preds(cfa()[nom]); }
-    size_t num_succs(Def* nom) const { return num_succs(cfa()[nom]); }
+    size_t num_preds(Def* mut) const { return num_preds(cfa()[mut]); }
+    size_t num_succs(Def* mut) const { return num_succs(cfa()[mut]); }
     const CFNode* entry() const { return forward ? cfa().entry() : cfa().exit(); }
     const CFNode* exit() const { return forward ? cfa().exit() : cfa().entry(); }
 
@@ -140,7 +140,7 @@ public:
     const CFNode* reverse_post_order(size_t i) const { return rpo_.array()[i]; }
     /// Maps from post-order index to CFNode.
     const CFNode* post_order(size_t i) const { return rpo_.array()[size() - 1 - i]; }
-    const CFNode* operator[](Def* nom) const { return cfa()[nom]; } ///< Maps from @p nom to CFNode.
+    const CFNode* operator[](Def* mut) const { return cfa()[mut]; } ///< Maps from @p mut to CFNode.
     const DomTreeBase<forward>& domtree() const;
     const LoopTree<forward>& looptree() const;
     const DomFrontierBase<forward>& domfrontier() const;

--- a/thorin/analyses/deptree.h
+++ b/thorin/analyses/deptree.h
@@ -8,11 +8,11 @@ namespace thorin {
 
 class DepNode {
 public:
-    DepNode(Def* nom, size_t depth)
-        : nom_(nom)
+    DepNode(Def* mut, size_t depth)
+        : mut_(mut)
         , depth_(depth) {}
 
-    Def* nom() const { return nom_; }
+    Def* mut() const { return mut_; }
     size_t depth() const { return depth_; }
     DepNode* parent() const { return parent_; }
     const auto& children() const { return children_; }
@@ -25,7 +25,7 @@ private:
         return this;
     }
 
-    Def* nom_;
+    Def* mut_;
     size_t depth_;
     DepNode* parent_ = nullptr;
     std::vector<DepNode*> children_;
@@ -43,7 +43,7 @@ public:
 
     World& world() const { return world_; };
     const DepNode* root() const { return root_.get(); }
-    const DepNode* nom2node(Def* nom) const { return nom2node_.find(nom)->second.get(); }
+    const DepNode* mut2node(Def* mut) const { return mut2node_.find(mut)->second.get(); }
     bool depends(Def* a, Def* b) const; ///< Does @p a depend on @p b?
 
 private:
@@ -54,7 +54,7 @@ private:
 
     World& world_;
     std::unique_ptr<DepNode> root_;
-    NomMap<std::unique_ptr<DepNode>> nom2node_;
+    MutMap<std::unique_ptr<DepNode>> mut2node_;
     DefMap<VarSet> def2vars_;
     std::deque<DepNode*> stack_;
 };

--- a/thorin/analyses/schedule.h
+++ b/thorin/analyses/schedule.h
@@ -17,7 +17,7 @@ public:
     ///@{
     const Scope& scope() const { return *scope_; }
     const F_CFG& cfg() const { return *cfg_; }
-    const CFNode* cfg(Def* nom) const { return cfg()[nom]; }
+    const CFNode* cfg(Def* mut) const { return cfg()[mut]; }
     const DomTree& domtree() const { return *domtree_; }
     const Uses& uses(const Def* def) const {
         auto i = def2uses_.find(def);

--- a/thorin/analyses/scope.cpp
+++ b/thorin/analyses/scope.cpp
@@ -74,8 +74,8 @@ void Scope::calc_free() const {
 
         if (auto var = def->isa<Var>())
             free_vars_.emplace(var);
-        else if (auto nom = def->isa_nom())
-            free_noms_.emplace(nom);
+        else if (auto mut = def->isa_mut())
+            free_muts_.emplace(mut);
         else
             queue.push(def);
     };
@@ -91,15 +91,15 @@ const CFA& Scope::cfa() const { return lazy_init(this, cfa_); }
 const F_CFG& Scope::f_cfg() const { return cfa().f_cfg(); }
 const B_CFG& Scope::b_cfg() const { return cfa().b_cfg(); }
 
-bool is_free(Def* nom, const Def* def) {
-    if (auto var = nom->var()) {
+bool is_free(Def* mut, const Def* def) {
+    if (auto var = mut->var()) {
         // optimize common cases first
         if (def->num_ops() == 0) return false;
         if (var == def) return true;
-        for (auto v : var->nom()->vars())
+        for (auto v : var->mut()->vars())
             if (var == v) return true;
 
-        Scope scope(nom);
+        Scope scope(mut);
         return scope.bound(def);
     }
 

--- a/thorin/analyses/scope.cpp
+++ b/thorin/analyses/scope.cpp
@@ -30,9 +30,8 @@ void Scope::run() {
         queue.push(var);
 
         while (!queue.empty()) {
-            for (auto use : queue.pop()->uses()) {
+            for (auto use : queue.pop()->uses())
                 if (use != entry_ && use != exit_) queue.push(use);
-            }
         }
     }
 }
@@ -56,9 +55,8 @@ void Scope::calc_bound() const {
 
     for (auto op : entry()->partial_ops()) enqueue(op);
 
-    while (!queue.empty()) {
+    while (!queue.empty())
         for (auto op : queue.pop()->partial_ops()) enqueue(op);
-    }
 
     swap(live, bound_);
 }
@@ -82,9 +80,8 @@ void Scope::calc_free() const {
 
     for (auto free : free_defs()) enqueue(free);
 
-    while (!queue.empty()) {
+    while (!queue.empty())
         for (auto op : queue.pop()->extended_ops()) enqueue(op);
-    }
 }
 
 const CFA& Scope::cfa() const { return lazy_init(this, cfa_); }

--- a/thorin/analyses/scope.h
+++ b/thorin/analyses/scope.h
@@ -42,9 +42,9 @@ public:
     bool bound(const Def* def) const { return bound().contains(def); }
     // clang-format off
     const DefSet& bound()     const { calc_bound(); return bound_;     } ///< All @p Def%s within this @p Scope.
-    const DefSet& free_defs() const { calc_bound(); return free_defs_; } ///< All @em non-const @p Def%s @em directly referenced but @em not @p bound within this @p Scope. May also include @p Var%s or @em noms.
-    const VarSet& free_vars() const { calc_free (); return free_vars_; } ///< All @p Var%s that occurr free in this @p Scope. Does @em not transitively contain any free @p Var%s from @p noms.
-    const NomSet& free_noms() const { calc_free (); return free_noms_; } ///< All @em noms that occurr free in this @p Scope.
+    const DefSet& free_defs() const { calc_bound(); return free_defs_; } ///< All @em non-const @p Def%s @em directly referenced but @em not @p bound within this @p Scope. May also include @p Var%s or @em muts.
+    const VarSet& free_vars() const { calc_free (); return free_vars_; } ///< All @p Var%s that occurr free in this @p Scope. Does @em not transitively contain any free @p Var%s from @p muts.
+    const MutSet& free_muts() const { calc_free (); return free_muts_; } ///< All @em muts that occurr free in this @p Scope.
     // clang-format on
     ///@}
 
@@ -68,11 +68,11 @@ private:
     mutable DefSet bound_;
     mutable DefSet free_defs_;
     mutable VarSet free_vars_;
-    mutable NomSet free_noms_;
+    mutable MutSet free_muts_;
     mutable std::unique_ptr<const CFA> cfa_;
 };
 
-/// Does @p nom's Var occurr free in @p def?
-bool is_free(Def* nom, const Def* def);
+/// Does @p mut's Var occurr free in @p def?
+bool is_free(Def* mut, const Def* def);
 
 } // namespace thorin

--- a/thorin/axiom.cpp
+++ b/thorin/axiom.cpp
@@ -53,17 +53,16 @@ std::optional<plugin_t> Axiom::mangle(Sym s) {
 
         if (i < n) {
             auto c = s[i];
-            if (c == '_') {
+            if (c == '_')
                 u = 1;
-            } else if ('a' <= c && c <= 'z') {
+            else if ('a' <= c && c <= 'z')
                 u = c - 'a' + 2_u64;
-            } else if ('A' <= c && c <= 'Z') {
+            else if ('A' <= c && c <= 'Z')
                 u = c - 'A' + 28_u64;
-            } else if ('0' <= c && c <= '9') {
+            else if ('0' <= c && c <= '9')
                 u = c - '0' + 54_u64;
-            } else {
+            else
                 return {};
-            }
         }
 
         result = (result << 6_u64) | u;
@@ -76,17 +75,16 @@ Sym Axiom::demangle(World& world, plugin_t u) {
     std::string result;
     for (size_t i = 0; i != Max_Plugin_Size; ++i) {
         u64 c = (u & 0xfc00000000000000_u64) >> 58_u64;
-        if (c == 0) {
+        if (c == 0)
             return world.sym(result);
-        } else if (c == 1) {
+        else if (c == 1)
             result += '_';
-        } else if (2 <= c && c < 28) {
+        else if (2 <= c && c < 28)
             result += 'a' + ((char)c - 2);
-        } else if (28 <= c && c < 54) {
+        else if (28 <= c && c < 54)
             result += 'A' + ((char)c - 28);
-        } else {
+        else
             result += '0' + ((char)c - 54);
-        }
 
         u <<= 6_u64;
     }

--- a/thorin/axiom.cpp
+++ b/thorin/axiom.cpp
@@ -16,16 +16,16 @@ Axiom::Axiom(NormalizeFn normalizer, u8 curry, u8 trip, const Def* type, plugin_
 std::pair<u8, u8> Axiom::infer_curry_and_trip(const Def* type) {
     u8 curry = 0;
     u8 trip  = 0;
-    NomSet done;
+    MutSet done;
     while (auto pi = type->isa<Pi>()) {
-        if (auto nom = pi->isa_nom()) {
-            if (auto [_, ins] = done.emplace(nom); !ins) {
+        if (auto mut = pi->isa_mut()) {
+            if (auto [_, ins] = done.emplace(mut); !ins) {
                 // infer trip
                 auto curr = pi;
                 do {
                     ++trip;
                     curr = curr->codom()->as<Pi>();
-                } while (curr != nom);
+                } while (curr != mut);
                 break;
             }
         }

--- a/thorin/be/dot/dot.cpp
+++ b/thorin/be/dot/dot.cpp
@@ -57,7 +57,7 @@ static void emit_cluster_start(std::ostream& os, Lam* lam) {
 }
 
 static void emit_node_attributes(std::ostream& stream, const Def* def) {
-    if (def->isa<Var>()) { stream << ", color=blue"; }
+    if (def->isa<Var>()) stream << ", color=blue";
 }
 
 void Emitter::emit_imported(Lam* lam) {

--- a/thorin/be/dot/dot.cpp
+++ b/thorin/be/dot/dot.cpp
@@ -35,7 +35,7 @@ public:
 
 private:
     std::function<void(std::ostream&, const Def*)> stream_def_;
-    DefSet visited_noms_;
+    DefSet visited_muts_;
     std::ostringstream connections_;
 };
 
@@ -65,8 +65,8 @@ void Emitter::emit_imported(Lam* lam) {
 }
 
 void Emitter::emit_epilogue(Lam* lam) {
-    if (visited_noms_.contains(lam)) return;
-    visited_noms_.insert(lam);
+    if (visited_muts_.contains(lam)) return;
+    visited_muts_.insert(lam);
 
     if (lam != entry_) {
         emit_cluster_start(ostream_, lam);
@@ -96,7 +96,7 @@ std::string Emitter::emit_bb(BB&, const Def* def) {
 }
 
 std::string Emitter::prepare(const Scope& scope) {
-    auto lam = scope.entry()->as_nom<Lam>();
+    auto lam = scope.entry()->as_mut<Lam>();
 
     emit_cluster_start(ostream_, lam);
 

--- a/thorin/be/emitter.h
+++ b/thorin/be/emitter.h
@@ -59,9 +59,8 @@ protected:
         auto muts = schedule(scope); // TODO make sure to not compute twice
 
         // make sure that we don't need to rehash later on
-        for (auto mut : muts) {
+        for (auto mut : muts)
             if (auto lam = mut->isa<Lam>()) lam2bb_.emplace(lam, BB());
-        }
         auto old_size = lam2bb_.size();
 
         entry_ = scope.entry()->as_mut<Lam>();

--- a/thorin/be/emitter.h
+++ b/thorin/be/emitter.h
@@ -16,7 +16,7 @@ private:
     /// Internal wrapper for Emitter::emit that schedules @p def and invokes `child().emit_bb`.
     Value emit_(const Def* def) {
         auto place = scheduler_.smart(def);
-        auto& bb   = lam2bb_[place->as_nom<Lam>()];
+        auto& bb   = lam2bb_[place->as_mut<Lam>()];
         return child().emit_bb(bb, def);
     }
 
@@ -49,22 +49,22 @@ protected:
     }
 
     void visit(const Scope& scope) override {
-        if (entry_ = scope.entry()->isa_nom<Lam>(); !entry_) return;
+        if (entry_ = scope.entry()->isa_mut<Lam>(); !entry_) return;
 
         if (!entry_->is_set()) {
             child().emit_imported(entry_);
             return;
         }
 
-        auto noms = schedule(scope); // TODO make sure to not compute twice
+        auto muts = schedule(scope); // TODO make sure to not compute twice
 
         // make sure that we don't need to rehash later on
-        for (auto nom : noms) {
-            if (auto lam = nom->isa<Lam>()) lam2bb_.emplace(lam, BB());
+        for (auto mut : muts) {
+            if (auto lam = mut->isa<Lam>()) lam2bb_.emplace(lam, BB());
         }
         auto old_size = lam2bb_.size();
 
-        entry_ = scope.entry()->as_nom<Lam>();
+        entry_ = scope.entry()->as_mut<Lam>();
         assert(entry_->ret_var());
 
         auto fct = child().prepare(scope);
@@ -72,8 +72,8 @@ protected:
         Scheduler new_scheduler(scope);
         swap(scheduler_, new_scheduler);
 
-        for (auto nom : noms) {
-            if (auto lam = nom->isa<Lam>(); lam && lam != scope.exit()) {
+        for (auto mut : muts) {
+            if (auto lam = mut->isa<Lam>(); lam && lam != scope.exit()) {
                 assert(lam == entry_ || lam->is_basicblock());
                 child().emit_epilogue(lam);
             }

--- a/thorin/check.h
+++ b/thorin/check.h
@@ -7,7 +7,7 @@
 namespace thorin {
 
 /// This node is a hole in the IR that is inferred by its context later on.
-/// It is modelled as a *nom*inal Def.
+/// It is modelled as a *mut*able Def.
 /// If inference was successful, it's Infer::op will be set to the inferred Def.
 class Infer : public Def {
 private:

--- a/thorin/def.cpp
+++ b/thorin/def.cpp
@@ -289,20 +289,15 @@ bool Def::equal(const Def* other) const {
 }
 
 void Def::finalize() {
-    for (size_t i = 0, e = num_ops(); i != e; ++i) {
-        dep_ |= op(i)->dep();
-        if (!op(i)->dep_const()) {
-            const auto& p = op(i)->uses_.emplace(this, i);
-            assert_unused(p.second);
+    for (size_t i = Use::Type; auto op : partial_ops()) {
+        if (op) {
+            dep_ |= op->dep();
+            if (!op->dep_const()) {
+                const auto& p = op->uses_.emplace(this, i);
+                assert_unused(p.second);
+            }
         }
-    }
-
-    if (auto t = type()) {
-        dep_ |= t->dep();
-        if (!t->dep_const()) {
-            const auto& p = type()->uses_.emplace(this, Use::Type);
-            assert_unused(p.second);
-        }
+        ++i;
     }
 }
 

--- a/thorin/def.h
+++ b/thorin/def.h
@@ -197,7 +197,7 @@ private:
 protected:
     Def(World*, node_t, const Def* type, Defs ops, flags_t flags); ///< Constructor for an *imm*utable Def.
     Def(node_t n, const Def* type, Defs ops, flags_t flags);
-    Def(node_t, const Def* type, size_t num_ops, flags_t flags);   ///< Constructor for a *mut*able Def.
+    Def(node_t, const Def* type, size_t num_ops, flags_t flags); ///< Constructor for a *mut*able Def.
     virtual ~Def() = default;
 
 public:

--- a/thorin/def.h
+++ b/thorin/def.h
@@ -241,7 +241,7 @@ public:
     size_t num_ops() const { return num_ops_; }
     ///@}
 
-    /// @name set/unset ops (mutable only)
+    /// @name set/unset ops (mutables only)
     ///@{
     /// You are supposed to set operands from left to right.
     /// You can change operands later on or even Def::unset them.
@@ -417,7 +417,7 @@ public:
 
     /// @name var
     ///@{
-    /// Retrieve Var for *mutable*.
+    /// Retrieve Var for *mut*ables.
     const Var* var();
     THORIN_PROJ(var, )
     ///@}

--- a/thorin/dump.cpp
+++ b/thorin/dump.cpp
@@ -13,9 +13,9 @@ using namespace std::literals;
 // * Inline: These Defs are *always* displayed with all of its operands "inline".
 //   E.g.: (1, 2, 3).
 // * All other Defs are referenced by its name/unique_name (see id) when they appear as an operand.
-// * Nominals are either classifed as "decl" (see isa_decl).
+// * Mutables are either classifed as "decl" (see isa_decl).
 //   In this case, recursing through the Defs' operands stops and this particular Decl is dumped as its own thing.
-// * Or - if they are not a "decl" - they are basicallally handled like structurals.
+// * Or - if they are not a "decl" - they are basicallally handled like immutables.
 
 namespace thorin {
 
@@ -24,8 +24,8 @@ namespace thorin {
  */
 
 static Def* isa_decl(const Def* def) {
-    if (auto nom = def->isa_nom()) {
-        if (nom->is_external() || nom->isa<Lam>() || (nom->sym() && nom->sym() != '_')) return nom;
+    if (auto mut = def->isa_mut()) {
+        if (mut->is_external() || mut->isa<Lam>() || (mut->sym() && mut->sym() != '_')) return mut;
     }
     return nullptr;
 }
@@ -57,8 +57,8 @@ struct Inline {
     explicit operator bool() const {
         if (def_->dep_const()) return true;
 
-        if (auto nom = def_->isa_nom()) {
-            if (isa_decl(nom)) return false;
+        if (auto mut = def_->isa_mut()) {
+            if (isa_decl(mut)) return false;
             return true;
         }
 
@@ -135,18 +135,18 @@ std::ostream& operator<<(std::ostream& os, Inline u) {
         return print(os, "{}", var->unique_name());
     } else if (auto pi = u->isa<Pi>()) {
         if (pi->is_cn()) return print(os, ".Cn {}", pi->dom());
-        if (auto nom = pi->isa_nom<Pi>(); nom && nom->var())
-            return print(os, "Π {}: {} → {}", nom->var(), pi->dom(), pi->codom());
+        if (auto mut = pi->isa_mut<Pi>(); mut && mut->var())
+            return print(os, "Π {}: {} → {}", mut->var(), pi->dom(), pi->codom());
         return print(os, "Π {} → {}", pi->dom(), pi->codom());
     } else if (auto lam = u->isa<Lam>()) {
         return print(os, "{}, {}", lam->filter(), lam->body());
     } else if (auto app = u->isa<App>()) {
         return print(os, "{} {}", LPrec(app->callee(), app), RPrec(app, app->arg()));
     } else if (auto sigma = u->isa<Sigma>()) {
-        if (auto nom = sigma->isa_nom<Sigma>(); nom && nom->var()) {
+        if (auto mut = sigma->isa_mut<Sigma>(); mut && mut->var()) {
             size_t i = 0;
             return print(os, "[{, }]", Elem(sigma->ops(), [&](auto op) {
-                             if (auto v = nom->var(i++))
+                             if (auto v = mut->var(i++))
                                  print(os, "{}: {}", v, op);
                              else
                                  os << op;
@@ -155,20 +155,20 @@ std::ostream& operator<<(std::ostream& os, Inline u) {
         return print(os, "[{, }]", sigma->ops());
     } else if (auto tuple = u->isa<Tuple>()) {
         print(os, "({, })", tuple->ops());
-        return tuple->type()->isa_nom() ? print(os, ":{}", tuple->type()) : os;
+        return tuple->type()->isa_mut() ? print(os, ":{}", tuple->type()) : os;
     } else if (auto arr = u->isa<Arr>()) {
-        if (auto nom = arr->isa_nom<Arr>(); nom && nom->var())
-            return print(os, "«{}: {}; {}»", nom->var(), nom->shape(), nom->body());
+        if (auto mut = arr->isa_mut<Arr>(); mut && mut->var())
+            return print(os, "«{}: {}; {}»", mut->var(), mut->shape(), mut->body());
         return print(os, "«{}; {}»", arr->shape(), arr->body());
     } else if (auto pack = u->isa<Pack>()) {
-        if (auto nom = pack->isa_nom<Pack>(); nom && nom->var())
-            return print(os, "‹{}: {}; {}›", nom->var(), nom->shape(), nom->body());
+        if (auto mut = pack->isa_mut<Pack>(); mut && mut->var())
+            return print(os, "‹{}: {}; {}›", mut->var(), mut->shape(), mut->body());
         return print(os, "‹{}; {}›", pack->shape(), pack->body());
     } else if (auto proxy = u->isa<Proxy>()) {
         return print(os, ".proxy#{}#{} {, }", proxy->pass(), proxy->tag(), proxy->ops());
     } else if (auto bound = u->isa<Bound>()) {
         auto op = bound->isa<Join>() ? "∪" : "∩";
-        if (auto nom = u->isa_nom()) print(os, "{}{}: {}", op, nom->unique_name(), nom->type());
+        if (auto mut = u->isa_mut()) print(os, "{}{}: {}", op, mut->unique_name(), mut->type());
         return print(os, "{}({, })", op, bound->ops());
     }
 
@@ -184,7 +184,7 @@ std::ostream& operator<<(std::ostream& os, Inline u) {
 /// This thing operates in two modes:
 /// 1. The output of decls is driven by the DepTree.
 /// 2. Alternatively, decls are output as soon as they appear somewhere during recurse%ing.
-///     Then, they are pushed to Dumper::noms.
+///     Then, they are pushed to Dumper::muts.
 class Dumper {
 public:
     Dumper(std::ostream& os, const DepTree* dep = nullptr)
@@ -201,17 +201,17 @@ public:
     std::ostream& os;
     const DepTree* dep;
     Tab tab;
-    unique_queue<NomSet> noms;
+    unique_queue<MutSet> muts;
     DefSet defs;
 };
 
-void Dumper::dump(Def* nom) {
-    if (auto lam = nom->isa<Lam>()) {
+void Dumper::dump(Def* mut) {
+    if (auto lam = mut->isa<Lam>()) {
         dump(lam);
         return;
     }
 
-    auto nom_prefix = [&](const Def* def) {
+    auto mut_prefix = [&](const Def* def) {
         if (def->isa<Sigma>()) return ".Sigma";
         if (def->isa<Arr>()) return ".Arr";
         if (def->isa<Pack>()) return ".pack";
@@ -219,7 +219,7 @@ void Dumper::dump(Def* nom) {
         unreachable();
     };
 
-    auto nom_op0 = [&](const Def* def) -> std::ostream& {
+    auto mut_op0 = [&](const Def* def) -> std::ostream& {
         if (auto sig = def->isa<Sigma>()) return print(os, ", {}", sig->num_ops());
         if (auto arr = def->isa<Arr>()) return print(os, ", {}", arr->shape());
         if (auto pack = def->isa<Pack>()) return print(os, ", {}", pack->shape());
@@ -227,30 +227,30 @@ void Dumper::dump(Def* nom) {
         unreachable();
     };
 
-    if (!nom->is_set()) {
-        tab.print(os, "{}: {} = {{ <unset> }};", id(nom), nom->type());
+    if (!mut->is_set()) {
+        tab.print(os, "{}: {} = {{ <unset> }};", id(mut), mut->type());
         return;
     }
 
-    tab.print(os, "{} {}{}: {}", nom_prefix(nom), external(nom), id(nom), nom->type());
-    nom_op0(nom);
-    if (nom->var()) { // TODO rewrite with dedicated methods
-        if (auto e = nom->num_vars(); e != 1) {
-            print(os, "{, }", Elem(nom->vars(), [&](auto def) {
+    tab.print(os, "{} {}{}: {}", mut_prefix(mut), external(mut), id(mut), mut->type());
+    mut_op0(mut);
+    if (mut->var()) { // TODO rewrite with dedicated methods
+        if (auto e = mut->num_vars(); e != 1) {
+            print(os, "{, }", Elem(mut->vars(), [&](auto def) {
                       if (def)
                           os << def->unique_name();
                       else
                           os << "<TODO>";
                   }));
         } else {
-            print(os, ", @{}", nom->var()->unique_name());
+            print(os, ", @{}", mut->var()->unique_name());
         }
     }
     tab.println(os, " = {{");
     ++tab;
-    if (dep) recurse(dep->nom2node(nom));
-    recurse(nom);
-    tab.print(os, "{, }\n", nom->ops());
+    if (dep) recurse(dep->mut2node(mut));
+    recurse(mut);
+    tab.print(os, "{, }\n", mut->ops());
     --tab;
     tab.print(os, "}};\n");
 }
@@ -266,10 +266,10 @@ void Dumper::dump(Lam* lam) {
 
     ++tab;
     if (lam->is_set()) {
-        if (dep) recurse(dep->nom2node(lam));
+        if (dep) recurse(dep->mut2node(lam));
         recurse(lam->filter());
         recurse(lam->body(), true);
-        if (lam->body()->isa_nom())
+        if (lam->body()->isa_mut())
             tab.print(os, "{}\n", lam->body());
         else
             tab.print(os, "{}\n", Inline(lam->body()));
@@ -301,12 +301,12 @@ void Dumper::dump_ptrn(const Def* def, const Def* type) {
 
 void Dumper::recurse(const DepNode* node) {
     for (auto child : node->children())
-        if (auto nom = isa_decl(child->nom())) dump(nom);
+        if (auto mut = isa_decl(child->mut())) dump(mut);
 }
 
 void Dumper::recurse(const Def* def, bool first /*= false*/) {
-    if (auto nom = isa_decl(def)) {
-        if (!dep) noms.push(nom);
+    if (auto mut = isa_decl(def)) {
+        if (!dep) muts.push(mut);
         return;
     }
 
@@ -340,15 +340,15 @@ std::ostream& Def::stream(std::ostream& os, int max) const {
 
     if (max == 0) {
         os << this << std::endl;
-    } else if (auto nom = isa_decl(this)) {
-        dumper.noms.push(nom);
+    } else if (auto mut = isa_decl(this)) {
+        dumper.muts.push(mut);
     } else {
         dumper.recurse(this);
         dumper.tab.print(os, "{}\n", Inline(this));
         --max;
     }
 
-    for (; !dumper.noms.empty() && max > 0; --max) dumper.dump(dumper.noms.pop());
+    for (; !dumper.muts.empty() && max > 0; --max) dumper.dump(dumper.muts.pop());
 
     return os;
 }
@@ -376,8 +376,8 @@ void World::dump(std::ostream& os) {
 
     if (flags().dump_recursive) {
         auto dumper = Dumper(os);
-        for (const auto& [_, nom] : externals()) dumper.noms.push(nom);
-        while (!dumper.noms.empty()) dumper.dump(dumper.noms.pop());
+        for (const auto& [_, mut] : externals()) dumper.muts.push(mut);
+        while (!dumper.muts.empty()) dumper.dump(dumper.muts.pop());
     } else {
         auto dep    = DepTree(*this);
         auto dumper = Dumper(os, &dep);

--- a/thorin/dump.cpp
+++ b/thorin/dump.cpp
@@ -312,7 +312,7 @@ void Dumper::recurse(const Def* def, bool first /*= false*/) {
 
     if (!defs.emplace(def).second) return;
 
-    for (auto op : def->partial_ops().skip_front()) { // ignore dbg
+    for (auto op : def->partial_ops()) {
         if (!op) continue;
         recurse(op);
     }

--- a/thorin/fe/ast.cpp
+++ b/thorin/fe/ast.cpp
@@ -29,7 +29,7 @@ void TuplePtrn::bind(Scopes& scopes, const Def* def) const {
 
 const Def* IdPtrn::type(World& world, Def2Fields&) const {
     if (type_) return type_;
-    return type_ = world.nom_infer_type()->set(loc());
+    return type_ = world.mut_infer_type()->set(loc());
 }
 
 const Def* TuplePtrn::type(World& world, Def2Fields& def2fields) const {
@@ -44,7 +44,7 @@ const Def* TuplePtrn::type(World& world, Def2Fields& def2fields) const {
     assert(ptrns().size() > 0);
 
     auto type  = world.umax<Sort::Type>(ops);
-    auto sigma = world.nom_sigma(type, n)->set(loc(), sym());
+    auto sigma = world.mut_sigma(type, n)->set(loc(), sym());
     assert_emplace(def2fields, sigma, Array<Sym>(n, [&](size_t i) { return ptrn(i)->sym(); }));
 
     sigma->set(0, ops[0]);

--- a/thorin/fe/parser.cpp
+++ b/thorin/fe/parser.cpp
@@ -82,8 +82,7 @@ void Parser::import(fs::path name, std::ostream* md) {
     world().VLOG("import: {}", name);
     auto filename = name;
 
-    if (!filename.has_extension())
-        filename.replace_extension("thorin"); // TODO error cases
+    if (!filename.has_extension()) filename.replace_extension("thorin"); // TODO error cases
 
     fs::path rel_path;
     for (const auto& path : driver().search_paths()) {

--- a/thorin/fe/parser.cpp
+++ b/thorin/fe/parser.cpp
@@ -191,7 +191,7 @@ Ref Parser::parse_extract(Tracker track, const Def* lhs, Tok::Prec p) {
     lex();
 
     if (ahead().isa(Tok::Tag::M_id)) {
-        if (auto sigma = lhs->type()->isa_nom<Sigma>()) {
+        if (auto sigma = lhs->type()->isa_mut<Sigma>()) {
             auto tok = eat(Tok::Tag::M_id);
             if (tok.sym() == '_') err(tok.loc(), "you cannot use special symbol '_' as field access");
 
@@ -274,9 +274,9 @@ Ref Parser::parse_Cn() {
 Ref Parser::parse_var() {
     eat(Tok::Tag::T_at);
     auto dbg = parse_sym("variable");
-    auto nom = scopes_.find(dbg)->isa_nom();
-    if (!nom) err(prev(), "variable must reference a nominal");
-    return nom->var()->set(dbg);
+    auto mut = scopes_.find(dbg)->isa_mut();
+    if (!mut) err(prev(), "variable must reference a mutable");
+    return mut->var()->set(dbg);
 }
 
 Ref Parser::parse_arr() {
@@ -291,8 +291,8 @@ Ref Parser::parse_arr() {
         eat(Tok::Tag::T_colon);
 
         auto shape = parse_expr("shape of an array");
-        auto type  = world().nom_infer_univ();
-        arr        = world().nom_arr(type)->set_shape(shape);
+        auto type  = world().mut_infer_univ();
+        arr        = world().mut_arr(type)->set_shape(shape);
         scopes_.bind(id.dbg(), arr->var()->set(id.dbg()));
     } else {
         shape = parse_expr("shape of an array");
@@ -314,13 +314,13 @@ Ref Parser::parse_pack() {
     eat(Tok::Tag::D_angle_l);
 
     const Def* shape;
-    // bool nom = false;
+    // bool mut = false;
     if (ahead(0).isa(Tok::Tag::M_id) && ahead(1).isa(Tok::Tag::T_colon)) {
         auto id = eat(Tok::Tag::M_id);
         eat(Tok::Tag::T_colon);
 
         shape      = parse_expr("shape of a pack");
-        auto infer = world().nom_infer(world().type_idx(shape))->set(id.sym());
+        auto infer = world().mut_infer(world().type_idx(shape))->set(id.sym());
         scopes_.bind(id.dbg(), infer);
     } else {
         shape = parse_expr("shape of a pack");
@@ -373,7 +373,7 @@ Ref Parser::parse_pi() {
     do {
         auto implicit = accept(Tok::Tag::T_dot).has_value();
         auto dom      = parse_ptrn(Tok::Tag::D_brckt_l, "domain of a dependent function type", Tok::Prec::App);
-        auto pi       = world().nom_pi(world().type_infer_univ(), implicit)->set_dom(dom->type(world(), def2fields_));
+        auto pi       = world().mut_pi(world().type_infer_univ(), implicit)->set_dom(dom->type(world(), def2fields_));
         auto var      = pi->var()->set(dom->sym());
         first         = first ? first : pi;
         pi->set(dom->dbg());
@@ -532,7 +532,7 @@ std::unique_ptr<TuplePtrn> Parser::parse_tuple_ptrn(Tracker track, bool rebind, 
             auto type = parse_expr("type of an identifier group within a tuple pattern");
 
             for (auto tok : sym_toks) {
-                infers.emplace_back(world().nom_infer(type)->set(tok.dbg()));
+                infers.emplace_back(world().mut_infer(type)->set(tok.dbg()));
                 ops.emplace_back(type);
                 ptrns.emplace_back(std::make_unique<IdPtrn>(tok.dbg(), false, type));
             }
@@ -548,7 +548,7 @@ std::unique_ptr<TuplePtrn> Parser::parse_tuple_ptrn(Tracker track, bool rebind, 
                 }
             }
 
-            infers.emplace_back(world().nom_infer(type)->set(ptrn->sym()));
+            infers.emplace_back(world().mut_infer(type)->set(ptrn->sym()));
             ops.emplace_back(type);
             ptrns.emplace_back(std::move(ptrn));
         }
@@ -573,7 +573,7 @@ Ref Parser::parse_decls(std::string_view ctxt) {
             case Tok::Tag::K_Sigma:
             case Tok::Tag::K_Arr:
             case Tok::Tag::K_pack:
-            case Tok::Tag::K_Pi:        parse_nom();     break;
+            case Tok::Tag::K_Pi:        parse_mut();     break;
             case Tok::Tag::K_con:
             case Tok::Tag::K_fun:
             case Tok::Tag::K_lam:       parse_lam(true); break;
@@ -670,46 +670,46 @@ void Parser::parse_let() {
     expect(Tok::Tag::T_semicolon, "let expression");
 }
 
-void Parser::parse_nom() {
+void Parser::parse_mut() {
     auto track    = tracker();
     auto tag      = lex().tag();
     bool external = accept(Tok::Tag::K_extern).has_value();
-    auto dbg      = parse_sym("nominal");
-    auto type     = accept(Tok::Tag::T_colon) ? parse_expr("type of a nominal") : world().type();
+    auto dbg      = parse_sym("mutable");
+    auto type     = accept(Tok::Tag::T_colon) ? parse_expr("type of a mutable") : world().type();
 
-    Def* nom;
+    Def* mut;
     switch (tag) {
         case Tok::Tag::K_Sigma: {
-            expect(Tok::Tag::T_comma, "nominal Sigma");
-            auto arity = expect(Tok::Tag::L_u, "arity of a nominal Sigma");
-            nom        = world().nom_sigma(type, arity.u())->set(dbg);
+            expect(Tok::Tag::T_comma, "mutable Sigma");
+            auto arity = expect(Tok::Tag::L_u, "arity of a mutable Sigma");
+            mut        = world().mut_sigma(type, arity.u())->set(dbg);
             break;
         }
         case Tok::Tag::K_Arr: {
-            expect(Tok::Tag::T_comma, "nominal array");
-            auto shape = parse_expr("shape of a nominal array");
-            nom        = world().nom_arr(type)->set(track.loc())->set_shape(shape);
+            expect(Tok::Tag::T_comma, "mutable array");
+            auto shape = parse_expr("shape of a mutable array");
+            mut        = world().mut_arr(type)->set(track.loc())->set_shape(shape);
             break;
         }
-        case Tok::Tag::K_pack: nom = world().nom_pack(type)->set(dbg); break;
+        case Tok::Tag::K_pack: mut = world().mut_pack(type)->set(dbg); break;
         case Tok::Tag::K_Pi: {
-            expect(Tok::Tag::T_comma, "nominal Pi");
-            auto dom = parse_expr("domain of a nominal Pi");
-            nom      = world().nom_pi(type)->set(dbg)->set_dom(dom);
+            expect(Tok::Tag::T_comma, "mutable Pi");
+            auto dom = parse_expr("domain of a mutable Pi");
+            mut      = world().mut_pi(type)->set(dbg)->set_dom(dom);
             break;
         }
         default: unreachable();
     }
-    scopes_.bind(dbg, nom);
+    scopes_.bind(dbg, mut);
 
     scopes_.push();
-    if (external) nom->make_external();
+    if (external) mut->make_external();
 
     scopes_.push();
     if (ahead().isa(Tok::Tag::T_assign))
         parse_def(dbg);
     else
-        expect(Tok::Tag::T_semicolon, "end of a nominal");
+        expect(Tok::Tag::T_semicolon, "end of a mutable");
 
     scopes_.pop();
     scopes_.pop();
@@ -722,7 +722,7 @@ Lam* Parser::parse_lam(bool decl) {
     bool is_cn    = tok.isa(Tok::Tag::K_cn) || tok.isa(Tok::Tag::K_con);
     auto prec     = is_cn ? Tok::Prec::Bot : Tok::Prec::Pi;
     bool external = decl && accept(Tok::Tag::K_extern).has_value();
-    auto dbg      = decl ? parse_sym("nominal lambda") : Dbg{prev(), anonymous_};
+    auto dbg      = decl ? parse_sym("mutable lambda") : Dbg{prev(), anonymous_};
 
     auto outer = scopes_.curr();
     scopes_.push();
@@ -734,8 +734,8 @@ Lam* Parser::parse_lam(bool decl) {
         bool implicit     = accept(Tok::Tag::T_dot).has_value();
         auto dom_p        = parse_ptrn(Tok::Tag::D_paren_l, "domain pattern of a lambda", prec);
         auto dom_t        = dom_p->type(world(), def2fields_);
-        auto pi           = world().nom_pi(world().type_infer_univ(), implicit)->set_dom(dom_t);
-        auto lam          = world().nom_lam(pi);
+        auto pi           = world().mut_pi(world().type_infer_univ(), implicit)->set_dom(dom_t);
+        auto lam          = world().mut_lam(pi);
         auto lam_var      = lam->var()->set(dom_p->loc(), dom_p->sym());
 
         if (first == nullptr) {
@@ -763,7 +763,7 @@ Lam* Parser::parse_lam(bool decl) {
 
     auto codom = is_cn                     ? world().type_bot()
                : accept(Tok::Tag::T_arrow) ? parse_expr("return type of a lambda", Tok::Prec::Arrow)
-                                           : world().nom_infer_type();
+                                           : world().mut_infer_type();
     for (auto [pi, lam] : funs | std::ranges::views::reverse) {
         // First, connect old codom to lam. Otherwise, scope will not find it.
         pi->set_codom(codom);
@@ -803,29 +803,29 @@ Lam* Parser::parse_lam(bool decl) {
 void Parser::parse_def(Dbg dbg /*= {}*/) {
     if (!dbg.sym) {
         eat(Tok::Tag::K_def);
-        dbg = parse_sym("nominal definition");
+        dbg = parse_sym("mutable definition");
     }
 
-    auto nom = scopes_.find(dbg)->as_nom();
-    expect(Tok::Tag::T_assign, "nominal definition");
+    auto mut = scopes_.find(dbg)->as_mut();
+    expect(Tok::Tag::T_assign, "mutable definition");
 
-    size_t i = nom->first_dependend_op();
-    size_t n = nom->num_ops();
+    size_t i = mut->first_dependend_op();
+    size_t n = mut->num_ops();
 
     if (ahead().isa(Tok::Tag::D_brace_l)) {
         scopes_.push();
-        parse_list("nominal definition", Tok::Tag::D_brace_l, [&]() {
+        parse_list("mutable definition", Tok::Tag::D_brace_l, [&]() {
             if (i == n) err(prev(), "too many operands");
-            nom->set(i++, parse_decls("operand of a nominal"));
+            mut->set(i++, parse_decls("operand of a mutable"));
         });
         scopes_.pop();
     } else if (n - i == 1) {
-        nom->set(i, parse_decls("operand of a nominal"));
+        mut->set(i, parse_decls("operand of a mutable"));
     } else {
-        err(prev(), "expected operands for nominal definition");
+        err(prev(), "expected operands for mutable definition");
     }
 
-    expect(Tok::Tag::T_semicolon, "end of a nominal definition");
+    expect(Tok::Tag::T_semicolon, "end of a mutable definition");
 }
 
 } // namespace thorin::fe

--- a/thorin/fe/parser.h
+++ b/thorin/fe/parser.h
@@ -147,7 +147,7 @@ private:
     Ref parse_decls(std::string_view ctxt);
     void parse_ax();
     void parse_let();
-    void parse_nom();
+    void parse_mut();
     /// If @p sym is **not** empty, this is an inline definition of @p sym,
     /// otherwise it's a standalone definition.
     void parse_def(Dbg dbg = {});

--- a/thorin/lam.cpp
+++ b/thorin/lam.cpp
@@ -36,7 +36,7 @@ Lam* Lam::set_filter(Filter filter) {
 }
 
 Lam* Lam::app(Filter f, const Def* callee, const Def* arg) {
-    assert(isa_nom() && !filter());
+    assert(isa_mut() && !filter());
     set_filter(f);
     return set_body(world().app(callee, arg));
 }

--- a/thorin/lam.cpp
+++ b/thorin/lam.cpp
@@ -41,20 +41,13 @@ Lam* Lam::app(Filter f, const Def* callee, const Def* arg) {
     return set_body(world().app(callee, arg));
 }
 
-Lam* Lam::app(Filter filter, const Def* callee, Defs args) {
-    return app(filter, callee, world().tuple(args));
-}
+Lam* Lam::app(Filter filter, const Def* callee, Defs args) { return app(filter, callee, world().tuple(args)); }
 
 Lam* Lam::branch(Filter filter, const Def* cond, const Def* t, const Def* f, const Def* mem) {
     return app(filter, world().select(t, f, cond), mem);
 }
 
-Lam* Lam::test(Filter filter,
-               const Def* value,
-               const Def* index,
-               const Def* match,
-               const Def* clash,
-               const Def* mem) {
+Lam* Lam::test(Filter filter, const Def* value, const Def* index, const Def* match, const Def* clash, const Def* mem) {
     return app(filter, world().test(value, index, match, clash), mem);
 }
 

--- a/thorin/lam.h
+++ b/thorin/lam.h
@@ -9,10 +9,10 @@ namespace thorin {
 /// A function type AKA Pi type.
 class Pi : public Def {
 protected:
-    /// Constructor for a *structural* Pi.
+    /// Constructor for an *immutable* Pi.
     Pi(const Def* type, const Def* dom, const Def* codom, bool implicit)
         : Def(Node, type, {dom, codom}, implicit ? 1 : 0) {}
-    /// Constructor for a *nom*inal Pi.
+    /// Constructor for a *mut*able Pi.
     Pi(const Def* type, bool implicit)
         : Def(Node, type, 2, implicit ? 1 : 0) {}
 
@@ -155,8 +155,8 @@ inline Lam* isa_workable(Lam* lam) {
 }
 
 inline const App* isa_callee(const Def* def, size_t i) { return i == 0 ? def->isa<App>() : nullptr; }
-inline std::pair<const App*, Lam*> isa_apped_nom_lam(const Def* def) {
-    if (auto app = def->isa<App>()) return {app, app->callee()->isa_nom<Lam>()};
+inline std::pair<const App*, Lam*> isa_apped_mut_lam(const Def* def) {
+    if (auto app = def->isa<App>()) return {app, app->callee()->isa_mut<Lam>()};
     return {nullptr, nullptr};
 }
 

--- a/thorin/lattice.cpp
+++ b/thorin/lattice.cpp
@@ -8,7 +8,7 @@
 namespace thorin {
 
 size_t Bound::find(const Def* type) const {
-    auto i = isa_nom() ? std::find(ops().begin(), ops().end(), type)
+    auto i = isa_mut() ? std::find(ops().begin(), ops().end(), type)
                        : binary_find(ops().begin(), ops().end(), type, GIDLt<const Def*>());
     return i == ops().end() ? size_t(-1) : i - ops().begin();
 }

--- a/thorin/lattice.h
+++ b/thorin/lattice.h
@@ -10,12 +10,10 @@ class Sigma;
 /// Common base for TBound.
 class Bound : public Def {
 protected:
-    /// Constructor for a *structural* Bound.
     Bound(node_t node, const Def* type, Defs ops)
-        : Def(node, type, ops, 0) {}
-    /// Constructor for a *nom*inal Bound.
+        : Def(node, type, ops, 0) {}  ///< Constructor for an *imm*utable Bound.
     Bound(node_t node, const Def* type, size_t size)
-        : Def(node, type, size, 0) {}
+        : Def(node, type, size, 0) {} ///< Constructor for a *mut*able Bound.
 
 public:
     size_t find(const Def* type) const;
@@ -30,12 +28,10 @@ public:
 template<bool Up>
 class TBound : public Bound {
 private:
-    /// Constructor for a *structural* Bound.
     TBound(const Def* type, Defs ops)
-        : Bound(Node, type, ops) {}
-    /// Constructor for a *nom*inal Bound.
+        : Bound(Node, type, ops) {}  ///< Constructor for an *imm*utable Bound.
     TBound(const Def* type, size_t size)
-        : Bound(Node, type, size) {}
+        : Bound(Node, type, size) {} ///< Constructor for a *mut*able Bound.
 
     THORIN_SETTERS(TBound)
     TBound* stub(World& w, const Def* type) { return stub_(w, type)->set(dbg())->template as<TBound>(); }

--- a/thorin/lattice.h
+++ b/thorin/lattice.h
@@ -11,7 +11,7 @@ class Sigma;
 class Bound : public Def {
 protected:
     Bound(node_t node, const Def* type, Defs ops)
-        : Def(node, type, ops, 0) {}  ///< Constructor for an *imm*utable Bound.
+        : Def(node, type, ops, 0) {} ///< Constructor for an *imm*utable Bound.
     Bound(node_t node, const Def* type, size_t size)
         : Def(node, type, size, 0) {} ///< Constructor for a *mut*able Bound.
 
@@ -29,7 +29,7 @@ template<bool Up>
 class TBound : public Bound {
 private:
     TBound(const Def* type, Defs ops)
-        : Bound(Node, type, ops) {}  ///< Constructor for an *imm*utable Bound.
+        : Bound(Node, type, ops) {} ///< Constructor for an *imm*utable Bound.
     TBound(const Def* type, size_t size)
         : Bound(Node, type, size) {} ///< Constructor for a *mut*able Bound.
 

--- a/thorin/pass/fp/beta_red.cpp
+++ b/thorin/pass/fp/beta_red.cpp
@@ -4,7 +4,7 @@
 
 namespace thorin {
 
-const Def* BetaRed::rewrite(const Def* def) {
+Ref BetaRed::rewrite(Ref def) {
     if (auto [app, lam] = isa_apped_mut_lam(def); isa_workable(lam) && !keep_.contains(lam)) {
         if (auto [_, ins] = data().emplace(lam); ins) {
             world().DLOG("beta-reduction {}", lam);
@@ -27,7 +27,7 @@ undo_t BetaRed::analyze(const Proxy* proxy) {
     return No_Undo;
 }
 
-undo_t BetaRed::analyze(const Def* def) {
+undo_t BetaRed::analyze(Ref def) {
     auto undo = No_Undo;
     for (auto op : def->ops()) {
         if (auto lam = isa_workable(op->isa_mut<Lam>()); lam && keep_.emplace(lam).second) {

--- a/thorin/pass/fp/beta_red.cpp
+++ b/thorin/pass/fp/beta_red.cpp
@@ -5,7 +5,7 @@
 namespace thorin {
 
 const Def* BetaRed::rewrite(const Def* def) {
-    if (auto [app, lam] = isa_apped_nom_lam(def); isa_workable(lam) && !keep_.contains(lam)) {
+    if (auto [app, lam] = isa_apped_mut_lam(def); isa_workable(lam) && !keep_.contains(lam)) {
         if (auto [_, ins] = data().emplace(lam); ins) {
             world().DLOG("beta-reduction {}", lam);
             return lam->reduce(app->arg()).back();
@@ -18,9 +18,9 @@ const Def* BetaRed::rewrite(const Def* def) {
 }
 
 undo_t BetaRed::analyze(const Proxy* proxy) {
-    auto lam = proxy->op(0)->as_nom<Lam>();
+    auto lam = proxy->op(0)->as_mut<Lam>();
     if (keep_.emplace(lam).second) {
-        world().DLOG("found proxy app of '{}' within '{}'", lam, curr_nom());
+        world().DLOG("found proxy app of '{}' within '{}'", lam, curr_mut());
         return undo_visit(lam);
     }
 
@@ -30,10 +30,10 @@ undo_t BetaRed::analyze(const Proxy* proxy) {
 undo_t BetaRed::analyze(const Def* def) {
     auto undo = No_Undo;
     for (auto op : def->ops()) {
-        if (auto lam = isa_workable(op->isa_nom<Lam>()); lam && keep_.emplace(lam).second) {
+        if (auto lam = isa_workable(op->isa_mut<Lam>()); lam && keep_.emplace(lam).second) {
             auto [_, ins] = data().emplace(lam);
             if (!ins) {
-                world().DLOG("non-callee-position of '{}'; undo inlining of {} within {}", lam, lam, curr_nom());
+                world().DLOG("non-callee-position of '{}'; undo inlining of {} within {}", lam, lam, curr_mut());
                 undo = std::min(undo, undo_visit(lam));
             }
         }

--- a/thorin/pass/fp/beta_red.h
+++ b/thorin/pass/fp/beta_red.h
@@ -16,9 +16,9 @@ public:
     void keep(Lam* lam) { keep_.emplace(lam); }
 
 private:
-    const Def* rewrite(const Def*) override;
+    Ref rewrite(Ref) override;
     undo_t analyze(const Proxy*) override;
-    undo_t analyze(const Def*) override;
+    undo_t analyze(Ref) override;
 
     LamSet keep_;
 };

--- a/thorin/pass/fp/eta_exp.cpp
+++ b/thorin/pass/fp/eta_exp.cpp
@@ -24,7 +24,7 @@ const Def* EtaExp::rewrite(const Def* def) {
     auto& [_, new_ops] = *def2new_ops_.emplace(def, def->ops()).first;
 
     for (size_t i = 0, e = def->num_ops(); i != e; ++i) {
-        if (auto lam = def->op(i)->isa_nom<Lam>(); lam && lam->is_set()) {
+        if (auto lam = def->op(i)->isa_mut<Lam>(); lam && lam->is_set()) {
             if (isa_callee(def, i)) {
                 if (auto orig = lookup(exp2orig_, lam)) new_ops[i] = orig;
             } else if (expand_.contains(lam)) {
@@ -50,7 +50,7 @@ Lam* EtaExp::eta_exp(Lam* lam) {
 
 undo_t EtaExp::analyze(const Proxy* proxy) {
     world().DLOG("found proxy: {}", proxy);
-    auto lam = proxy->op(0)->as_nom<Lam>();
+    auto lam = proxy->op(0)->as_mut<Lam>();
     if (expand_.emplace(lam).second) return undo_visit(lam);
     return No_Undo;
 }
@@ -58,7 +58,7 @@ undo_t EtaExp::analyze(const Proxy* proxy) {
 undo_t EtaExp::analyze(const Def* def) {
     auto undo = No_Undo;
     for (size_t i = 0, e = def->num_ops(); i != e; ++i) {
-        if (auto lam = def->op(i)->isa_nom<Lam>(); lam && lam->is_set()) {
+        if (auto lam = def->op(i)->isa_mut<Lam>(); lam && lam->is_set()) {
             lam = new2old(lam);
             if (expand_.contains(lam) || exp2orig_.contains(lam)) continue;
 

--- a/thorin/pass/fp/eta_exp.cpp
+++ b/thorin/pass/fp/eta_exp.cpp
@@ -17,8 +17,8 @@ Lam* EtaExp::new2old(Lam* new_lam) {
     return new_lam;
 }
 
-const Def* EtaExp::rewrite(const Def* def) {
-    if (std::ranges::none_of(def->ops(), [](const Def* def) { return def->isa<Lam>(); })) return def;
+Ref EtaExp::rewrite(Ref def) {
+    if (std::ranges::none_of(def->ops(), [](Ref def) { return def->isa<Lam>(); })) return def;
     if (auto n = lookup(old2new(), def)) return n;
 
     auto& [_, new_ops] = *def2new_ops_.emplace(def, def->ops()).first;
@@ -55,7 +55,7 @@ undo_t EtaExp::analyze(const Proxy* proxy) {
     return No_Undo;
 }
 
-undo_t EtaExp::analyze(const Def* def) {
+undo_t EtaExp::analyze(Ref def) {
     auto undo = No_Undo;
     for (size_t i = 0, e = def->num_ops(); i != e; ++i) {
         if (auto lam = def->op(i)->isa_mut<Lam>(); lam && lam->is_set()) {

--- a/thorin/pass/fp/eta_exp.h
+++ b/thorin/pass/fp/eta_exp.h
@@ -48,9 +48,9 @@ public:
 private:
     /// @name PassMan hooks
     ///@{
-    const Def* rewrite(const Def*) override;
+    Ref rewrite(Ref) override;
     undo_t analyze(const Proxy*) override;
-    undo_t analyze(const Def*) override;
+    undo_t analyze(Ref) override;
     ///@}
     Lam* eta_exp(Lam*); ///< Helper that peforms the actual η-expansion.
 

--- a/thorin/pass/fp/eta_red.cpp
+++ b/thorin/pass/fp/eta_red.cpp
@@ -2,7 +2,7 @@
 
 namespace thorin {
 
-static bool is_var(const Def* def) {
+static bool is_var(Ref def) {
     if (def->isa<Var>()) return true;
     if (auto extract = def->isa<Extract>()) return extract->tuple()->isa<Var>();
     return false;
@@ -16,7 +16,7 @@ static const App* eta_rule(Lam* lam) {
     return nullptr;
 }
 
-const Def* EtaRed::rewrite(const Def* def) {
+Ref EtaRed::rewrite(Ref def) {
     for (size_t i = 0, e = def->num_ops(); i != e; ++i) {
         // TODO (ClosureConv): Factor this out
         if (auto lam = def->op(i)->isa_mut<Lam>(); (!callee_only_ || isa_callee(def, i)) && lam && lam->is_set()) {

--- a/thorin/pass/fp/eta_red.cpp
+++ b/thorin/pass/fp/eta_red.cpp
@@ -19,7 +19,7 @@ static const App* eta_rule(Lam* lam) {
 const Def* EtaRed::rewrite(const Def* def) {
     for (size_t i = 0, e = def->num_ops(); i != e; ++i) {
         // TODO (ClosureConv): Factor this out
-        if (auto lam = def->op(i)->isa_nom<Lam>(); (!callee_only_ || isa_callee(def, i)) && lam && lam->is_set()) {
+        if (auto lam = def->op(i)->isa_mut<Lam>(); (!callee_only_ || isa_callee(def, i)) && lam && lam->is_set()) {
             if (auto app = eta_rule(lam); app && !irreducible_.contains(lam)) {
                 data().emplace(lam, Lattice::Reduce);
                 auto new_def = def->refine(i, app->callee());
@@ -33,7 +33,7 @@ const Def* EtaRed::rewrite(const Def* def) {
 }
 
 undo_t EtaRed::analyze(const Var* var) {
-    if (auto lam = var->nom()->isa_nom<Lam>()) {
+    if (auto lam = var->mut()->isa_mut<Lam>()) {
         auto [_, l] = *data().emplace(lam, Lattice::Bot).first;
         auto succ   = irreducible_.emplace(lam).second;
         if (l == Lattice::Reduce && succ) {

--- a/thorin/pass/fp/eta_red.h
+++ b/thorin/pass/fp/eta_red.h
@@ -23,7 +23,7 @@ public:
 
 private:
     const bool callee_only_;
-    const Def* rewrite(const Def*) override;
+    Ref rewrite(Ref) override;
     undo_t analyze(const Var*) override;
 
     LamSet irreducible_;

--- a/thorin/pass/fp/tail_rec_elim.cpp
+++ b/thorin/pass/fp/tail_rec_elim.cpp
@@ -5,7 +5,7 @@
 
 namespace thorin {
 
-const Def* TailRecElim::rewrite(const Def* def) {
+Ref TailRecElim::rewrite(Ref def) {
     if (auto [app, old] = isa_apped_mut_lam(def); old) {
         if (auto i = old2rec_loop_.find(old); i != old2rec_loop_.end()) {
             auto [rec, loop] = i->second;
@@ -19,7 +19,7 @@ const Def* TailRecElim::rewrite(const Def* def) {
     return def;
 }
 
-undo_t TailRecElim::analyze(const Def* def) {
+undo_t TailRecElim::analyze(Ref def) {
     if (auto [app, old] = isa_apped_mut_lam(def); old) {
         if (auto ret_var = old->ret_var(); ret_var && app->args().back() == ret_var) {
             if (auto [i, ins] = old2rec_loop_.emplace(old, std::pair<Lam*, Lam*>(nullptr, nullptr)); ins) {
@@ -31,8 +31,8 @@ undo_t TailRecElim::analyze(const Def* def) {
                 world().DLOG("old {} -> (rec: {}, loop: {})", old, rec, loop);
 
                 auto n = rec->num_doms();
-                std::vector<const Def*> loop_args(n - 1);
-                std::vector<const Def*> loop_vars(n);
+                DefVec loop_args(n - 1);
+                DefVec loop_vars(n);
                 for (size_t i = 0; i != n - 1; ++i) {
                     loop_args[i] = rec->var(i);
                     loop_vars[i] = loop->var(i);

--- a/thorin/pass/fp/tail_rec_elim.cpp
+++ b/thorin/pass/fp/tail_rec_elim.cpp
@@ -6,7 +6,7 @@
 namespace thorin {
 
 const Def* TailRecElim::rewrite(const Def* def) {
-    if (auto [app, old] = isa_apped_nom_lam(def); old) {
+    if (auto [app, old] = isa_apped_mut_lam(def); old) {
         if (auto i = old2rec_loop_.find(old); i != old2rec_loop_.end()) {
             auto [rec, loop] = i->second;
             if (auto ret_var = rec->ret_var(); app->args().back() == ret_var)
@@ -20,7 +20,7 @@ const Def* TailRecElim::rewrite(const Def* def) {
 }
 
 undo_t TailRecElim::analyze(const Def* def) {
-    if (auto [app, old] = isa_apped_nom_lam(def); old) {
+    if (auto [app, old] = isa_apped_mut_lam(def); old) {
         if (auto ret_var = old->ret_var(); ret_var && app->args().back() == ret_var) {
             if (auto [i, ins] = old2rec_loop_.emplace(old, std::pair<Lam*, Lam*>(nullptr, nullptr)); ins) {
                 auto& [rec, loop] = i->second;

--- a/thorin/pass/fp/tail_rec_elim.h
+++ b/thorin/pass/fp/tail_rec_elim.h
@@ -15,8 +15,8 @@ public:
 private:
     /// @name PassMan hooks
     ///@{
-    const Def* rewrite(const Def*) override;
-    undo_t analyze(const Def*) override;
+    Ref rewrite(Ref) override;
+    undo_t analyze(Ref) override;
     ///@}
 
     EtaRed* eta_red_;

--- a/thorin/pass/pass.cpp
+++ b/thorin/pass/pass.cpp
@@ -88,7 +88,7 @@ void PassMan::run() {
     Phase::run<Cleanup>(world());
 }
 
-const Def* PassMan::rewrite(const Def* old_def) {
+Ref PassMan::rewrite(Ref old_def) {
     if (!old_def->dep()) return old_def;
 
     if (auto mut = old_def->isa_mut()) {
@@ -127,7 +127,7 @@ const Def* PassMan::rewrite(const Def* old_def) {
     return map(old_def, new_def);
 }
 
-undo_t PassMan::analyze(const Def* def) {
+undo_t PassMan::analyze(Ref def) {
     undo_t undo = No_Undo;
 
     if (!def->dep() || analyzed(def)) {

--- a/thorin/pass/pass.h
+++ b/thorin/pass/pass.h
@@ -31,7 +31,7 @@ public:
 
     /// @name Rewrite Hook for the PassMan
     ///@{
-    /// Rewrites a *structural* @p def within PassMan::curr_mut.
+    /// Rewrites an *imm*utable @p def within PassMan::curr_mut.
     /// @returns the replacement.
     virtual const Def* rewrite(const Def* def) { return def; }
     virtual const Def* rewrite(const Var* var) { return var; }

--- a/thorin/pass/pass.h
+++ b/thorin/pass/pass.h
@@ -57,9 +57,9 @@ public:
 
     /// Invoked just before Pass::rewrite%ing PassMan::curr_mut's body.
     /// @note This is invoked when seeing the *inside* of a mutable the first time.
-    /// This is often too late, as you usually want to do something when you see a mutable the first time from the *outside*.
-    /// This means that this PassMan::curr_mut has already been encountered elsewhere.
-    /// Otherwise, we wouldn't have seen PassMan::curr_mut to begin with (unless it is Def::is_external).
+    /// This is often too late, as you usually want to do something when you see a mutable the first time from the
+    /// *outside*. This means that this PassMan::curr_mut has already been encountered elsewhere. Otherwise, we wouldn't
+    /// have seen PassMan::curr_mut to begin with (unless it is Def::is_external).
     virtual void enter() {}
 
     /// Invoked **once** before entering the main rewrite loop.

--- a/thorin/pass/pass.h
+++ b/thorin/pass/pass.h
@@ -33,9 +33,9 @@ public:
     ///@{
     /// Rewrites an *imm*utable @p def within PassMan::curr_mut.
     /// @returns the replacement.
-    virtual const Def* rewrite(const Def* def) { return def; }
-    virtual const Def* rewrite(const Var* var) { return var; }
-    virtual const Def* rewrite(const Proxy* proxy) { return proxy; }
+    virtual Ref rewrite(Ref def) { return def; }
+    virtual Ref rewrite(const Var* var) { return var; }
+    virtual Ref rewrite(const Proxy* proxy) { return proxy; }
     ///@}
 
     /// @name Analyze Hook for the PassMan
@@ -43,7 +43,7 @@ public:
     /// Invoked after the PassMan has finished Pass::rewrite%ing PassMan::curr_mut to analyze the Def.
     /// Will only be invoked if Pass::fixed_point() yields `true` - which will be the case for FPPass%es.
     /// @returns thorin::No_Undo or the state to roll back to.
-    virtual undo_t analyze(const Def*) { return No_Undo; }
+    virtual undo_t analyze(Ref) { return No_Undo; }
     virtual undo_t analyze(const Var*) { return No_Undo; }
     virtual undo_t analyze(const Proxy*) { return No_Undo; }
     ///@}
@@ -68,14 +68,14 @@ public:
 
     /// @name proxy
     ///@{
-    const Proxy* proxy(const Def* type, Defs ops, u32 tag = 0) { return world().proxy(type, ops, index(), tag); }
+    const Proxy* proxy(Ref type, Defs ops, u32 tag = 0) { return world().proxy(type, ops, index(), tag); }
     /// Check whether given @p def is a Proxy whose Proxy::pass matches this Pass's @p IPass::index.
-    const Proxy* isa_proxy(const Def* def, u32 tag = 0) {
+    const Proxy* isa_proxy(Ref def, u32 tag = 0) {
         if (auto proxy = def->isa<Proxy>(); proxy != nullptr && proxy->pass() == index() && proxy->tag() == tag)
             return proxy;
         return nullptr;
     }
-    const Proxy* as_proxy(const Def* def, u32 tag = 0) {
+    const Proxy* as_proxy(Ref def, u32 tag = 0) {
         auto proxy = def->as<Proxy>();
         assert_unused(proxy->pass() == index() && proxy->tag() == tag);
         return proxy;
@@ -175,15 +175,15 @@ private:
 
     /// @name rewriting
     ///@{
-    const Def* rewrite(const Def*);
+    Ref rewrite(Ref);
 
-    const Def* map(const Def* old_def, const Def* new_def) {
+    Ref map(Ref old_def, Ref new_def) {
         curr_state().old2new[old_def] = new_def;
         curr_state().old2new.emplace(new_def, new_def);
         return new_def;
     }
 
-    std::optional<const Def*> lookup(const Def* old_def) {
+    std::optional<Ref> lookup(Ref old_def) {
         for (auto& state : states_ | std::ranges::views::reverse)
             if (auto i = state.old2new.find(old_def); i != state.old2new.end()) return i->second;
         return {};
@@ -192,8 +192,8 @@ private:
 
     /// @name analyze
     ///@{
-    undo_t analyze(const Def*);
-    bool analyzed(const Def* def) {
+    undo_t analyze(Ref);
+    bool analyzed(Ref def) {
         for (auto& state : states_ | std::ranges::views::reverse)
             if (state.analyzed.contains(def)) return true;
         curr_state().analyzed.emplace(def);

--- a/thorin/pass/rw/lam_spec.cpp
+++ b/thorin/pass/rw/lam_spec.cpp
@@ -16,8 +16,8 @@ static bool is_top_level(LamMap<bool>& top, Lam* lam) {
     Scope scope(lam);
     if (!scope.free_vars().empty()) return top[lam] = false;
 
-    for (auto nom : scope.free_noms()) {
-        if (auto inner = nom->isa<Lam>()) {
+    for (auto mut : scope.free_muts()) {
+        if (auto inner = mut->isa<Lam>()) {
             if (!is_top_level(top, inner)) return top[lam] = false;
         }
     }
@@ -33,7 +33,7 @@ static bool is_top_level(Lam* lam) {
 const Def* LamSpec::rewrite(const Def* def) {
     if (auto i = old2new_.find(def); i != old2new_.end()) return i->second;
 
-    auto [app, old_lam] = isa_apped_nom_lam(def);
+    auto [app, old_lam] = isa_apped_mut_lam(def);
     if (!isa_workable(old_lam)) return def;
 
     Scope scope(old_lam);

--- a/thorin/pass/rw/lam_spec.cpp
+++ b/thorin/pass/rw/lam_spec.cpp
@@ -30,7 +30,7 @@ static bool is_top_level(Lam* lam) {
     return is_top_level(top, lam);
 }
 
-const Def* LamSpec::rewrite(const Def* def) {
+Ref LamSpec::rewrite(Ref def) {
     if (auto i = old2new_.find(def); i != old2new_.end()) return i->second;
 
     auto [app, old_lam] = isa_apped_mut_lam(def);

--- a/thorin/pass/rw/lam_spec.cpp
+++ b/thorin/pass/rw/lam_spec.cpp
@@ -44,9 +44,8 @@ const Def* LamSpec::rewrite(const Def* def) {
     auto skip     = old_lam->ret_var() && is_top_level(old_lam);
     auto old_doms = old_lam->doms();
 
-    for (auto dom : old_doms.skip_back(skip)) {
+    for (auto dom : old_doms.skip_back(skip))
         if (!dom->isa<Pi>()) new_doms.emplace_back(dom);
-    }
 
     if (skip) new_doms.emplace_back(old_lam->doms().back());
     if (new_doms.size() == old_lam->num_doms()) return def;

--- a/thorin/pass/rw/lam_spec.h
+++ b/thorin/pass/rw/lam_spec.h
@@ -12,7 +12,7 @@ public:
 private:
     /// @name PassMan hooks
     ///@{
-    const Def* rewrite(const Def*) override;
+    Ref rewrite(Ref) override;
     ///@}
 
     Def2Def old2new_;

--- a/thorin/pass/rw/partial_eval.cpp
+++ b/thorin/pass/rw/partial_eval.cpp
@@ -4,7 +4,7 @@
 
 namespace thorin {
 
-const Def* PartialEval::rewrite(const Def* def) {
+Ref PartialEval::rewrite(Ref def) {
     if (auto [app, lam] = isa_apped_mut_lam(def); lam && lam->is_set()) {
         if (lam->filter() == world().lit_ff()) return def; // optimize this common case
 

--- a/thorin/pass/rw/partial_eval.cpp
+++ b/thorin/pass/rw/partial_eval.cpp
@@ -5,12 +5,12 @@
 namespace thorin {
 
 const Def* PartialEval::rewrite(const Def* def) {
-    if (auto [app, lam] = isa_apped_nom_lam(def); lam && lam->is_set()) {
+    if (auto [app, lam] = isa_apped_mut_lam(def); lam && lam->is_set()) {
         if (lam->filter() == world().lit_ff()) return def; // optimize this common case
 
         auto [filter, body] = lam->reduce(app->arg()).to_array<2>();
         if (auto f = isa_lit<bool>(filter); f && *f) {
-            world().DLOG("PE {} within {}", lam, curr_nom());
+            world().DLOG("PE {} within {}", lam, curr_mut());
             return body;
         }
     }

--- a/thorin/pass/rw/partial_eval.h
+++ b/thorin/pass/rw/partial_eval.h
@@ -9,7 +9,7 @@ public:
     PartialEval(PassMan& man)
         : RWPass(man, "partial_eval") {}
 
-    const Def* rewrite(const Def*) override;
+    Ref rewrite(Ref) override;
 };
 
 } // namespace thorin

--- a/thorin/pass/rw/ret_wrap.cpp
+++ b/thorin/pass/rw/ret_wrap.cpp
@@ -3,19 +3,19 @@
 namespace thorin {
 
 void RetWrap::enter() {
-    auto ret_var = curr_nom()->ret_var();
+    auto ret_var = curr_mut()->ret_var();
     if (!ret_var) return;
 
     // new wrapper that calls the return continuation
-    auto ret_cont = world().nom_lam(ret_var->type()->as<Pi>())->set(ret_var->dbg());
+    auto ret_cont = world().mut_lam(ret_var->type()->as<Pi>())->set(ret_var->dbg());
     ret_cont->app(false, ret_var, ret_cont->var())->set(ret_var->dbg());
 
     // rebuild a new "var" that substitutes the actual ret_var with ret_cont
-    auto new_vars = curr_nom()->vars();
+    auto new_vars = curr_mut()->vars();
     assert(new_vars.back() == ret_var && "we assume that the last element is the ret_var");
     new_vars.back() = ret_cont;
-    auto new_var    = world().tuple(curr_nom()->dom(), new_vars);
-    curr_nom()->set(curr_nom()->reduce(new_var));
+    auto new_var    = world().tuple(curr_mut()->dom(), new_vars);
+    curr_mut()->set(curr_mut()->reduce(new_var));
 }
 
 } // namespace thorin

--- a/thorin/pass/rw/scalarize.h
+++ b/thorin/pass/rw/scalarize.h
@@ -22,11 +22,11 @@ public:
         : RWPass(man, "scalerize")
         , eta_exp_(eta_exp) {}
 
-    const Def* rewrite(const Def*) override;
+    Ref rewrite(Ref) override;
 
 private:
     bool should_expand(Lam* lam);
-    Lam* make_scalar(const Def* def);
+    Lam* make_scalar(Ref def);
 
     EtaExp* eta_exp_;
     Lam2Lam tup2sca_;

--- a/thorin/pass/rw/scalarize.h
+++ b/thorin/pass/rw/scalarize.h
@@ -15,7 +15,7 @@ class EtaExp;
 /// f' := λ (y_1:T_1, y_2:T2, .. y_n:T_n).E[x_1 \ (y_1, y2); ..; x_n \ y_n]
 /// ```
 /// if `f` appears in callee position only (see @p EtaExp).
-/// It will not flatten nominal @p Sigma%s or @p Arr%ays.
+/// It will not flatten mutable @p Sigma%s or @p Arr%ays.
 class Scalerize : public RWPass<Scalerize, Lam> {
 public:
     Scalerize(PassMan& man, EtaExp* eta_exp = nullptr)

--- a/thorin/phase/phase.cpp
+++ b/thorin/phase/phase.cpp
@@ -13,9 +13,9 @@ void Phase::run() {
 void RWPhase::start() {
     for (const auto& [_, ax] : world().axioms()) rewrite(ax);
     auto externals = world().externals();
-    for (const auto& [_, nom] : externals) {
-        nom->make_internal();
-        rewrite(nom)->as_nom()->make_external();
+    for (const auto& [_, mut] : externals) {
+        mut->make_internal();
+        rewrite(mut)->as_mut()->make_external();
     }
 }
 
@@ -33,7 +33,7 @@ void Cleanup::start() {
     Rewriter rewriter(new_world);
 
     for (const auto& [_, ax] : world().axioms()) rewriter.rewrite(ax);
-    for (const auto& [_, nom] : world().externals()) rewriter.rewrite(nom)->as_nom()->make_external();
+    for (const auto& [_, mut] : world().externals()) rewriter.rewrite(mut)->as_mut()->make_external();
 
     swap(world(), new_world);
 }
@@ -43,22 +43,22 @@ void Pipeline::start() {
 }
 
 void ScopePhase::start() {
-    unique_queue<NomSet> noms;
+    unique_queue<MutSet> muts;
 
-    for (const auto& [name, nom] : world().externals()) {
-        assert(nom->is_set() && "external must not be empty");
-        noms.push(nom);
+    for (const auto& [name, mut] : world().externals()) {
+        assert(mut->is_set() && "external must not be empty");
+        muts.push(mut);
     }
 
-    while (!noms.empty()) {
-        auto nom = noms.pop();
-        if (elide_empty_ && !nom->is_set()) continue;
+    while (!muts.empty()) {
+        auto mut = muts.pop();
+        if (elide_empty_ && !mut->is_set()) continue;
 
-        Scope scope(nom);
+        Scope scope(mut);
         scope_ = &scope;
         visit(scope);
 
-        for (auto nom : scope.free_noms()) noms.push(nom);
+        for (auto mut : scope.free_muts()) muts.push(mut);
     }
 }
 

--- a/thorin/phase/phase.h
+++ b/thorin/phase/phase.h
@@ -49,7 +49,7 @@ protected:
 
 /// Visits the current Phase::world and constructs a new RWPhase::world along the way.
 /// It recursively **rewrites** all World::externals().
-/// @note You can override Rewriter::rewrite, Rewriter::rewrite_structural, and Rewriter::rewrite_nom.
+/// @note You can override Rewriter::rewrite, Rewriter::rewrite_imm, and Rewriter::rewrite_mut.
 class RWPhase : public Phase, public Rewriter {
 public:
     RWPhase(World& world, std::string_view name)
@@ -145,7 +145,7 @@ private:
 
 /// Transitively visits all *reachable* Scope%s in World that do not have free variables.
 /// We call these Scope%s *top-level* Scope%s.
-/// Select with `elide_empty` whether you want to visit trivial Scope%s of *noms* without body.
+/// Select with `elide_empty` whether you want to visit trivial Scope%s of *muts* without body.
 /// Assumes that you don't change anything - hence `dirty` flag is set to `false`.
 class ScopePhase : public Phase {
 public:

--- a/thorin/rewrite.cpp
+++ b/thorin/rewrite.cpp
@@ -10,29 +10,29 @@ Ref Rewriter::rewrite(Ref old_def) {
     if (!old_def) return nullptr;
     if (old_def->isa<Univ>()) return world().univ();
     if (auto i = old2new_.find(old_def); i != old2new_.end()) return i->second;
-    if (auto old_nom = old_def->isa_nom()) return rewrite_nom(old_nom);
+    if (auto old_mut = old_def->isa_mut()) return rewrite_mut(old_mut);
 
-    auto new_def = rewrite_structural(old_def);
+    auto new_def = rewrite_imm(old_def);
     return map(old_def, new_def);
 }
 
-Ref Rewriter::rewrite_structural(Ref old_def) {
+Ref Rewriter::rewrite_imm(Ref old_def) {
     auto new_type = rewrite(old_def->type());
     DefArray new_ops(old_def->num_ops(), [&](auto i) { return rewrite(old_def->op(i)); });
     return old_def->rebuild(world(), new_type, new_ops);
 }
 
-Ref Rewriter::rewrite_nom(Def* old_nom) {
-    auto new_type = rewrite(old_nom->type());
-    auto new_nom  = old_nom->stub(world(), new_type);
-    map(old_nom, new_nom);
+Ref Rewriter::rewrite_mut(Def* old_mut) {
+    auto new_type = rewrite(old_mut->type());
+    auto new_mut  = old_mut->stub(world(), new_type);
+    map(old_mut, new_mut);
 
-    if (old_nom->is_set()) {
-        for (size_t i = 0, e = old_nom->num_ops(); i != e; ++i) new_nom->set(i, rewrite(old_nom->op(i)));
-        if (auto new_def = new_nom->restructure()) return map(old_nom, new_def);
+    if (old_mut->is_set()) {
+        for (size_t i = 0, e = old_mut->num_ops(); i != e; ++i) new_mut->set(i, rewrite(old_mut->op(i)));
+        if (auto new_def = new_mut->restructure()) return map(old_mut, new_def);
     }
 
-    return new_nom;
+    return new_mut;
 }
 
 Ref rewrite(Ref def, Ref old_def, Ref new_def, const Scope& scope) {
@@ -41,22 +41,22 @@ Ref rewrite(Ref def, Ref old_def, Ref new_def, const Scope& scope) {
     return rewriter.rewrite(def);
 }
 
-Ref rewrite(Def* nom, Ref arg, size_t i, const Scope& scope) { return rewrite(nom->op(i), nom->var(), arg, scope); }
+Ref rewrite(Def* mut, Ref arg, size_t i, const Scope& scope) { return rewrite(mut->op(i), mut->var(), arg, scope); }
 
-Ref rewrite(Def* nom, Ref arg, size_t i) {
-    Scope scope(nom);
-    return rewrite(nom, arg, i, scope);
+Ref rewrite(Def* mut, Ref arg, size_t i) {
+    Scope scope(mut);
+    return rewrite(mut, arg, i, scope);
 }
 
-DefArray rewrite(Def* nom, Ref arg, const Scope& scope) {
-    ScopeRewriter rewriter(nom->world(), scope);
-    rewriter.map(nom->var(), arg);
-    return DefArray(nom->num_ops(), [&](size_t i) { return rewriter.rewrite(nom->op(i)); });
+DefArray rewrite(Def* mut, Ref arg, const Scope& scope) {
+    ScopeRewriter rewriter(mut->world(), scope);
+    rewriter.map(mut->var(), arg);
+    return DefArray(mut->num_ops(), [&](size_t i) { return rewriter.rewrite(mut->op(i)); });
 }
 
-DefArray rewrite(Def* nom, Ref arg) {
-    Scope scope(nom);
-    return rewrite(nom, arg, scope);
+DefArray rewrite(Def* mut, Ref arg) {
+    Scope scope(mut);
+    return rewrite(mut, arg, scope);
 }
 
 } // namespace thorin

--- a/thorin/rewrite.h
+++ b/thorin/rewrite.h
@@ -19,8 +19,8 @@ public:
     ///@{
     Ref map(Ref old_def, Ref new_def) { return old2new_[old_def] = new_def; }
     virtual Ref rewrite(Ref);
-    virtual Ref rewrite_structural(Ref);
-    virtual Ref rewrite_nom(Def*);
+    virtual Ref rewrite_imm(Ref);
+    virtual Ref rewrite_mut(Def*);
     ///@}
 
 private:
@@ -52,7 +52,7 @@ public:
         : Rewriter(world) {}
 
     Ref rewrite(Ref old_def) override {
-        if (old_def->isa_nom()) return old_def;
+        if (old_def->isa_mut()) return old_def;
         if (old_def->has_dep(Dep::Infer)) return Rewriter::rewrite(old_def);
         return old_def;
     }
@@ -61,16 +61,16 @@ public:
 /// Rewrites @p def by mapping @p old_def to @p new_def while obeying @p scope.
 Ref rewrite(Ref def, Ref old_def, Ref new_def, const Scope& scope);
 
-/// Rewrites @p nom's @p i^th op by substituting @p nom's @p Var with @p arg while obeying @p nom's @p scope.
-Ref rewrite(Def* nom, Ref arg, size_t i);
+/// Rewrites @p mut's @p i^th op by substituting @p mut's @p Var with @p arg while obeying @p mut's @p scope.
+Ref rewrite(Def* mut, Ref arg, size_t i);
 
 /// Same as above but uses @p scope as an optimization instead of computing a new Scope.
-Ref rewrite(Def* nom, Ref arg, size_t i, const Scope& scope);
+Ref rewrite(Def* mut, Ref arg, size_t i, const Scope& scope);
 
-/// Rewrites @p nom's ops by substituting @p nom's @p Var with @p arg while obeying @p nom's @p scope.
-DefArray rewrite(Def* nom, Ref arg);
+/// Rewrites @p mut's ops by substituting @p mut's @p Var with @p arg while obeying @p mut's @p scope.
+DefArray rewrite(Def* mut, Ref arg);
 
 /// Same as above but uses @p scope as an optimization instead of computing a new Scope.
-DefArray rewrite(Def* nom, Ref arg, const Scope& scope);
+DefArray rewrite(Def* mut, Ref arg, const Scope& scope);
 
 } // namespace thorin

--- a/thorin/tuple.cpp
+++ b/thorin/tuple.cpp
@@ -11,15 +11,15 @@ namespace thorin {
 
 static bool should_flatten(const Def* def) { return (def->is_term() ? def->type() : def)->isa<Sigma, Arr>(); }
 
-static bool nom_val_or_typ(const Def* def) {
+static bool mut_val_or_typ(const Def* def) {
     auto typ = def->is_term() ? def->type() : def;
-    return typ->isa_nom();
+    return typ->isa_mut();
 }
 
-size_t flatten(DefVec& ops, const Def* def, bool flatten_noms) {
-    if (auto a = def->isa_lit_arity(); a && *a != 1 && should_flatten(def) && flatten_noms == nom_val_or_typ(def)) {
+size_t flatten(DefVec& ops, const Def* def, bool flatten_muts) {
+    if (auto a = def->isa_lit_arity(); a && *a != 1 && should_flatten(def) && flatten_muts == mut_val_or_typ(def)) {
         auto n = 0;
-        for (size_t i = 0; i != *a; ++i) n += flatten(ops, def->proj(*a, i), flatten_noms);
+        for (size_t i = 0; i != *a; ++i) n += flatten(ops, def->proj(*a, i), flatten_muts);
         return n;
     } else {
         ops.emplace_back(def);
@@ -34,20 +34,20 @@ const Def* flatten(const Def* def) {
     return def->is_term() ? def->world().tuple(def->type(), ops) : def->world().sigma(ops);
 }
 
-static const Def* unflatten(Defs defs, const Def* type, size_t& j, bool flatten_noms) {
+static const Def* unflatten(Defs defs, const Def* type, size_t& j, bool flatten_muts) {
     if (!defs.empty() && defs[0]->type() == type) return defs[j++];
-    if (auto a = type->isa_lit_arity(); flatten_noms == nom_val_or_typ(type) && a && *a != 1) {
+    if (auto a = type->isa_lit_arity(); flatten_muts == mut_val_or_typ(type) && a && *a != 1) {
         auto& world = type->world();
-        DefArray ops(*a, [&](size_t i) { return unflatten(defs, type->proj(*a, i), j, flatten_noms); });
+        DefArray ops(*a, [&](size_t i) { return unflatten(defs, type->proj(*a, i), j, flatten_muts); });
         return world.tuple(type, ops);
     }
 
     return defs[j++];
 }
 
-const Def* unflatten(Defs defs, const Def* type, bool flatten_noms) {
+const Def* unflatten(Defs defs, const Def* type, bool flatten_muts) {
     size_t j = 0;
-    auto def = unflatten(defs, type, j, flatten_noms);
+    auto def = unflatten(defs, type, j, flatten_muts);
     assert(j == defs.size());
     return def;
 }
@@ -68,14 +68,14 @@ DefArray merge(Defs a, Defs b) {
 }
 
 const Def* merge_sigma(const Def* def, Defs defs) {
-    if (auto sigma = def->isa<Sigma>(); sigma && !sigma->isa_nom())
+    if (auto sigma = def->isa<Sigma>(); sigma && !sigma->isa_mut())
         return def->world().sigma(merge(sigma->ops(), defs));
     return def->world().sigma(merge(def, defs));
 }
 
 const Def* merge_tuple(const Def* def, Defs defs) {
     auto& w = def->world();
-    if (auto sigma = def->type()->isa<Sigma>(); sigma && !sigma->isa_nom()) {
+    if (auto sigma = def->type()->isa<Sigma>(); sigma && !sigma->isa_mut()) {
         auto a = sigma->num_ops();
         DefArray tuple(a, [&](auto i) { return w.extract(def, a, i); });
         return w.tuple(merge(tuple, defs));
@@ -96,12 +96,12 @@ std::string tuple2str(const Def* def) {
  */
 
 const Def* Arr::reduce(const Def* arg) const {
-    if (auto nom = isa_nom<Arr>()) return rewrite(nom, arg, 1);
+    if (auto mut = isa_mut<Arr>()) return rewrite(mut, arg, 1);
     return body();
 }
 
 const Def* Pack::reduce(const Def* arg) const {
-    if (auto nom = isa_nom<Pack>()) return rewrite(nom, arg, 0);
+    if (auto mut = isa_mut<Pack>()) return rewrite(mut, arg, 0);
     return body();
 }
 

--- a/thorin/tuple.h
+++ b/thorin/tuple.h
@@ -6,7 +6,7 @@ namespace thorin {
 
 class Sigma : public Def {
 private:
-    Sigma(const Def* type, Defs ops)    ///< Constructor for a *imm*utable Sigma.
+    Sigma(const Def* type, Defs ops) ///< Constructor for a *imm*utable Sigma.
         : Def(Node, type, ops, 0) {}
     Sigma(const Def* type, size_t size) ///< Constructor for a *mut*able Sigma.
         : Def(Node, type, size, 0) {}
@@ -41,7 +41,7 @@ class Arr : public Def {
 private:
     Arr(const Def* type, const Def* shape, const Def* body) /// Constructor for a *imm*utable Arr.
         : Def(Node, type, {shape, body}, 0) {}
-    Arr(const Def* type)                                    /// Constructor for a *mut*able Arr.
+    Arr(const Def* type) /// Constructor for a *mut*able Arr.
         : Def(Node, type, 2, 0) {}
 
 public:
@@ -70,7 +70,7 @@ class Pack : public Def {
 private:
     Pack(const Def* type, const Def* body) ///< Constructor for a *imm*utable Pack.
         : Def(Node, type, {body}, 0) {}
-    Pack(const Def* type)                  ///< Constructor for a *mut*ablel Pack.
+    Pack(const Def* type) ///< Constructor for a *mut*ablel Pack.
         : Def(Node, type, 1, 0) {}
 
 public:

--- a/thorin/tuple.h
+++ b/thorin/tuple.h
@@ -6,11 +6,9 @@ namespace thorin {
 
 class Sigma : public Def {
 private:
-    /// Constructor for a *structural* Sigma.
-    Sigma(const Def* type, Defs ops)
+    Sigma(const Def* type, Defs ops)    ///< Constructor for a *imm*utable Sigma.
         : Def(Node, type, ops, 0) {}
-    /// Constructor for a *nom*inal Sigma.
-    Sigma(const Def* type, size_t size)
+    Sigma(const Def* type, size_t size) ///< Constructor for a *mut*able Sigma.
         : Def(Node, type, size, 0) {}
 
 public:
@@ -41,11 +39,9 @@ private:
 
 class Arr : public Def {
 private:
-    /// Constructor for a *structural* Arr.
-    Arr(const Def* type, const Def* shape, const Def* body)
+    Arr(const Def* type, const Def* shape, const Def* body) /// Constructor for a *imm*utable Arr.
         : Def(Node, type, {shape, body}, 0) {}
-    /// Constructor for a *nom*inaml Arr.
-    Arr(const Def* type)
+    Arr(const Def* type)                                    /// Constructor for a *mut*able Arr.
         : Def(Node, type, 2, 0) {}
 
 public:
@@ -72,11 +68,9 @@ public:
 
 class Pack : public Def {
 private:
-    /// Constructor for a *structural* Pack.
-    Pack(const Def* type, const Def* body)
+    Pack(const Def* type, const Def* body) ///< Constructor for a *imm*utable Pack.
         : Def(Node, type, {body}, 0) {}
-    /// Constructor for a *nom*inaml Pack.
-    Pack(const Def* type)
+    Pack(const Def* type)                  ///< Constructor for a *mut*ablel Pack.
         : Def(Node, type, 1, 0) {}
 
 public:
@@ -142,7 +136,7 @@ size_t flatten(DefVec& ops, const Def* def, bool flatten_sigmas = true);
 /// Applies the reverse transformation on a pack/tuple, given the original type.
 const Def* unflatten(const Def* def, const Def* type);
 /// Same as unflatten, but uses the operands of a flattened pack/tuple directly.
-const Def* unflatten(Defs ops, const Def* type, bool flatten_noms = true);
+const Def* unflatten(Defs ops, const Def* type, bool flatten_muts = true);
 
 DefArray merge(const Def* def, Defs defs);
 const Def* merge_sigma(const Def* def, Defs defs);

--- a/thorin/tuple.h
+++ b/thorin/tuple.h
@@ -6,10 +6,10 @@ namespace thorin {
 
 class Sigma : public Def {
 private:
-    Sigma(const Def* type, Defs ops) ///< Constructor for a *imm*utable Sigma.
-        : Def(Node, type, ops, 0) {}
-    Sigma(const Def* type, size_t size) ///< Constructor for a *mut*able Sigma.
-        : Def(Node, type, size, 0) {}
+    Sigma(const Def* type, Defs ops)
+        : Def(Node, type, ops, 0) {} ///< Constructor for an *imm*utable Sigma.
+    Sigma(const Def* type, size_t size)
+        : Def(Node, type, size, 0) {} ///< Constructor for a *mut*able Sigma.
 
 public:
     /// @name setters
@@ -39,10 +39,10 @@ private:
 
 class Arr : public Def {
 private:
-    Arr(const Def* type, const Def* shape, const Def* body) /// Constructor for a *imm*utable Arr.
-        : Def(Node, type, {shape, body}, 0) {}
-    Arr(const Def* type) /// Constructor for a *mut*able Arr.
-        : Def(Node, type, 2, 0) {}
+    Arr(const Def* type, const Def* shape, const Def* body)
+        : Def(Node, type, {shape, body}, 0) {} ///< Constructor for an *imm*utable Arr.
+    Arr(const Def* type)
+        : Def(Node, type, 2, 0) {}             ///< Constructor for a *mut*able Arr.
 
 public:
     /// @name ops
@@ -68,10 +68,10 @@ public:
 
 class Pack : public Def {
 private:
-    Pack(const Def* type, const Def* body) ///< Constructor for a *imm*utable Pack.
-        : Def(Node, type, {body}, 0) {}
-    Pack(const Def* type) ///< Constructor for a *mut*ablel Pack.
-        : Def(Node, type, 1, 0) {}
+    Pack(const Def* type, const Def* body)
+        : Def(Node, type, {body}, 0) {} ///< Constructor for an *imm*utable Pack.
+    Pack(const Def* type)
+        : Def(Node, type, 1, 0) {}      ///< Constructor for a *mut*ablel Pack.
 
 public:
     /// @name ops

--- a/thorin/tuple.h
+++ b/thorin/tuple.h
@@ -42,7 +42,7 @@ private:
     Arr(const Def* type, const Def* shape, const Def* body)
         : Def(Node, type, {shape, body}, 0) {} ///< Constructor for an *imm*utable Arr.
     Arr(const Def* type)
-        : Def(Node, type, 2, 0) {}             ///< Constructor for a *mut*able Arr.
+        : Def(Node, type, 2, 0) {} ///< Constructor for a *mut*able Arr.
 
 public:
     /// @name ops
@@ -71,7 +71,7 @@ private:
     Pack(const Def* type, const Def* body)
         : Def(Node, type, {body}, 0) {} ///< Constructor for an *imm*utable Pack.
     Pack(const Def* type)
-        : Def(Node, type, 1, 0) {}      ///< Constructor for a *mut*ablel Pack.
+        : Def(Node, type, 1, 0) {} ///< Constructor for a *mut*ablel Pack.
 
 public:
     /// @name ops

--- a/thorin/world.cpp
+++ b/thorin/world.cpp
@@ -344,8 +344,7 @@ Ref World::insert(Ref d, Ref index, Ref val) {
 bool is_shape(Ref s) {
     if (s->isa<Nat>()) return true;
     if (auto arr = s->isa<Arr>()) return arr->body()->isa<Nat>();
-    if (auto sig = s->isa_imm<Sigma>())
-        return std::ranges::all_of(sig->ops(), [](Ref op) { return op->isa<Nat>(); });
+    if (auto sig = s->isa_imm<Sigma>()) return std::ranges::all_of(sig->ops(), [](Ref op) { return op->isa<Nat>(); });
 
     return false;
 }

--- a/thorin/world.h
+++ b/thorin/world.h
@@ -23,8 +23,8 @@ class Checker;
 class Driver;
 
 /// The World represents the whole program and manages creation of Thorin nodes (Def%s).
-/// *Structural* Def%s are hashed into an internal HashSet.
-/// The getters just calculate a hash and lookup the Def, if it is already present, or create a new one otherwise.
+/// Def%s are hashed into an internal HashSet.
+/// The World's factory methods just calculate a hash and lookup the Def, if it is already present, or create a new one otherwise.
 /// This corresponds to value numbering.
 ///
 /// You can create several worlds.

--- a/thorin/world.h
+++ b/thorin/world.h
@@ -24,8 +24,8 @@ class Driver;
 
 /// The World represents the whole program and manages creation of Thorin nodes (Def%s).
 /// Def%s are hashed into an internal HashSet.
-/// The World's factory methods just calculate a hash and lookup the Def, if it is already present, or create a new one otherwise.
-/// This corresponds to value numbering.
+/// The World's factory methods just calculate a hash and lookup the Def, if it is already present, or create a new one
+/// otherwise. This corresponds to value numbering.
 ///
 /// You can create several worlds.
 /// All worlds are completely independent from each other.
@@ -392,7 +392,7 @@ public:
     Ref join(Defs ops) { return bound<true>(ops); }
     Ref meet(Defs ops) { return bound<false>(ops); }
     Ref ac(Ref type, Defs ops);
-    /// Infers the type using a *immutable* Meet.
+    /// Infers the type using an *immutable* Meet.
     Ref ac(Defs ops);
     Ref vel(Ref type, Ref value);
     Ref pick(Ref type, Ref value);

--- a/thorin/world.h
+++ b/thorin/world.h
@@ -172,7 +172,7 @@ public:
     template<Sort = Sort::Univ>
     Ref umax(DefArray);
     const Type* type(Ref level);
-    const Type* type_infer_univ() { return type(nom_infer_univ()); }
+    const Type* type_infer_univ() { return type(mut_infer_univ()); }
     template<level_t level = 0>
     const Type* type() {
         if constexpr (level == 0)
@@ -182,19 +182,19 @@ public:
         else
             return type(lit_univ(level));
     }
-    const Var* var(Ref type, Def* nom) { return unify<Var>(1, type, nom); }
+    const Var* var(Ref type, Def* mut) { return unify<Var>(1, type, mut); }
     const Proxy* proxy(Ref type, Defs ops, u32 index, u32 tag) {
         return unify<Proxy>(ops.size(), type, ops, index, tag);
     }
 
-    Infer* nom_infer(Ref type) { return insert<Infer>(1, type); }
-    Infer* nom_infer_univ() { return nom_infer(univ()); }
-    Infer* nom_infer_type() { return nom_infer(type_infer_univ()); }
+    Infer* mut_infer(Ref type) { return insert<Infer>(1, type); }
+    Infer* mut_infer_univ() { return mut_infer(univ()); }
+    Infer* mut_infer_type() { return mut_infer(type_infer_univ()); }
 
     /// Either a value `?:?:.Type ?` or a type `?:.Type ?:.Type ?`.
-    Infer* nom_infer_entity() {
+    Infer* mut_infer_entity() {
         auto t   = type_infer_univ();
-        auto res = nom_infer(nom_infer(t));
+        auto res = mut_infer(mut_infer(t));
         assert(this == &res->world());
         return res;
     }
@@ -241,7 +241,7 @@ public:
         return unify<Pi>(2, Pi::infer(dom, codom), dom, codom, implicit);
     }
     const Pi* pi(Defs dom, Ref codom, bool implicit = false) { return pi(sigma(dom), codom, implicit); }
-    Pi* nom_pi(Ref type, bool implicit = false) { return insert<Pi>(2, type, implicit); }
+    Pi* mut_pi(Ref type, bool implicit = false) { return insert<Pi>(2, type, implicit); }
     ///@}
 
     /// @name Cn (Pi with codom Bot)
@@ -253,7 +253,7 @@ public:
 
     /// @name Lam
     ///@{
-    Lam* nom_lam(const Pi* cn) { return insert<Lam>(2, cn); }
+    Lam* mut_lam(const Pi* cn) { return insert<Lam>(2, cn); }
     const Lam* lam(const Pi* pi, Ref filter, Ref body) { return unify<Lam>(2, pi, filter, body); }
     const Lam* lam(const Pi* pi, Ref body) { return lam(pi, lit_tt(), body); }
     Lam* exit() { return data_.exit; } ///< Used as a dummy exit node within Scope.
@@ -273,11 +273,11 @@ public:
 
     /// @name Sigma
     ///@{
-    Sigma* nom_sigma(Ref type, size_t size) { return insert<Sigma>(size, type, size); }
-    /// A *nom*inal Sigma of type @p level.
+    Sigma* mut_sigma(Ref type, size_t size) { return insert<Sigma>(size, type, size); }
+    /// A *mut*able Sigma of type @p level.
     template<level_t level = 0>
-    Sigma* nom_sigma(size_t size) {
-        return nom_sigma(type<level>(), size);
+    Sigma* mut_sigma(size_t size) {
+        return mut_sigma(type<level>(), size);
     }
     Ref sigma(Defs ops);
     const Sigma* sigma() { return data_.sigma; } ///< The unit type within Type 0.
@@ -285,10 +285,10 @@ public:
 
     /// @name Arr
     ///@{
-    Arr* nom_arr(Ref type) { return insert<Arr>(2, type); }
+    Arr* mut_arr(Ref type) { return insert<Arr>(2, type); }
     template<level_t level = 0>
-    Arr* nom_arr() {
-        return nom_arr(type<level>());
+    Arr* mut_arr() {
+        return mut_arr(type<level>());
     }
     Ref arr(Ref shape, Ref body);
     Ref arr(Defs shape, Ref body);
@@ -302,14 +302,14 @@ public:
     /// @name Tuple
     ///@{
     Ref tuple(Defs ops);
-    /// Ascribes @p type to this tuple - needed for dependently typed and nominal Sigma%s.
+    /// Ascribes @p type to this tuple - needed for dependently typed and mutable Sigma%s.
     Ref tuple(Ref type, Defs ops);
     const Tuple* tuple() { return data_.tuple; } ///< the unit value of type `[]`
     ///@}
 
     /// @name Pack
     ///@{
-    Pack* nom_pack(Ref type) { return insert<Pack>(1, type); }
+    Pack* mut_pack(Ref type) { return insert<Pack>(1, type); }
     Ref pack(Ref arity, Ref body);
     Ref pack(Defs shape, Ref body);
     Ref pack(u64 n, Ref body) { return pack(lit_nat(n), body); }
@@ -381,18 +381,18 @@ public:
     Ref top(Ref type) { return ext<true>(type); }
     Ref type_bot() { return data_.type_bot; }
     Ref top_nat() { return data_.top_nat; }
-    template<bool Up> TBound<Up>* nom_bound(Ref type, size_t size) { return insert<TBound<Up>>(size, type, size); }
-    /// A *nom*inal Bound of Type @p l%evel.
-    template<bool Up, level_t l = 0> TBound<Up>* nom_bound(size_t size) { return nom_bound<Up>(type<l>(), size); }
+    template<bool Up> TBound<Up>* mut_bound(Ref type, size_t size) { return insert<TBound<Up>>(size, type, size); }
+    /// A *mut*able Bound of Type @p l%evel.
+    template<bool Up, level_t l = 0> TBound<Up>* mut_bound(size_t size) { return mut_bound<Up>(type<l>(), size); }
     template<bool Up> Ref bound(Defs ops);
-    Join* nom_join(Ref type, size_t size) { return nom_bound<true>(type, size); }
-    Meet* nom_meet(Ref type, size_t size) { return nom_bound<false>(type, size); }
-    template<level_t l = 0> Join* nom_join(size_t size) { return nom_join(type<l>(), size); }
-    template<level_t l = 0> Meet* nom_meet(size_t size) { return nom_meet(type<l>(), size); }
+    Join* mut_join(Ref type, size_t size) { return mut_bound<true>(type, size); }
+    Meet* mut_meet(Ref type, size_t size) { return mut_bound<false>(type, size); }
+    template<level_t l = 0> Join* mut_join(size_t size) { return mut_join(type<l>(), size); }
+    template<level_t l = 0> Meet* mut_meet(size_t size) { return mut_meet(type<l>(), size); }
     Ref join(Defs ops) { return bound<true>(ops); }
     Ref meet(Defs ops) { return bound<false>(ops); }
     Ref ac(Ref type, Defs ops);
-    /// Infers the type using a *structural* Meet.
+    /// Infers the type using a *immutable* Meet.
     Ref ac(Defs ops);
     Ref vel(Ref type, Ref value);
     Ref pick(Ref type, Ref value);
@@ -461,7 +461,7 @@ private:
     const T* unify(size_t num_ops, Args&&... args) {
         auto def = arena_.allocate<T>(num_ops, std::forward<Args&&>(args)...);
         if (auto loc = emit_loc()) def->set(loc);
-        assert(!def->isa_nom());
+        assert(!def->isa_mut());
 #if THORIN_ENABLE_CHECKS
         if (flags().trace_gids) outln("{}: {} - {}", def->node_name(), def->gid(), def->flags());
         if (flags().reeval_breakpoints && breakpoints().contains(def->gid())) thorin::breakpoint();


### PR DESCRIPTION
As I've already pointed out several times the name *nominal* is confusing as *nominals* are in fact **not** [nominal](https://en.wikipedia.org/wiki/Nominal_type_system) as they are tested like structurals for alpha-equiv.

This patch renames:
* **nom**inal -> **mut**able
* **structural** -> **imm**utable

In the future I'd like to add the *option* to make **mut**ables truely *nominal*/unique.

In addition: Some more porting from `const Def*` -> `Ref`.