### PR TITLE
macro to declare all kind of operators for enums

### DIFF
--- a/dialects/core/core.h
+++ b/dialects/core/core.h
@@ -10,11 +10,13 @@ namespace thorin::core {
 /// @name Mode
 ///@{
 /// What should happen if Idx arithmetic overflows?
-enum Mode : nat_t {
+enum class Mode : nat_t {
     none = 0,      ///< Wrap around.
     nsw  = 1 << 0, ///< No Signed Wrap around.
     nuw  = 1 << 1, ///< No Unsigned Wrap around.
 };
+
+THORIN_ENUM_OPERATORS(Mode)
 
 /// Give Mode as thorin::math::Mode, thorin::nat_t or Ref.
 using VMode = std::variant<Mode, nat_t, Ref>;
@@ -23,7 +25,7 @@ using VMode = std::variant<Mode, nat_t, Ref>;
 inline Ref mode(World& w, VMode m) {
     if (auto def = std::get_if<Ref>(&m)) return *def;
     if (auto nat = std::get_if<nat_t>(&m)) return w.lit_nat(*nat);
-    return w.lit_nat(std::get<Mode>(m));
+    return w.lit_nat((nat_t)std::get<Mode>(m));
 }
 ///@}
 

--- a/dialects/core/normalizers.cpp
+++ b/dialects/core/normalizers.cpp
@@ -159,7 +159,7 @@ Ref reassociate(Id id, World& world, [[maybe_unused]] const App* ab, Ref a, Ref 
     auto w  = zw ? zw->arg(1) : nullptr;
 
     // if we reassociate, we have to forget about nsw/nuw
-    auto make_op = [&world, id](Ref a, Ref b) { return world.call(id, Mode::none, Defs{a, b}); };
+    auto make_op = [&world, id](Ref a, Ref b) { return world.call(id, (nat_t)Mode::none, Defs{a, b}); };
 
     if (la && lz) return make_op(make_op(la, lz), w);             // (1)
     if (lx && lz) return make_op(make_op(lx, lz), make_op(y, w)); // (2)

--- a/dialects/core/normalizers.cpp
+++ b/dialects/core/normalizers.cpp
@@ -159,7 +159,7 @@ Ref reassociate(Id id, World& world, [[maybe_unused]] const App* ab, Ref a, Ref 
     auto w  = zw ? zw->arg(1) : nullptr;
 
     // if we reassociate, we have to forget about nsw/nuw
-    auto make_op = [&world, id](Ref a, Ref b) { return world.call(id, (nat_t)Mode::none, Defs{a, b}); };
+    auto make_op = [&world, id](Ref a, Ref b) { return world.call(id, Mode::none, Defs{a, b}); };
 
     if (la && lz) return make_op(make_op(la, lz), w);             // (1)
     if (lx && lz) return make_op(make_op(lx, lz), make_op(y, w)); // (2)

--- a/dialects/math/math.h
+++ b/dialects/math/math.h
@@ -11,33 +11,35 @@ namespace thorin::math {
 ///@{
 // clang-format off
 /// Allowed optimizations for a specific operation.
-enum Mode : nat_t {
+enum class Mode : nat_t {
     top      = 0,
-    none     = top,
-    nnan     = 1 << 0, ///< No NaNs.
-                       ///< Allow optimizations to assume the arguments and result are not NaN.
-                       ///< Such optimizations are required to retain defined behavior over NaNs,
-                       ///< but the value of the result is undefined.
-    ninf     = 1 << 1, ///< No Infs.
-                       ///< Allow optimizations to assume the arguments and result are not +/-Inf.
-                       ///< Such optimizations are required to retain defined behavior over +/-Inf,
-                       ///< but the value of the result is undefined.
-    nsz      = 1 << 2, ///< No Signed Zeros.
-                       ///< Allow optimizations to treat the sign of a zero argument or result as insignificant.
-    arcp     = 1 << 3, ///< Allow Reciprocal.
-                       ///< Allow optimizations to use the reciprocal of an argument rather than perform division.
-    contract = 1 << 4, ///< Allow floating-point contraction.
-                       ///< (e.g. fusing a multiply followed by an addition into a fused multiply-and-add).
-    afn      = 1 << 5, ///< Approximate functions.
-                       ///< Allow substitution of approximate calculations for functions (sin, log, sqrt, etc).
-    reassoc  = 1 << 6, ///< Allow reassociation transformations for floating-point operations.
-                       ///< This may dramatically change results in floating point.
-    finite = nnan | ninf,
-    unsafe = nsz | arcp | reassoc,
-    fast   = nnan | ninf | nsz | arcp | contract | afn | reassoc,
-    bot    = fast,
+    none     = top,                ///< Alias for Mode::none.
+    nnan     = 1 << 0,             ///< No NaNs.
+                                   ///< Allow optimizations to assume the arguments and result are not NaN.
+                                   ///< Such optimizations are required to retain defined behavior over NaNs, but the value of the result is undefined.
+    ninf     = 1 << 1,             ///< No Infs.
+                                   ///< Allow optimizations to assume the arguments and result are not +/-Inf.
+                                   ///< Such optimizations are required to retain defined behavior over +/-Inf, but the value of the result is undefined.
+    nsz      = 1 << 2,             ///< No Signed Zeros.
+                                   ///< Allow optimizations to treat the sign of a zero argument or result as insignificant.
+    arcp     = 1 << 3,             ///< Allow Reciprocal.
+                                   ///< Allow optimizations to use the reciprocal of an argument rather than perform division.
+    contract = 1 << 4,             ///< Allow floating-point contraction
+                                   ///< (e.g. fusing a multiply followed by an addition into a fused multiply-and-add).
+    afn      = 1 << 5,             ///< Approximate functions.
+                                   ///< Allow substitution of approximate calculations for functions (sin, log, sqrt, etc).
+    reassoc  = 1 << 6,             ///< Allow reassociation transformations for floating-point operations.
+                                   ///< This may dramatically change results in floating point.
+    finite = nnan | ninf,          ///< Mode::nnan `|` Mode::ninf.
+    unsafe = nsz | arcp | reassoc, ///< Mode::nsz `|` Mode::arcp `|` Mode::reassoc
+    fast   = nnan | ninf | nsz
+           | arcp | contract | afn
+           | reassoc,              ///< All flags.
+    bot    = fast,                 ///< Alias for Mode::fast.
 };
 // clang-format on
+
+THORIN_ENUM_OPERATORS(Mode)
 
 /// Give Mode as thorin::math::Mode, thorin::nat_t or Ref.
 using VMode = std::variant<Mode, nat_t, Ref>;
@@ -46,7 +48,7 @@ using VMode = std::variant<Mode, nat_t, Ref>;
 inline Ref mode(World& w, VMode m) {
     if (auto def = std::get_if<Ref>(&m)) return *def;
     if (auto nat = std::get_if<nat_t>(&m)) return w.lit_nat(*nat);
-    return w.lit_nat(std::get<Mode>(m));
+    return w.lit_nat((nat_t)std::get<Mode>(m));
 }
 ///@}
 

--- a/dialects/math/normalizers.cpp
+++ b/dialects/math/normalizers.cpp
@@ -189,7 +189,7 @@ Ref reassociate(Id id, World& world, [[maybe_unused]] const App* ab, Ref a, Ref 
     std::function<Ref(Ref, Ref)> make_op;
 
     // build mode for all new ops by using the least upper bound of all involved apps
-    nat_t mode      = (nat_t)Mode::bot;
+    auto mode      = (nat_t)Mode::bot;
     auto check_mode = [&](const App* app) {
         auto app_m = Lit::isa(app->arg(0));
         if (!app_m || !(*app_m & Mode::reassoc)) return false;

--- a/dialects/math/normalizers.cpp
+++ b/dialects/math/normalizers.cpp
@@ -189,7 +189,7 @@ Ref reassociate(Id id, World& world, [[maybe_unused]] const App* ab, Ref a, Ref 
     std::function<Ref(Ref, Ref)> make_op;
 
     // build mode for all new ops by using the least upper bound of all involved apps
-    nat_t mode      = Mode::bot;
+    nat_t mode      = (nat_t)Mode::bot;
     auto check_mode = [&](const App* app) {
         auto app_m = Lit::isa(app->arg(0));
         if (!app_m || !(*app_m & Mode::reassoc)) return false;

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -2362,6 +2362,7 @@ EXPAND_AS_DEFINED      = CODE \
                          CODE3 \
                          CODE4 \
                          THORIN_ENABLE_CHECKS \
+                         THORIN_ENUM_OPERATORS \
                          THORIN_1_8_16_32_64 \
                          THORIN_8_16_32_64 \
                          THORIN_16_32_64 \

--- a/gtest/test.cpp
+++ b/gtest/test.cpp
@@ -190,3 +190,17 @@ TEST(Type, Level) {
     auto pi  = w.pi(w.type<7>(), w.type<2>());
     EXPECT_EQ(Lit::as(pi->type()->isa<Type>()->level()), 8);
 }
+
+TEST(Sym, cmp) {
+    Driver driver;
+    auto abc = driver.sym("abc");
+    auto b   = driver.sym("b");
+
+    EXPECT_GT(b, 'a');
+    EXPECT_EQ(b, 'b');
+    EXPECT_LT(b, 'c');
+    EXPECT_GT(abc, 'a');
+    EXPECT_LT(abc, 'b');
+    EXPECT_NE(b, 'a');
+    EXPECT_EQ(b, 'b');
+}

--- a/thorin/be/h/bootstrap.cpp
+++ b/thorin/be/h/bootstrap.cpp
@@ -59,14 +59,7 @@ void bootstrap(Driver& driver, Sym plugin, std::ostream& h) {
         --tab;
         tab.print(h, "}};\n\n");
 
-        if (!ax.subs.empty()) {
-            tab.print(h, "inline bool operator==({} lhs, flags_t rhs) {{ return static_cast<flags_t>(lhs) == rhs; }}\n", ax.tag);
-            tab.print(h, "inline flags_t operator&({} lhs, flags_t rhs) {{ return static_cast<flags_t>(lhs) & rhs; }}\n", ax.tag);
-            tab.print(h, "inline flags_t operator&({} lhs, {} rhs) {{ return static_cast<flags_t>(lhs) & static_cast<flags_t>(rhs); }}\n", ax.tag, ax.tag);
-            tab.print(h, "inline flags_t operator|({} lhs, flags_t rhs) {{ return static_cast<flags_t>(lhs) | rhs; }}\n", ax.tag);
-            tab.print(h, "inline flags_t operator|({} lhs, {} rhs) {{ return static_cast<flags_t>(lhs) | static_cast<flags_t>(rhs); }}\n\n", ax.tag, ax.tag);
-        }
-
+        if (!ax.subs.empty()) tab.print(h, "THORIN_ENUM_OPERATORS({})\n", ax.tag);
         print(outer_namespace.emplace_back(), "template<> constexpr size_t Axiom::Num<{}::{}> = {};\n", plugin, ax.tag, ax.subs.size());
 
         if (ax.normalizer) {

--- a/thorin/def.h
+++ b/thorin/def.h
@@ -144,16 +144,7 @@ enum class Dep : unsigned {
     Var   = 1 << 4,
 };
 
-inline unsigned operator&(Dep d1, Dep d2) { return unsigned(d1) & unsigned(d2); }
-inline unsigned operator|(Dep d1, Dep d2) { return unsigned(d1) | unsigned(d2); }
-inline unsigned operator&(unsigned d1, Dep d2) { return d1 & unsigned(d2); }
-inline unsigned operator|(unsigned d1, Dep d2) { return d1 | unsigned(d2); }
-inline unsigned operator&(Dep d1, unsigned d2) { return unsigned(d1) & d2; }
-inline unsigned operator|(Dep d1, unsigned d2) { return unsigned(d1) | d2; }
-inline unsigned operator==(unsigned d1, Dep d2) { return d1 == unsigned(d2); }
-inline unsigned operator!=(unsigned d1, Dep d2) { return d1 != unsigned(d2); }
-inline unsigned operator==(Dep d1, unsigned d2) { return unsigned(d1) == d2; }
-inline unsigned operator!=(Dep d1, unsigned d2) { return unsigned(d1) != d2; }
+THORIN_ENUM_OPERATORS(Dep)
 ///@}
 
 /// Use as mixin to wrap all kind of Def::proj and Def::projs variants.

--- a/thorin/fe/scopes.cpp
+++ b/thorin/fe/scopes.cpp
@@ -11,7 +11,7 @@ void Scopes::pop() {
 
 const Def* Scopes::find(Dbg dbg) const {
     auto [loc, sym] = dbg;
-    if (sym == '_') error(loc, "the symbol '_' is special and never binds to anything", sym);
+    if (sym == '_') error(loc, "the symbol '_' is special and never binds to anything");
 
     for (auto& scope : scopes_ | std::ranges::views::reverse)
         if (auto i = scope.find(sym); i != scope.end()) return i->second.second;

--- a/thorin/util/sym.h
+++ b/thorin/util/sym.h
@@ -36,13 +36,11 @@ public:
 
     /// @name Comparisons
     ///@{
-    auto operator<=>(Sym other) const { return *(*this) <=> *other; }
+    auto operator<=>(char c) const { return (*this)->size() == 0 ? std::strong_ordering::less : (*this)[0] <=> c; }
+    auto operator==(char c) const { return (*this) <=> c == std::strong_ordering::equal; }
+    auto operator<=>(Sym other) const { return **this <=> *other; }
     bool operator==(Sym other) const { return this->ptr_ == other.ptr_; }
     bool operator!=(Sym other) const { return this->ptr_ != other.ptr_; }
-    bool operator==(char c) const { return (*this)->size() == 1 && (*this)[0] == c; }
-    bool operator!=(char c) const { return !((*this) == c); }
-    friend bool operator==(char c, Sym s) { return s == c; }
-    friend bool operator!=(char c, Sym s) { return s != c; }
     ///@}
 
     /// @name Cast Operators

--- a/thorin/util/sym.h
+++ b/thorin/util/sym.h
@@ -40,7 +40,7 @@ public:
         if ((*this)->size() == 0) return std::strong_ordering::less;
         auto cmp = (*this)[0] <=> c;
         if ((*this)->size() == 1) return cmp;
-        return (*this)[0] == c ? std::strong_ordering::greater : cmp;
+        return cmp == 0 ? std::strong_ordering::greater : cmp;
     }
     auto operator==(char c) const { return (*this) <=> c == std::strong_ordering::equal; }
     auto operator<=>(Sym other) const { return **this <=> *other; }

--- a/thorin/util/sym.h
+++ b/thorin/util/sym.h
@@ -36,11 +36,11 @@ public:
 
     /// @name Comparisons
     ///@{
-    bool operator==(char c) const { return (*this)->size() == 1 && (*this)[0] == c; }
-    bool operator!=(char c) const { return !((*this) == c); }
+    auto operator<=>(Sym other) const { return *(*this) <=> *other; }
     bool operator==(Sym other) const { return this->ptr_ == other.ptr_; }
     bool operator!=(Sym other) const { return this->ptr_ != other.ptr_; }
-    auto operator<=>(Sym other) const { return *(*this) <=> *other; }
+    bool operator==(char c) const { return (*this)->size() == 1 && (*this)[0] == c; }
+    bool operator!=(char c) const { return !((*this) == c); }
     friend bool operator==(char c, Sym s) { return s == c; }
     friend bool operator!=(char c, Sym s) { return s != c; }
     ///@}

--- a/thorin/util/sym.h
+++ b/thorin/util/sym.h
@@ -36,7 +36,12 @@ public:
 
     /// @name Comparisons
     ///@{
-    auto operator<=>(char c) const { return (*this)->size() == 0 ? std::strong_ordering::less : (*this)[0] <=> c; }
+    auto operator<=>(char c) const {
+        if ((*this)->size() == 0) return std::strong_ordering::less;
+        auto cmp = (*this)[0] <=> c;
+        if ((*this)->size() == 1) return cmp;
+        return (*this)[0] == c ? std::strong_ordering::greater : cmp;
+    }
     auto operator==(char c) const { return (*this) <=> c == std::strong_ordering::equal; }
     auto operator<=>(Sym other) const { return **this <=> *other; }
     bool operator==(Sym other) const { return this->ptr_ == other.ptr_; }

--- a/thorin/util/util.h
+++ b/thorin/util/util.h
@@ -3,6 +3,7 @@
 #include <optional>
 #include <queue>
 #include <stack>
+#include <type_traits>
 
 #include <absl/container/flat_hash_map.h>
 #include <absl/container/flat_hash_set.h>
@@ -185,14 +186,33 @@ struct GIDLt {
     bool operator()(T a, T b) const { return a->gid() < b->gid(); }
 };
 
+// clang-format off
 /// @name GID
 ///@{
-// clang-format off
 template<class K, class V> using GIDMap     = absl::flat_hash_map<K, V, GIDHash<K>, GIDEq<K>>;
 template<class K>          using GIDSet     = absl::flat_hash_set<K,    GIDHash<K>, GIDEq<K>>;
 template<class K, class V> using GIDNodeMap = absl::node_hash_map<K, V, GIDHash<K>, GIDEq<K>>;
 template<class K>          using GIDNodeSet = absl::node_hash_set<K,    GIDHash<K>, GIDEq<K>>;
-// clang-format on
 ///@}
+
+/// Use this to declare all kind of bit and comparison operators for an `enum` @p E.
+/// Note that the bit operators return the @p E's underlying type and not the original `enum` @p E.
+/// This is because the result may not be a valid `enum` value.
+/// For the same reason, it doesn't make sense to declare operators such as `&=`.
+#define THORIN_ENUM_OPERATORS(E)                                                                                                                                         \
+    constexpr inline auto operator&  (                       E  x,                       E  y) { return std::underlying_type_t<E>(x)  &  std::underlying_type_t<E>(y); } \
+    constexpr inline auto operator&  (std::underlying_type_t<E> x,                       E  y) { return                           x   &  std::underlying_type_t<E>(y); } \
+    constexpr inline auto operator&  (                       E x, std::underlying_type_t<E> y) { return std::underlying_type_t<E>(x)  &                            y ; } \
+    constexpr inline auto operator|  (                       E x,                        E  y) { return std::underlying_type_t<E>(x)  |  std::underlying_type_t<E>(y); } \
+    constexpr inline auto operator|  (std::underlying_type_t<E> x,                       E  y) { return                           x   |  std::underlying_type_t<E>(y); } \
+    constexpr inline auto operator|  (                       E x, std::underlying_type_t<E> y) { return std::underlying_type_t<E>(x)  |                            y ; } \
+    constexpr inline auto operator^  (                       E x,                        E  y) { return std::underlying_type_t<E>(x)  ^  std::underlying_type_t<E>(y); } \
+    constexpr inline auto operator^  (std::underlying_type_t<E> x,                       E  y) { return                           x   ^  std::underlying_type_t<E>(y); } \
+    constexpr inline auto operator^  (                       E x, std::underlying_type_t<E> y) { return std::underlying_type_t<E>(x)  ^                            y ; } \
+    constexpr inline auto operator<=>(std::underlying_type_t<E> x,                       E  y) { return                           x  <=> std::underlying_type_t<E>(y); } \
+    constexpr inline auto operator<=>(                       E x, std::underlying_type_t<E> y) { return std::underlying_type_t<E>(x) <=>                           y ; } \
+    constexpr inline auto operator== (std::underlying_type_t<E> x,                       E  y) { return                           x  ==  std::underlying_type_t<E>(y); } \
+    constexpr inline auto operator!= (                       E x, std::underlying_type_t<E> y) { return std::underlying_type_t<E>(x) !=                            y ; }
+// clang-format on
 
 } // namespace thorin

--- a/thorin/util/util.h
+++ b/thorin/util/util.h
@@ -199,20 +199,18 @@ template<class K>          using GIDNodeSet = absl::node_hash_set<K,    GIDHash<
 /// Note that the bit operators return the @p E's underlying type and not the original `enum` @p E.
 /// This is because the result may not be a valid `enum` value.
 /// For the same reason, it doesn't make sense to declare operators such as `&=`.
-#define THORIN_ENUM_OPERATORS(E)                                                                                                                                         \
-    constexpr inline auto operator&  (                       E  x,                       E  y) { return std::underlying_type_t<E>(x)  &  std::underlying_type_t<E>(y); } \
-    constexpr inline auto operator&  (std::underlying_type_t<E> x,                       E  y) { return                           x   &  std::underlying_type_t<E>(y); } \
-    constexpr inline auto operator&  (                       E x, std::underlying_type_t<E> y) { return std::underlying_type_t<E>(x)  &                            y ; } \
-    constexpr inline auto operator|  (                       E x,                        E  y) { return std::underlying_type_t<E>(x)  |  std::underlying_type_t<E>(y); } \
-    constexpr inline auto operator|  (std::underlying_type_t<E> x,                       E  y) { return                           x   |  std::underlying_type_t<E>(y); } \
-    constexpr inline auto operator|  (                       E x, std::underlying_type_t<E> y) { return std::underlying_type_t<E>(x)  |                            y ; } \
-    constexpr inline auto operator^  (                       E x,                        E  y) { return std::underlying_type_t<E>(x)  ^  std::underlying_type_t<E>(y); } \
-    constexpr inline auto operator^  (std::underlying_type_t<E> x,                       E  y) { return                           x   ^  std::underlying_type_t<E>(y); } \
-    constexpr inline auto operator^  (                       E x, std::underlying_type_t<E> y) { return std::underlying_type_t<E>(x)  ^                            y ; } \
-    constexpr inline auto operator<=>(std::underlying_type_t<E> x,                       E  y) { return                           x  <=> std::underlying_type_t<E>(y); } \
-    constexpr inline auto operator<=>(                       E x, std::underlying_type_t<E> y) { return std::underlying_type_t<E>(x) <=>                           y ; } \
-    constexpr inline auto operator== (std::underlying_type_t<E> x,                       E  y) { return                           x  ==  std::underlying_type_t<E>(y); } \
-    constexpr inline auto operator!= (                       E x, std::underlying_type_t<E> y) { return std::underlying_type_t<E>(x) !=                            y ; }
+#define THORIN_ENUM_OPERATORS(E)                                                                                                                                        \
+    constexpr inline auto operator&(                       E  x,                        E  y) { return std::underlying_type_t<E>(x)  &  std::underlying_type_t<E>(y); } \
+    constexpr inline auto operator&(std::underlying_type_t<E> x,                        E  y) { return                           x   &  std::underlying_type_t<E>(y); } \
+    constexpr inline auto operator&(                       E  x, std::underlying_type_t<E> y) { return std::underlying_type_t<E>(x)  &                            y ; } \
+    constexpr inline auto operator|(                       E  x,                        E  y) { return std::underlying_type_t<E>(x)  |  std::underlying_type_t<E>(y); } \
+    constexpr inline auto operator|(std::underlying_type_t<E> x,                        E  y) { return                           x   |  std::underlying_type_t<E>(y); } \
+    constexpr inline auto operator|(                       E  x, std::underlying_type_t<E> y) { return std::underlying_type_t<E>(x)  |                            y ; } \
+    constexpr inline auto operator^(                       E  x,                        E  y) { return std::underlying_type_t<E>(x)  ^  std::underlying_type_t<E>(y); } \
+    constexpr inline auto operator^(std::underlying_type_t<E> x,                        E  y) { return                           x   ^  std::underlying_type_t<E>(y); } \
+    constexpr inline auto operator^(                       E  x, std::underlying_type_t<E> y) { return std::underlying_type_t<E>(x)  ^                            y ; } \
+    constexpr inline std::strong_ordering operator<=>(std::underlying_type_t<E> x, E y) { return x <=> std::underlying_type_t<E>(y); }                                 \
+    constexpr inline std::strong_ordering operator<=>(E x, std::underlying_type_t<E> y) { return std::underlying_type_t<E>(x) <=> y; }
 // clang-format on
 
 } // namespace thorin

--- a/thorin/util/util.h
+++ b/thorin/util/util.h
@@ -199,18 +199,20 @@ template<class K>          using GIDNodeSet = absl::node_hash_set<K,    GIDHash<
 /// Note that the bit operators return the @p E's underlying type and not the original `enum` @p E.
 /// This is because the result may not be a valid `enum` value.
 /// For the same reason, it doesn't make sense to declare operators such as `&=`.
-#define THORIN_ENUM_OPERATORS(E)                                                                                                                                        \
-    constexpr inline auto operator&(                       E  x,                        E  y) { return std::underlying_type_t<E>(x)  &  std::underlying_type_t<E>(y); } \
-    constexpr inline auto operator&(std::underlying_type_t<E> x,                        E  y) { return                           x   &  std::underlying_type_t<E>(y); } \
-    constexpr inline auto operator&(                       E  x, std::underlying_type_t<E> y) { return std::underlying_type_t<E>(x)  &                            y ; } \
-    constexpr inline auto operator|(                       E  x,                        E  y) { return std::underlying_type_t<E>(x)  |  std::underlying_type_t<E>(y); } \
-    constexpr inline auto operator|(std::underlying_type_t<E> x,                        E  y) { return                           x   |  std::underlying_type_t<E>(y); } \
-    constexpr inline auto operator|(                       E  x, std::underlying_type_t<E> y) { return std::underlying_type_t<E>(x)  |                            y ; } \
-    constexpr inline auto operator^(                       E  x,                        E  y) { return std::underlying_type_t<E>(x)  ^  std::underlying_type_t<E>(y); } \
-    constexpr inline auto operator^(std::underlying_type_t<E> x,                        E  y) { return                           x   ^  std::underlying_type_t<E>(y); } \
-    constexpr inline auto operator^(                       E  x, std::underlying_type_t<E> y) { return std::underlying_type_t<E>(x)  ^                            y ; } \
-    constexpr inline std::strong_ordering operator<=>(std::underlying_type_t<E> x, E y) { return x <=> std::underlying_type_t<E>(y); }                                 \
-    constexpr inline std::strong_ordering operator<=>(E x, std::underlying_type_t<E> y) { return std::underlying_type_t<E>(x) <=> y; }
+#define THORIN_ENUM_OPERATORS(E)                                                                                                                                 \
+    constexpr auto operator&(                       E  x,                        E  y) { return std::underlying_type_t<E>(x)  &  std::underlying_type_t<E>(y); } \
+    constexpr auto operator&(std::underlying_type_t<E> x,                        E  y) { return                           x   &  std::underlying_type_t<E>(y); } \
+    constexpr auto operator&(                       E  x, std::underlying_type_t<E> y) { return std::underlying_type_t<E>(x)  &                            y ; } \
+    constexpr auto operator|(                       E  x,                        E  y) { return std::underlying_type_t<E>(x)  |  std::underlying_type_t<E>(y); } \
+    constexpr auto operator|(std::underlying_type_t<E> x,                        E  y) { return                           x   |  std::underlying_type_t<E>(y); } \
+    constexpr auto operator|(                       E  x, std::underlying_type_t<E> y) { return std::underlying_type_t<E>(x)  |                            y ; } \
+    constexpr auto operator^(                       E  x,                        E  y) { return std::underlying_type_t<E>(x)  ^  std::underlying_type_t<E>(y); } \
+    constexpr auto operator^(std::underlying_type_t<E> x,                        E  y) { return                           x   ^  std::underlying_type_t<E>(y); } \
+    constexpr auto operator^(                       E  x, std::underlying_type_t<E> y) { return std::underlying_type_t<E>(x)  ^                            y ; } \
+    constexpr std::strong_ordering operator<=>(std::underlying_type_t<E> x, E y) { return x <=> std::underlying_type_t<E>(y); }                                  \
+    constexpr std::strong_ordering operator<=>(E x, std::underlying_type_t<E> y) { return std::underlying_type_t<E>(x) <=> y; }                                  \
+    constexpr bool operator==(std::underlying_type_t<E> x, E y) { return x == std::underlying_type_t<E>(y); }                                                    \
+    constexpr bool operator==(E x, std::underlying_type_t<E> y) { return std::underlying_type_t<E>(x) == y; }
 // clang-format on
 
 } // namespace thorin

--- a/thorin/util/util.h
+++ b/thorin/util/util.h
@@ -196,7 +196,7 @@ template<class K>          using GIDNodeSet = absl::node_hash_set<K,    GIDHash<
 ///@}
 
 /// Use this to declare all kind of bit and comparison operators for an `enum` @p E.
-/// Note that the bit operators return the @p E's underlying type and not the original `enum` @p E.
+/// Note that the bit operators return @p E's underlying type and not the original `enum` @p E.
 /// This is because the result may not be a valid `enum` value.
 /// For the same reason, it doesn't make sense to declare operators such as `&=`.
 #define THORIN_ENUM_OPERATORS(E)                                                                                                                                 \

--- a/thorin/world.h
+++ b/thorin/world.h
@@ -3,6 +3,7 @@
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <type_traits>
 
 #include <absl/container/btree_map.h>
 #include <absl/container/btree_set.h>
@@ -430,6 +431,11 @@ public:
     Ref iapp(Ref callee, Ref arg);
     Ref iapp(Ref callee, Defs args) { return iapp(callee, tuple(args)); }
     Ref iapp(Ref callee, nat_t arg) { return iapp(callee, lit_nat(arg)); }
+    template<class E>
+    Ref iapp(Ref callee, E arg)
+    requires std::is_enum_v<E> && std::is_same_v<std::underlying_type_t<E>, nat_t> {
+        return iapp(callee, lit_nat((nat_t)arg));
+    }
 
     // clang-format off
     template<class Id, class... Args> const Def* call(Id id, Args&&... args) { return call_(ax(id),   std::forward<Args>(args)...); }

--- a/thorin/world.h
+++ b/thorin/world.h
@@ -566,10 +566,10 @@ private:
             assert(index_ % alignof(T) == 0);
         }
 
-        static constexpr inline size_t align(size_t n) { return (n + (sizeof(void*) - 1)) & ~(sizeof(void*) - 1); }
+        static constexpr size_t align(size_t n) { return (n + (sizeof(void*) - 1)) & ~(sizeof(void*) - 1); }
 
         template<class T>
-        static constexpr inline size_t num_bytes_of(size_t num_ops) {
+        static constexpr size_t num_bytes_of(size_t num_ops) {
             size_t result = sizeof(Def) + sizeof(void*) * num_ops;
             return align(result);
         }


### PR DESCRIPTION
```c++
enum class E {
    A = 1,
    B = 2,
    C = 4,
};

THORIN_ENUM_OPERATORS(E)
//...
auto x = E::A | E::B;
auto y = x ^ E::C;
```

Also switching to scoped `enum`s at some spots like `core::Mode`, `math::Mode`, etc.