### PR TITLE
Refactor/set2

### DIFF
--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -70,9 +70,6 @@ int main(int argc, char** argv) {
         // clang-format on
 
         if (auto result = cli.parse({argc, argv}); !result) throw std::invalid_argument(result.message());
-#if 0
-        flags.break_on_error = true;
-#endif
 
         if (show_help) {
             std::cout << cli << std::endl;

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -70,6 +70,9 @@ int main(int argc, char** argv) {
         // clang-format on
 
         if (auto result = cli.parse({argc, argv}); !result) throw std::invalid_argument(result.message());
+#if 0
+        flags.break_on_error = true;
+#endif
 
         if (show_help) {
             std::cout << cli << std::endl;

--- a/dialects/clos/pass/rw/clos2sjlj.cpp
+++ b/dialects/clos/pass/rw/clos2sjlj.cpp
@@ -163,8 +163,9 @@ void Clos2SJLJ::enter() {
     assert(m0->type() == mem::type_mem(w));
     auto [m1, tag] = op_setjmp(m0, cur_jbuf_)->projs<2>();
     tag            = w.call(core::conv::s, branches.size(), tag);
+    auto filter    = curr_mut()->filter();
     auto branch    = w.extract(w.tuple(branches), tag);
-    curr_mut()->reset(curr_mut()->filter(), clos_apply(branch, m1));
+    curr_mut()->unset()->set({filter, clos_apply(branch, m1)});
 }
 
 Ref Clos2SJLJ::rewrite(Ref def) {

--- a/dialects/clos/pass/rw/clos2sjlj.cpp
+++ b/dialects/clos/pass/rw/clos2sjlj.cpp
@@ -131,7 +131,7 @@ void Clos2SJLJ::enter() {
 
         auto new_args = curr_mut()->vars();
         new_args[0]   = m2;
-        curr_mut()->set(curr_mut()->reduce(w.tuple(new_args)));
+        curr_mut()->reset(curr_mut()->reduce(w.tuple(new_args)));
 
         cur_jbuf_ = jb;
         cur_rbuf_ = rb;
@@ -164,7 +164,7 @@ void Clos2SJLJ::enter() {
     auto [m1, tag] = op_setjmp(m0, cur_jbuf_)->projs<2>();
     tag            = w.call(core::conv::s, branches.size(), tag);
     auto branch    = w.extract(w.tuple(branches), tag);
-    curr_mut()->set_body(clos_apply(branch, m1));
+    curr_mut()->reset(curr_mut()->filter(), clos_apply(branch, m1));
 }
 
 Ref Clos2SJLJ::rewrite(Ref def) {

--- a/dialects/clos/pass/rw/clos2sjlj.cpp
+++ b/dialects/clos/pass/rw/clos2sjlj.cpp
@@ -165,7 +165,7 @@ void Clos2SJLJ::enter() {
     tag            = w.call(core::conv::s, branches.size(), tag);
     auto filter    = curr_mut()->filter();
     auto branch    = w.extract(w.tuple(branches), tag);
-    curr_mut()->unset()->set({filter, clos_apply(branch, m1)});
+    curr_mut()->reset({filter, clos_apply(branch, m1)});
 }
 
 Ref Clos2SJLJ::rewrite(Ref def) {

--- a/dialects/clos/phase/clos_conv.cpp
+++ b/dialects/clos/phase/clos_conv.cpp
@@ -146,7 +146,7 @@ void ClosConv::rewrite_body(Lam* new_lam, Def2Def& subst) {
 
     auto filter = rewrite(new_fn->filter(), subst);
     auto body   = rewrite(new_fn->body(), subst);
-    new_fn->reset(filter, body);
+    new_fn->unset()->set({filter, body});
 }
 
 const Def* ClosConv::rewrite(const Def* def, Def2Def& subst) {

--- a/dialects/clos/phase/clos_conv.cpp
+++ b/dialects/clos/phase/clos_conv.cpp
@@ -295,7 +295,7 @@ ClosConv::Stub ClosConv::make_stub(const DefSet& fvs, Lam* old_lam, Def2Def& sub
             new_ext_lam->app(false, new_lam, clos_insert_env(env, new_ext_lam->var()));
             new_lam->set(old_lam->filter(), old_lam->body());
         } else {
-            new_ext_lam->set((const Def*)nullptr, (const Def*)nullptr);
+            new_ext_lam->unset();
             new_lam->app(false, new_ext_lam, clos_remove_env(new_lam->var()));
         }
     } else {

--- a/dialects/clos/phase/clos_conv.cpp
+++ b/dialects/clos/phase/clos_conv.cpp
@@ -146,7 +146,7 @@ void ClosConv::rewrite_body(Lam* new_lam, Def2Def& subst) {
 
     auto filter = rewrite(new_fn->filter(), subst);
     auto body   = rewrite(new_fn->body(), subst);
-    new_fn->unset()->set({filter, body});
+    new_fn->reset({filter, body});
 }
 
 const Def* ClosConv::rewrite(const Def* def, Def2Def& subst) {

--- a/dialects/clos/phase/clos_conv.cpp
+++ b/dialects/clos/phase/clos_conv.cpp
@@ -146,7 +146,7 @@ void ClosConv::rewrite_body(Lam* new_lam, Def2Def& subst) {
 
     auto filter = rewrite(new_fn->filter(), subst);
     auto body   = rewrite(new_fn->body(), subst);
-    new_fn->set(filter, body);
+    new_fn->reset(filter, body);
 }
 
 const Def* ClosConv::rewrite(const Def* def, Def2Def& subst) {

--- a/dialects/clos/phase/lower_typed_clos.cpp
+++ b/dialects/clos/phase/lower_typed_clos.cpp
@@ -24,8 +24,9 @@ void LowerTypedClos::start() {
         lvm_ = lvm;
         world().DLOG("in {} (lvm={}, lcm={})", lam, lvm_, lcm_);
         if (lam->is_set()) {
-            lam->set_filter(rewrite(lam->filter()));
-            lam->set_body(rewrite(lam->body()));
+            auto new_f = rewrite(lam->filter());
+            auto new_b = rewrite(lam->body());
+            lam->reset(new_f, new_b);
         }
     }
 }

--- a/dialects/clos/phase/lower_typed_clos.cpp
+++ b/dialects/clos/phase/lower_typed_clos.cpp
@@ -26,7 +26,7 @@ void LowerTypedClos::start() {
         if (lam->is_set()) {
             auto new_f = rewrite(lam->filter());
             auto new_b = rewrite(lam->body());
-            lam->unset()->set({new_f, new_b});
+            lam->reset({new_f, new_b});
         }
     }
 }

--- a/dialects/clos/phase/lower_typed_clos.cpp
+++ b/dialects/clos/phase/lower_typed_clos.cpp
@@ -47,9 +47,9 @@ Lam* LowerTypedClos::make_stub(Lam* lam, enum Mode mode, bool adjust_bb_type) {
     }));
     if (Lam::isa_basicblock(lam) && adjust_bb_type) new_dom = insert_ret(new_dom, dummy_ret_->type());
     auto new_type = w.cn(new_dom);
-    auto new_lam  = lam->stub(w, new_type)->set(lam->sym());
+    auto new_lam  = lam->stub(w, new_type);
     w.DLOG("stub {} ~> {}", lam, new_lam);
-    new_lam->set(lam->filter(), lam->body());
+    if (lam->is_set()) new_lam->set(lam->filter(), lam->body());
     if (lam->is_external()) {
         lam->make_internal();
         new_lam->make_external();

--- a/dialects/clos/phase/lower_typed_clos.cpp
+++ b/dialects/clos/phase/lower_typed_clos.cpp
@@ -26,7 +26,7 @@ void LowerTypedClos::start() {
         if (lam->is_set()) {
             auto new_f = rewrite(lam->filter());
             auto new_b = rewrite(lam->body());
-            lam->reset(new_f, new_b);
+            lam->unset()->set({new_f, new_b});
         }
     }
 }

--- a/dialects/direct/direct.thorin
+++ b/dialects/direct/direct.thorin
@@ -24,8 +24,8 @@
 /// This axiom lets the user call a cps function in direct style.
 /// The function is not converted. Only the call site is changed.
 /// 
-.ax %direct.cps2ds: Π [T: *, U: *] -> (.Cn [T, .Cn U]) -> (T -> U), normalize_cps2ds, 2;
-.ax %direct.cps2ds_dep: Π [T: *, U: T -> *] -> (.Cn [t:T, .Cn ((U t))]) -> (Π [t:T] -> ((U t)));
+.ax %direct.cps2ds: Π [T: *, U: *] -> .Cn [T, .Cn U] -> (T -> U), normalize_cps2ds, 2;
+.ax %direct.cps2ds_dep: Π [T: *, U: T -> *] -> .Cn [t: T, .Cn U t] -> [Π [t:T] -> U t], 2;
 ///
 /// ## Passes and Phases
 /// 

--- a/dialects/direct/passes/cps2ds.cpp
+++ b/dialects/direct/passes/cps2ds.cpp
@@ -96,8 +96,8 @@ const Def* CPS2DS::rewrite_body_(const Def* def) {
             const Def* inst_ret_ty;
             if (auto ty_pi = ty->isa_mut<Pi>()) {
                 auto ty_dom = ty_pi->var();
-                world().DLOG("replace ty_dom: {} : {} <{};{}>", ty_dom, ty_dom->type(),
-                            ty_dom->unique_name(), ty_dom->node_name());
+                world().DLOG("replace ty_dom: {} : {} <{};{}>", ty_dom, ty_dom->type(), ty_dom->unique_name(),
+                             ty_dom->node_name());
 
                 Scope r_scope{ty->as_mut()}; // scope that surrounds ret_ty
                 inst_ret_ty = thorin::rewrite(ret_ty, ty_dom, new_arg, r_scope);

--- a/dialects/direct/passes/cps2ds.cpp
+++ b/dialects/direct/passes/cps2ds.cpp
@@ -99,8 +99,8 @@ const Def* CPS2DS::rewrite_body_(const Def* def) {
                         const Def* inst_ret_ty;
                         if (auto ty_pi = ty->isa_mut<Pi>()) {
                             auto ty_dom = ty_pi->var();
-                            world().DLOG("replace ty_dom: {} : {} <{};{}>", ty_dom, ty_dom->type(), ty_dom->unique_name(),
-                                       ty_dom->node_name());
+                            world().DLOG("replace ty_dom: {} : {} <{};{}>", ty_dom, ty_dom->type(),
+                                         ty_dom->unique_name(), ty_dom->node_name());
 
                             Scope r_scope{ty->as_mut()}; // scope that surrounds ret_ty
                             inst_ret_ty = thorin::rewrite(ret_ty, ty_dom, new_arg, r_scope);

--- a/dialects/direct/passes/cps2ds.cpp
+++ b/dialects/direct/passes/cps2ds.cpp
@@ -97,7 +97,7 @@ const Def* CPS2DS::rewrite_body_(const Def* def) {
             world().DLOG("  curr_lam {}", curr_lam_->sym());
             if (curr_lam_->is_set()) {
                 auto filter = curr_lam_->filter();
-                curr_lam_->unset()->set({filter, cps_call});
+                curr_lam_->reset({filter, cps_call});
             } else {
                 curr_lam_->set(world().lit_ff(), cps_call);
             }

--- a/dialects/direct/passes/cps2ds.cpp
+++ b/dialects/direct/passes/cps2ds.cpp
@@ -94,16 +94,17 @@ const Def* CPS2DS::rewrite_body_(const Def* def) {
             // Generate the cps function call `f a` -> `f_cps(a,cont)`
             auto cps_call = world().app(cps_fun, {new_arg, fun_cont})->set("cps_call");
             world().DLOG("  curr_lam {}", curr_lam_->sym());
-            curr_lam_->set_body(cps_call);
+            if (curr_lam_->is_set())
+                curr_lam_->reset(curr_lam_->filter(), cps_call);
+            else
+                curr_lam_->set(world().lit_ff(), cps_call);
 
             // Fixme: would be great to PE the newly added overhead away..
             // The current PE just does not terminate on loops.. :/
             // TODO: Set filter (inline call wrapper)
             // curr_lam_->set_filter(true);
 
-            // The filter can only be set here (not earlier) as otherwise a debug print causes the "some
-            // operands are set" issue.
-            fun_cont->set_filter(curr_lam_->filter());
+            // fun_cont->set_filter(curr_lam_->filter());
 
             // We write the body context in the newly created continuation that has access to the result
             // (as its argument).

--- a/dialects/direct/passes/cps2ds.h
+++ b/dialects/direct/passes/cps2ds.h
@@ -9,7 +9,7 @@ namespace thorin::direct {
 
 /// This is the second part of ds2cps.
 /// We replace all ds call sites of cps (or ds converted) functions with the cps calls.
-/// `b = f args` becomes `f (args,cont)` with a newly introduced continuation `cont : cn b`.
+/// `b = f args` becomes `f (args,cont)` with a newly introduced continuation `cont: .Cn b`.
 class CPS2DS : public RWPass<CPS2DS, Lam> {
 public:
     CPS2DS(PassMan& man)

--- a/dialects/direct/passes/ds2cps.h
+++ b/dialects/direct/passes/ds2cps.h
@@ -7,8 +7,10 @@ namespace thorin::direct {
 
 /// Converts direct style function to cps functions.
 /// To do so, for each (non-type-level) ds function a corresponding cps function is created:
-/// `f: Π a : A -> B`
-/// `f_cps : cn[a:A, cn B]`
+/// ```
+/// f:     Π a: A -> B
+/// f_cps: .Cn [a: A, .Cn B]
+/// ```
 /// Only the type signature of the function is changed and the body is wrapped in the newly added return continuation.
 /// (Technical detail: the arguments are substituted to fit the new function)
 ///

--- a/dialects/mem/passes/rw/reshape.cpp
+++ b/dialects/mem/passes/rw/reshape.cpp
@@ -142,8 +142,8 @@ Lam* Reshape::reshape_lam(Lam* old_lam) {
 
     if (name != "main") { // TODO I don't this is correct. we should check for old_lam->is_external
         // TODO maybe use new_lam->debug_suff("_reshape"), instead?
-        name          = name + "_reshape";
-        new_lam       = world().mut_lam(new_ty)->set((name));
+        name              = name + "_reshape";
+        new_lam           = world().mut_lam(new_ty)->set((name));
         old2new_[old_lam] = new_lam;
     } else {
         new_lam = old_lam;

--- a/dialects/mem/passes/rw/reshape.cpp
+++ b/dialects/mem/passes/rw/reshape.cpp
@@ -167,7 +167,7 @@ Lam* Reshape::reshape_lam(Lam* old_lam) {
     // old2new_[new_arg] = new_arg;
 
     auto new_body = rewrite_def(old_lam->body());
-    if (new_lam->is_set()) new_lam->unset();
+    new_lam->unset();
     new_lam->set(true, new_body);
 
     if (old_lam->is_external()) {

--- a/dialects/mem/passes/rw/reshape.cpp
+++ b/dialects/mem/passes/rw/reshape.cpp
@@ -138,12 +138,9 @@ Lam* Reshape::reshape_lam(Lam* old_lam) {
     auto new_ty = reshape_type(pi_ty)->as<Pi>();
 
     Lam* new_lam;
-    auto name = *old_lam->sym();
-
-    if (name != "main") { // TODO I don't this is correct. we should check for old_lam->is_external
-        // TODO maybe use new_lam->debug_suff("_reshape"), instead?
-        name              = name + "_reshape";
-        new_lam           = world().mut_lam(new_ty)->set((name));
+    if (*old_lam->sym() != "main") { // TODO I don't this is correct. we should check for old_lam->is_external
+        new_lam = old_lam->stub(world(), new_ty);
+        new_lam->debug_suffix("_reshape");
         old2new_[old_lam] = new_lam;
     } else {
         new_lam = old_lam;
@@ -169,7 +166,9 @@ Lam* Reshape::reshape_lam(Lam* old_lam) {
     // TODO: Remove after testing.
     // old2new_[new_arg] = new_arg;
 
-    new_lam->set(true, rewrite_def(old_lam->body()));
+    auto new_body = rewrite_def(old_lam->body());
+    if (new_lam->is_set()) new_lam->unset();
+    new_lam->set(true, new_body);
 
     if (old_lam->is_external()) {
         old_lam->make_internal();

--- a/dialects/mem/passes/rw/reshape.cpp
+++ b/dialects/mem/passes/rw/reshape.cpp
@@ -138,10 +138,12 @@ Lam* Reshape::reshape_lam(Lam* old_lam) {
     auto new_ty = reshape_type(pi_ty)->as<Pi>();
 
     Lam* new_lam;
+    auto name = *old_lam->sym();
 
-    if (!old_lam->is_external()) {
-        new_lam = world().mut_lam(new_ty)->set(old_lam->dbg());
-        new_lam->debug_suffix("_reshape");
+    if (name != "main") { // TODO I don't this is correct. we should check for old_lam->is_external
+        // TODO maybe use new_lam->debug_suff("_reshape"), instead?
+        name          = name + "_reshape";
+        new_lam       = world().mut_lam(new_ty)->set((name));
         old2new_[old_lam] = new_lam;
     } else {
         new_lam = old_lam;
@@ -167,9 +169,7 @@ Lam* Reshape::reshape_lam(Lam* old_lam) {
     // TODO: Remove after testing.
     // old2new_[new_arg] = new_arg;
 
-    auto new_body = rewrite_def(old_lam->body());
-    if (new_lam->is_set()) new_lam->unset();
-    new_lam->set(true, new_body);
+    new_lam->set(true, rewrite_def(old_lam->body()));
 
     if (old_lam->is_external()) {
         old_lam->make_internal();

--- a/dialects/mem/phases/rw/add_mem.cpp
+++ b/dialects/mem/phases/rw/add_mem.cpp
@@ -164,13 +164,15 @@ const Def* AddMem::add_mem_to_lams(Lam* curr_lam, const Def* def) {
         for (size_t i = 0; i < lam->num_vars() && new_lam->num_vars() > 1; ++i)
             mem_rewritten_[lam->var(i)] = new_lam->var(i + var_offset);
 
-        mem_rewritten_[new_lam]           = new_lam;
-        mem_rewritten_[lam]               = new_lam;
-        val2mem_[new_lam]                 = new_lam->var(0_s);
-        val2mem_[lam]                     = new_lam->var(0_s);
-        mem_rewritten_[new_lam->var(0_s)] = new_lam->var(0_s);
-        for (size_t i = 0, n = new_lam->num_ops(); i < n; ++i)
-            if (auto op = lam->op(i)) static_cast<Def*>(new_lam)->reset(i, add_mem_to_lams(lam, op));
+        auto var                = new_lam->var(0_n);
+        mem_rewritten_[new_lam] = new_lam;
+        mem_rewritten_[lam]     = new_lam;
+        val2mem_[new_lam]       = var;
+        val2mem_[lam]           = var;
+        mem_rewritten_[var]     = var;
+        auto filter             = add_mem_to_lams(lam, lam->filter());
+        auto body               = add_mem_to_lams(lam, lam->body());
+        new_lam->unset()->set({filter, body});
 
         if (lam != new_lam && lam->is_external()) {
             lam->make_internal();

--- a/thorin/check.cpp
+++ b/thorin/check.cpp
@@ -18,7 +18,7 @@ const Def* Infer::find(const Def* def) {
     // path compression: set all Infers along the chain to res
     for (auto infer = def->isa_mut<Infer>(); infer && infer->op(); infer = def->isa_mut<Infer>()) {
         def = infer->op();
-        infer->set(res);
+        infer->reset(res);
     }
 
     assert((!res->isa<Infer>() || res != res->op(0)) && "an Infer shouldn't point to itself");

--- a/thorin/check.cpp
+++ b/thorin/check.cpp
@@ -18,7 +18,7 @@ const Def* Infer::find(const Def* def) {
     // path compression: set all Infers along the chain to res
     for (auto infer = def->isa_mut<Infer>(); infer && infer->op(); infer = def->isa_mut<Infer>()) {
         def = infer->op();
-        infer->unset()->set(res);
+        infer->reset(res);
     }
 
     assert((!res->isa<Infer>() || res != res->op(0)) && "an Infer shouldn't point to itself");

--- a/thorin/check.cpp
+++ b/thorin/check.cpp
@@ -18,7 +18,7 @@ const Def* Infer::find(const Def* def) {
     // path compression: set all Infers along the chain to res
     for (auto infer = def->isa_mut<Infer>(); infer && infer->op(); infer = def->isa_mut<Infer>()) {
         def = infer->op();
-        infer->reset(res);
+        infer->unset()->set(res);
     }
 
     assert((!res->isa<Infer>() || res != res->op(0)) && "an Infer shouldn't point to itself");

--- a/thorin/check.h
+++ b/thorin/check.h
@@ -19,6 +19,7 @@ public:
     ///@{
     const Def* op() const { return Def::op(0); }
     Infer* set(const Def* op) { return Def::set(0, op)->as<Infer>(); }
+    Infer* reset(const Def* op) { return unset()->as<Infer>()->set(op); }
     ///@}
 
     /// @name union-find

--- a/thorin/check.h
+++ b/thorin/check.h
@@ -19,7 +19,7 @@ public:
     ///@{
     const Def* op() const { return Def::op(0); }
     Infer* set(const Def* op) { return Def::set(0, op)->as<Infer>(); }
-    Infer* reset(const Def* op) { return unset()->as<Infer>()->set(op); }
+    Infer* unset() { return Def::unset()->as<Infer>(); }
     ///@}
 
     /// @name union-find

--- a/thorin/check.h
+++ b/thorin/check.h
@@ -19,7 +19,7 @@ public:
     ///@{
     const Def* op() const { return Def::op(0); }
     Infer* set(const Def* op) { return Def::set(0, op)->as<Infer>(); }
-    Infer* unset() { return Def::unset()->as<Infer>(); }
+    Infer* reset(const Def* op) { return Def::reset(0, op)->as<Infer>(); }
     ///@}
 
     /// @name union-find

--- a/thorin/def.cpp
+++ b/thorin/def.cpp
@@ -360,24 +360,16 @@ void Def::finalize() {
 }
 
 Def* Def::set(size_t i, const Def* def) {
-    if (op(i)) {
-        world().ELOG("You should Def::unset() this whole Def beforehand!");
-        unset(i);
+    assert(def && !op(i));
+    ops_ptr()[i]  = def;
+    const auto& p = def->uses_.emplace(this, i);
+    assert_unused(p.second);
+
+    if (i == num_ops() - 1) {
+        check();
+        update();
     }
 
-    if (def != nullptr) {
-        ops_ptr()[i]  = def;
-        const auto& p = def->uses_.emplace(this, i);
-        assert_unused(p.second);
-
-        // TODO check that others are set
-        if (i == num_ops() - 1) {
-            check();
-            update();
-        }
-    } else {
-        world().ELOG("You shouldn't invoke with nullptr: 'Def::set({}, nullptr)'", i);
-    }
     return this;
 }
 

--- a/thorin/def.cpp
+++ b/thorin/def.cpp
@@ -361,7 +361,7 @@ void Def::finalize() {
 
 Def* Def::set(size_t i, const Def* def) {
     if (op(i)) {
-        world().WLOG("You should Def::unset() this whole Def beforehand!");
+        world().ELOG("You should Def::unset() this whole Def beforehand!");
         unset(i);
     }
 
@@ -376,7 +376,7 @@ Def* Def::set(size_t i, const Def* def) {
             update();
         }
     } else {
-        world().WLOG("You shouldn't invoke with nullptr: 'Def::set({}, nullptr)'", i);
+        world().ELOG("You shouldn't invoke with nullptr: 'Def::set({}, nullptr)'", i);
     }
     return this;
 }

--- a/thorin/def.cpp
+++ b/thorin/def.cpp
@@ -374,11 +374,9 @@ Def* Def::set(size_t i, const Def* def) {
 }
 
 Def* Def::unset(size_t i) {
-    if (auto def = op(i)) {
-        assert(def->uses_.contains(Use(this, i)));
-        def->uses_.erase(Use(this, i));
-        ops_ptr()[i] = nullptr;
-    }
+    assert(op(i) && op(i)->uses_.contains(Use(this, i)));
+    op(i)->uses_.erase(Use(this, i));
+    ops_ptr()[i] = nullptr;
     return this;
 }
 

--- a/thorin/def.h
+++ b/thorin/def.h
@@ -287,8 +287,20 @@ public:
     Def*   set(size_t i, const Def* def);
     Def* reset(size_t i, const Def* def) { return unset(i)->set(i, def); }
     Def*   set(Defs ops) { for (size_t i = 0, e = num_ops(); i != e; ++i)   set(i, ops[i]); return this; }
-    Def* unset()         { for (size_t i = 0, e = num_ops(); i != e; ++i) unset(i);         return this; }
     Def* reset(Defs ops) { for (size_t i = 0, e = num_ops(); i != e; ++i) reset(i, ops[i]); return this; }
+
+    Def* unset() {
+        for (size_t i = 0, e = num_ops(); i != e; ++i) {
+            if (op(i))
+                unset(i);
+            else {
+                assert(std::all_of(ops_ptr() + i + 1, ops_ptr() + num_ops(), [](auto op) { return !op; }));
+                break;
+            }
+        }
+        return this;
+    }
+
     // clang-format on
     Def* set_type(const Def*);
     void unset_type();

--- a/thorin/def.h
+++ b/thorin/def.h
@@ -274,13 +274,16 @@ public:
     size_t num_ops() const { return num_ops_; }
     ///@}
 
-    /// @name set/unset/reset ops (mutables only)
+    /// @name Setting Ops (Mutables Only)
     /// @anchor set_ops
     ///@{
-    /// When setting/updating operands, you have to obey the following rules:
+    /// You can set and change the Def::ops of a mutable after construction.
+    /// However, you have to obey the following rules:
     /// 1. If Def::is_set() is ...
-    ///     1. ... `true`, Def::set the operands from left (`i == 0`) to right (`i == num_ops() - 1`).
-    ///     2. ... `false`, Def::reset the operands from left to right as in 1a.
+    ///     1. ... `false`, [set](@ref Def::set) the [operands](@ref Def::ops) from
+    ///         * left (`i == 0`) to
+    ///         * right (`i == num_ops() - 1`).
+    ///     2. ... `true`, [reset](@ref Def::reset) the operands from left to right as in 1a.
     /// 2. In addition, you can invoke Def::unset() at *any time* to start over with 1a:
     /// ```
     /// mut->unset()->set({a, b, c}); // This will always work, but should be your last resort.

--- a/thorin/fe/ast.cpp
+++ b/thorin/fe/ast.cpp
@@ -44,7 +44,7 @@ const Def* TuplePtrn::type(World& world, Def2Fields& def2fields) const {
     assert(n > 0);
     auto type  = world.umax<Sort::Type>(ops);
     auto sigma = world.mut_sigma(type, n)->set(loc(), sym());
-    assert_emplace(def2fields, sigma, Array<Sym>(n, [&](size_t i) { return ptrn(i)->sym(); }));
+    assert_emplace(def2fields, sigma, Array<Sym>(n, [this](size_t i) { return ptrn(i)->sym(); }));
 
     sigma->set(0, ops[0]);
     for (size_t i = 1; i != n; ++i) {

--- a/thorin/fe/ast.cpp
+++ b/thorin/fe/ast.cpp
@@ -55,7 +55,7 @@ const Def* TuplePtrn::type(World& world, Def2Fields& def2fields) const {
 
     thorin::Scope scope(sigma);
     ScopeRewriter rw(world, scope);
-    //sigma->unset()->set(0, ops[0]);
+    // sigma->unset()->set(0, ops[0]);
     for (size_t i = 1; i != n; ++i) sigma->set(i, rw.rewrite(ops[i]));
 
     if (auto imm = sigma->immutabilize()) return type_ = imm;

--- a/thorin/fe/ast.cpp
+++ b/thorin/fe/ast.cpp
@@ -55,6 +55,7 @@ const Def* TuplePtrn::type(World& world, Def2Fields& def2fields) const {
 
     thorin::Scope scope(sigma);
     ScopeRewriter rw(world, scope);
+    //sigma->unset()->set(0, ops[0]);
     for (size_t i = 1; i != n; ++i) sigma->set(i, rw.rewrite(ops[i]));
 
     if (auto imm = sigma->immutabilize()) return type_ = imm;

--- a/thorin/fe/ast.cpp
+++ b/thorin/fe/ast.cpp
@@ -41,8 +41,7 @@ const Def* TuplePtrn::type(World& world, Def2Fields& def2fields) const {
     if (std::ranges::all_of(ptrns_, [](auto&& b) { return b->is_anonymous(); }))
         return type_ = world.sigma(ops)->set(loc());
 
-    assert(ptrns().size() > 0);
-
+    assert(n > 0);
     auto type  = world.umax<Sort::Type>(ops);
     auto sigma = world.mut_sigma(type, n)->set(loc(), sym());
     assert_emplace(def2fields, sigma, Array<Sym>(n, [&](size_t i) { return ptrn(i)->sym(); }));
@@ -55,8 +54,8 @@ const Def* TuplePtrn::type(World& world, Def2Fields& def2fields) const {
 
     thorin::Scope scope(sigma);
     ScopeRewriter rw(world, scope);
-    // sigma->unset()->set(0, ops[0]);
-    for (size_t i = 1; i != n; ++i) sigma->set(i, rw.rewrite(ops[i]));
+    sigma->reset(0, ops[0]);
+    for (size_t i = 1; i != n; ++i) sigma->reset(i, rw.rewrite(ops[i]));
 
     if (auto imm = sigma->immutabilize()) return type_ = imm;
 

--- a/thorin/fe/parser.cpp
+++ b/thorin/fe/parser.cpp
@@ -779,7 +779,7 @@ Lam* Parser::parse_lam(bool decl) {
         // Now update.
         auto dom = pi->dom();
         codom    = rw.rewrite(codom);
-        pi->unset()->set({dom, codom});
+        pi->reset({dom, codom});
         codom = pi;
     }
 

--- a/thorin/fe/parser.cpp
+++ b/thorin/fe/parser.cpp
@@ -783,8 +783,7 @@ Lam* Parser::parse_lam(bool decl) {
     auto body = accept(Tok::Tag::T_assign) ? parse_decls("body of a lambda") : nullptr;
     if (!body) {
         if (!decl) error(prev(), "body of a lambda expression is mandatory");
-        if (auto [_, __, filter] = funs.back(); filter)
-            error(prev(), "cannot specify filter of a lambda declaration");
+        if (auto [_, __, filter] = funs.back(); filter) error(prev(), "cannot specify filter of a lambda declaration");
     }
 
     for (auto [_, lam, filter] : funs | std::ranges::views::reverse) {

--- a/thorin/fe/parser.cpp
+++ b/thorin/fe/parser.cpp
@@ -772,9 +772,9 @@ Lam* Parser::parse_lam(bool decl) {
         rw.map(lam->var(), pi->var()->set(lam->var()->dbg()));
 
         // Now update.
-        codom = rw.rewrite(codom);
-        pi->set_codom(codom);
-
+        auto dom = pi->dom();
+        codom    = rw.rewrite(codom);
+        pi->unset()->set({dom, codom});
         codom = pi;
     }
 

--- a/thorin/fe/parser.cpp
+++ b/thorin/fe/parser.cpp
@@ -623,10 +623,15 @@ void Parser::parse_ax() {
         error(ax.loc(), "all declarations of axiom '{}' have to be function types if any is", ax);
     info.pi = type->isa<Pi>() != nullptr;
 
-    auto normalizer_name = accept(Tok::Tag::T_comma) ? parse_sym("normalizer of an axiom").sym : Sym();
-    if (!is_new && (info.normalizer && normalizer_name) && info.normalizer != normalizer_name)
+    Sym normalizer;
+    if (ahead().isa(Tok::Tag::T_comma) && ahead(1).isa(Tok::Tag::M_id)) {
+        lex();
+        normalizer = parse_sym("normalizer of an axiom").sym;
+    }
+
+    if (!is_new && (info.normalizer && normalizer) && info.normalizer != normalizer)
         error(ax.loc(), "all declarations of axiom '{}' must use the same normalizer name", ax);
-    info.normalizer = normalizer_name;
+    info.normalizer = normalizer;
 
     auto [curry, trip] = Axiom::infer_curry_and_trip(type);
 

--- a/thorin/lam.h
+++ b/thorin/lam.h
@@ -138,12 +138,12 @@ public:
     /// lam1->app(true, f, arg);
     /// lam2->app(my_filter_def, f, arg);
     /// ```
+    /// @see Def::set_ops
     using Filter = std::variant<bool, const Def*>;
     Lam* set(Defs ops) { return Def::set(ops)->as<Lam>(); }
-    Lam* set(Filter filter, const Def* body) {
-        set_filter(filter);
-        return set_body(body);
-    }
+    Lam* set(Filter filter, const Def* body) { return set_filter(filter)->set_body(body); }
+    Lam* reset(Defs ops) { return Def::unset()->set(ops)->as<Lam>(); }
+    Lam* reset(Filter filter, const Def* body) { return Def::unset()->as<Lam>()->set(filter, body); }
     Lam* set_filter(Filter);
     Lam* set_body(const Def* body) { return Def::set(1, body)->as<Lam>(); }
     /// Set body to an App of @p callee and @p arg.

--- a/thorin/lam.h
+++ b/thorin/lam.h
@@ -140,12 +140,9 @@ public:
     /// ```
     /// @see Def::set_ops
     using Filter = std::variant<bool, const Def*>;
-    Lam* set(Defs ops) { return Def::set(ops)->as<Lam>(); }
     Lam* set(Filter filter, const Def* body) { return set_filter(filter)->set_body(body); }
-    Lam* reset(Defs ops) { return Def::unset()->set(ops)->as<Lam>(); }
-    Lam* reset(Filter filter, const Def* body) { return Def::unset()->as<Lam>()->set(filter, body); }
-    Lam* set_filter(Filter);
-    Lam* set_body(const Def* body) { return Def::set(1, body)->as<Lam>(); }
+    Lam* set_filter(Filter);                                                ///< Set filter first.
+    Lam* set_body(const Def* body) { return Def::set(1, body)->as<Lam>(); } ///< Set body second.
     /// Set body to an App of @p callee and @p arg.
     Lam* app(Filter filter, const Def* callee, const Def* arg);
     /// Set body to an App of @p callee and @p args.
@@ -153,6 +150,7 @@ public:
     /// Set body to an App of `(f, t)#cond mem`.
     Lam* branch(Filter filter, const Def* cond, const Def* t, const Def* f, const Def* mem);
     Lam* test(Filter filter, const Def* val, const Def* idx, const Def* match, const Def* clash, const Def* mem);
+    Lam* set(Defs ops) { return Def::set(ops)->as<Lam>(); }
     ///@}
 
     Lam* stub(World&, Ref) override;

--- a/thorin/lam.h
+++ b/thorin/lam.h
@@ -60,6 +60,7 @@ public:
 
     /// @name Setters
     ///@{
+    /// @see @ref set_ops "Setting Ops"
     Pi* set_dom(const Def* dom) { return Def::set(0, dom)->as<Pi>(); }
     Pi* set_dom(Defs doms);
     Pi* set_codom(const Def* codom) { return Def::set(1, codom)->as<Pi>(); }
@@ -95,7 +96,6 @@ public:
     ///@}
 
     /// @name dom
-    ///@{
     ///@{
     /// @see @ref proj
     Ref dom() const { return type()->dom(); }
@@ -138,7 +138,7 @@ public:
     /// lam1->app(true, f, arg);
     /// lam2->app(my_filter_def, f, arg);
     /// ```
-    /// @see Def::set_ops
+    /// @see @ref set_ops "Setting Ops"
     using Filter = std::variant<bool, const Def*>;
     Lam* set(Filter filter, const Def* body) { return set_filter(filter)->set_body(body); }
     Lam* set_filter(Filter);                                                ///< Set filter first.

--- a/thorin/pass/rw/ret_wrap.cpp
+++ b/thorin/pass/rw/ret_wrap.cpp
@@ -15,7 +15,7 @@ void RetWrap::enter() {
     assert(new_vars.back() == ret_var && "we assume that the last element is the ret_var");
     new_vars.back() = ret_cont;
     auto new_var    = world().tuple(curr_mut()->dom(), new_vars);
-    curr_mut()->set(curr_mut()->reduce(new_var));
+    curr_mut()->reset(curr_mut()->reduce(new_var));
 }
 
 } // namespace thorin

--- a/thorin/tuple.h
+++ b/thorin/tuple.h
@@ -16,6 +16,7 @@ private:
 public:
     /// @name Setters
     ///@{
+    /// @see @ref set_ops "Setting Ops"
     Sigma* set(size_t i, const Def* def) { return Def::set(i, def)->as<Sigma>(); }
     Sigma* set(Defs ops) { return Def::set(ops)->as<Sigma>(); }
     ///@}
@@ -56,6 +57,11 @@ public:
     ///@{
     const Def* shape() const { return op(0); }
     const Def* body() const { return op(1); }
+    ///@}
+
+    /// @name Setters
+    ///@{
+    /// @see @ref set_ops "Setting Ops"
     Arr* set_shape(const Def* shape) { return Def::set(0, shape)->as<Arr>(); }
     Arr* set_body(const Def* body) { return Def::set(1, body)->as<Arr>(); }
     ///@}
@@ -87,6 +93,11 @@ public:
     const Def* body() const { return op(0); }
     const Arr* type() const { return Def::type()->as<Arr>(); }
     const Def* shape() const { return type()->shape(); }
+    ///@}
+
+    /// @name Setters
+    ///@{
+    /// @see @ref set_ops "Setting Ops"
     Pack* set(const Def* body) { return Def::set(0, body)->as<Pack>(); }
     ///@}
 


### PR DESCRIPTION
# Changes

## Restricting Write Access for Mutables

I'm currently working on (implicitly) maintaining the nesting structure of a Thorin program. One major headache is that right now, you can arbitrarily change the ops of a mutable. With this patch you can still change the ops of a mutable, but you have to obey certain rules:

1. If Def::is_set() is ...
    1. ... `false`, Def::set the operands from left (`i == 0`) to right (`i == num_ops() - 1`).
    2. ... `true`, Def::reset the operands from left to right as in 1i.
2. In addition, you can invoke Def::unset() at *any time* to start over with 1i:
    ```
    mut->unset()->set({a, b, c}); // This will always work, but should be your last resort.
    ```
Violating these rule will raise an assertion.

Putting aside that these rules will help me to keep track of some infos in a much more efficient way, having these rules in place will also help to prevent you from doing really questionable things - to say at least.

## Other Changes

* This PR already includes #205
* Made some members `private` instead of `protected` in `Def`
* You can now specify a curry/trip count for axioms even if you have not specified a normalizer.
* Using this feature for `%direct.cps2ds_dep`.
* Using `match<direct::cps2ds_dep>` instead of nested `if`s in `cps2ds.cpp`.
* Other simplifications `cps2ds.cpp`
* Some minor changes here and there