### PR TITLE
Refactor/colon

### DIFF
--- a/dialects/autodiff/autodiff.thorin
+++ b/dialects/autodiff/autodiff.thorin
@@ -109,19 +109,19 @@
 ///
 /// The comparison pullback exists formally but is not used.
 ///
-.fun .extern internal_diff_core_icmp_xYgLE !.(s: .Nat)!(ab: «2; .Idx s») -> [.Bool, .Cn[.Bool, .Cn«2; .Idx s»]] =
-    return (%core.icmp.sle ab, .fn ![.Bool] -> «2; .Idx s» = return ‹2; 0:(.Idx s)›);
+.fun .extern internal_diff_core_icmp_xYgLE !.(s: .Nat)!(ab: «2; .Idx s»): [.Bool, .Cn[.Bool, .Cn«2; .Idx s»]] =
+    return (%core.icmp.sle ab, .fn ![.Bool]: «2; .Idx s» = return ‹2; 0:(.Idx s)›);
 ///
 /// ### %core.wrap.add
 ///
 /// s ↦ (s, s)
 ///
-.fun .extern internal_diff_core_wrap_add !.(s: .Nat)!(m: .Nat)!(ab: «2; .Idx s») -> [.Idx s, .Cn[.Idx s, .Cn«2; .Idx s»]] =
-    return (%core.wrap.add m ab, .fn !(i: .Idx s) -> «2; .Idx s» = return ‹2; i›);
+.fun .extern internal_diff_core_wrap_add !.(s: .Nat)!(m: .Nat)!(ab: «2; .Idx s»): [.Idx s, .Cn[.Idx s, .Cn«2; .Idx s»]] =
+    return (%core.wrap.add m ab, .fn !(i: .Idx s): «2; .Idx s» = return ‹2; i›);
 ///
 /// ### %core.wrap.mul
 ///
 /// s ↦ (s*b, s*a)
 ///
-.fun .extern internal_diff_core_wrap_mul !.(s: .Nat)!(m: .Nat)!ab::(a b: .Idx s) -> [.Idx s, .Cn[.Idx s, .Cn«2; .Idx s»]] =
-    return (%core.wrap.mul m ab, .fn !(i: .Idx s) -> «2; .Idx s» = return (%core.wrap.mul m (i, b), %core.wrap.mul m (i, a)));
+.fun .extern internal_diff_core_wrap_mul !.(s: .Nat)!(m: .Nat)!ab::(a b: .Idx s): [.Idx s, .Cn[.Idx s, .Cn«2; .Idx s»]] =
+    return (%core.wrap.mul m ab, .fn !(i: .Idx s): «2; .Idx s» = return (%core.wrap.mul m (i, b), %core.wrap.mul m (i, a)));

--- a/dialects/compile/compile.thorin
+++ b/dialects/compile/compile.thorin
@@ -145,7 +145,7 @@
         (%compile.single_pass_phase %compile.lam_spec_pass)
         (%compile.single_pass_phase %compile.ret_wrap_pass)
 };
-.lam .extern _fallback_compile() -> %compile.Pipeline = default_core_pipeline;
+.lam .extern _fallback_compile(): %compile.Pipeline = default_core_pipeline;
 ///
 /// ### Dependent Passes and Phases
 ///
@@ -154,6 +154,6 @@
 .ax %compile.plugin_select: Π [T:*] -> %compile.Plugin -> T -> T -> T;
 .let plugin_phase = %compile.plugin_select %compile.Phase;
 .let plugin_pass = %compile.plugin_select %compile.Pass;
-.lam plugin_cond_phase!(plugin: %compile.Plugin, phase: %compile.Phase) -> %compile.Phase = plugin_phase plugin phase empty_phase;
-.lam plugin_cond_pass!(plugin: %compile.Plugin, pass: %compile.Pass) -> %compile.Pass = plugin_pass plugin pass empty_pass;
+.lam plugin_cond_phase!(plugin: %compile.Plugin, phase: %compile.Phase): %compile.Phase = plugin_phase plugin phase empty_phase;
+.lam plugin_cond_pass!(plugin: %compile.Plugin, pass: %compile.Pass): %compile.Pass = plugin_pass plugin pass empty_pass;
 

--- a/dialects/core/core.thorin
+++ b/dialects/core/core.thorin
@@ -130,7 +130,7 @@
 ///
 .ax %core.wrap(add, sub, mul, shl): Π.[s: .Nat][m: .Nat][«2; .Idx s»] -> .Idx s, normalize_wrap;
 
-.lam %core.minus!.(s: .Nat)!(m: .Nat)!(a: .Idx s) -> .Idx s = %core.wrap.sub m (0:(.Idx s), a);
+.lam %core.minus!.(s: .Nat)!(m: .Nat)!(a: .Idx s): .Idx s = %core.wrap.sub m (0:(.Idx s), a);
 ///
 /// ### %core.div
 ///

--- a/dialects/math/math.thorin
+++ b/dialects/math/math.thorin
@@ -41,7 +41,7 @@
 .ax %math.arith(add, sub, mul, div, rem):
     Π.[pe: «2; .Nat»][.Nat][«2; %math.F pe»] -> %math.F pe, normalize_arith;
 
-.lam %math.minus!.(pe: «2; .Nat»)!(m: .Nat)!(a: %math.F pe) -> %math.F pe =
+.lam %math.minus!.(pe: «2; .Nat»)!(m: .Nat)!(a: %math.F pe): %math.F pe =
     %math.arith.sub m (0:(%math.F pe), a);
 ///
 /// ### %math.extrema
@@ -236,12 +236,15 @@
 /// ### %math.slf
 /// [Standard logistic function](https://en.wikipedia.org/wiki/Logistic_function) of a floating point number (\f$slf(x) = \frac{1}{1+e^{-x}}\f$)
 ///
-.lam %math.slf!.(pe : <<2; .Nat>>)!(m : .Nat)(x : %math.F pe) -> %math.F pe = %math.arith.div m ((%math.conv.f2f pe 1.0:(%math.F64)), %math.arith.add m ((%math.conv.f2f pe 1.0:(%math.F64)), %math.exp.exp m (%math.minus m x)));
+.lam %math.slf!.(pe : <<2; .Nat>>)!(m : .Nat)(x : %math.F pe): %math.F pe =
+    %math.arith.div m ((%math.conv.f2f pe 1.0:(%math.F64)), %math.arith.add m ((%math.conv.f2f pe 1.0:(%math.F64)), %math.exp.exp m (%math.minus m x)));
 ///
 /// ### %math.sgn
 /// [Sign function](https://en.wikipedia.org/wiki/Sign_function)
-.lam %math.sgn!.(pe : <<2; .Nat>>)!(m : .Nat)!(x : %math.F pe) -> %math.F pe = ((%math.conv.f2f pe -1.0:(%math.F64)), ((%math.conv.f2f pe 0.0:(%math.F64)), (%math.conv.f2f pe 1.0:(%math.F64)))#(%math.cmp.g m (x,(%math.conv.f2f pe 0.0:(%math.F64)))))#(%math.cmp.ge m (x, (%math.conv.f2f pe 0.0:(%math.F64))));
+.lam %math.sgn!.(pe : <<2; .Nat>>)!(m : .Nat)!(x : %math.F pe): %math.F pe =
+    ((%math.conv.f2f pe -1.0:(%math.F64)), ((%math.conv.f2f pe 0.0:(%math.F64)), (%math.conv.f2f pe 1.0:(%math.F64)))#(%math.cmp.g m (x,(%math.conv.f2f pe 0.0:(%math.F64)))))#(%math.cmp.ge m (x, (%math.conv.f2f pe 0.0:(%math.F64))));
 ///
 /// ### %math.rrt
 /// [Reciprocal](https://en.wikipedia.org/wiki/Multiplicative_inverse) of the [square root](https://en.wikipedia.org/wiki/Square_root) (\f$rrt(x) = \frac{1}{\sqrt{x}}\f$)
-.lam %math.rrt!.(pe : <<2; .Nat>>)!(m : .Nat)!(x : %math.F pe) -> %math.F pe = %math.arith.div m (%math.conv.f2f pe 1.0:(%math.F64), %math.rt.sq m x);
+.lam %math.rrt!.(pe : <<2; .Nat>>)!(m : .Nat)!(x : %math.F pe): %math.F pe =
+    %math.arith.div m (%math.conv.f2f pe 1.0:(%math.F64), %math.rt.sq m x);

--- a/dialects/matrix/matrix.thorin
+++ b/dialects/matrix/matrix.thorin
@@ -146,7 +146,7 @@
 ///
 /// Follow the principle `ij <- ik,kj` (`out[i,j] = sum_k in1[i,k] * in2[k,j]`) by using mulplication as combination function and addition as reduction function.
 .lam .extern internal_mapRed_matrix_prod
-    ![m: .Nat, k: .Nat, l: .Nat, [p: .Nat, e:.Nat]] ->
+    ![m: .Nat, k: .Nat, l: .Nat, [p: .Nat, e:.Nat]]:
     (.Cn[
         [%mem.M,%matrix.Mat (2,(m, k),%math.F (p,e)), %matrix.Mat (2,(k, l),%math.F (p,e))],
         .Cn[%mem.M,%matrix.Mat (2,(m, l),%math.F (p,e))]
@@ -201,11 +201,11 @@
 // TODO: check code for 1-matrix edge case
 // TODO: would this automatically be handled by read(transpose) ?
 .lam .extern internal_mapRed_matrix_transpose
-    ![[k: .Nat, l: .Nat], T:*] ->
-    (.Cn[
+    ![[k: .Nat, l: .Nat], T:*]:
+    .Cn[
         [%mem.M,%matrix.Mat (2,(k, l),T)],
         .Cn[%mem.M,%matrix.Mat (2,(l, k),T)]
-    ])
+    ]
     = {
     .con transpose_comb [[mem:%mem.M, acc:T, [a:T]], ret:.Cn[%mem.M,T]] = {
         // We ignore the (zero) accumulator and just return the read value.
@@ -249,7 +249,7 @@
 /// Sums up all elements of a matrix and returns a scalar.
 //  TODO: test 0d matrix (edge cases in code)
 .lam .extern internal_mapRed_matrix_sum
-    ![n: .Nat, S: «n; .Nat», [p:.Nat,e:.Nat]] ->
+    ![n: .Nat, S: «n; .Nat», [p:.Nat,e:.Nat]]:
     (.Cn[
         [%mem.M,%matrix.Mat (n,S,%math.F (p,e))],
         .Cn[%mem.M,%math.F (p,e)]

--- a/dialects/matrix/matrix.thorin
+++ b/dialects/matrix/matrix.thorin
@@ -145,55 +145,37 @@
 /// ### product
 ///
 /// Follow the principle `ij <- ik,kj` (`out[i,j] = sum_k in1[i,k] * in2[k,j]`) by using mulplication as combination function and addition as reduction function.
-.lam .extern internal_mapRed_matrix_prod
-    ![m: .Nat, k: .Nat, l: .Nat, [p: .Nat, e:.Nat]]:
-    (.Cn[
-        [%mem.M,%matrix.Mat (2,(m, k),%math.F (p,e)), %matrix.Mat (2,(k, l),%math.F (p,e))],
-        .Cn[%mem.M,%matrix.Mat (2,(m, l),%math.F (p,e))]
-    ])
-    = {
-    .let R = %math.F (p,e);
+.lam .extern internal_mapRed_matrix_prod!(m k l: .Nat, pe: «2; .Nat»):
+        .Fn [%mem.M, %matrix.Mat (2, (m, k), %math.F pe), %matrix.Mat (2, (k, l), %math.F pe)] -> [%mem.M, %matrix.Mat (2, (m, l), %math.F pe)] =
+    .let R = %math.F pe;
 
-    .con prod_comb [[mem:%mem.M, acc:R, [a:R, b:R]], ret:.Cn[%mem.M,R]] = {
-        .let v = %math.arith.mul 0 (a,b);
+    .fun prod_comb(mem: %mem.M, acc: R, ab: «2; R»): [%mem.M, R] =
+        .let v       = %math.arith.mul 0 ab;
+        .let new_acc = %math.arith.add 0 (acc,v); // reduce op = addition
+        return (mem, new_acc);
 
-        // reduce op = addition
-        .let new_acc = %math.arith.add 0 (acc,v);
-        ret (mem, new_acc)
-    };
-    .con inner_matrix_prod
-        ![
-            [
-                mem:%mem.M,
-                M:%matrix.Mat (2,(m, k),R),
-                N: %matrix.Mat (2,(k, l),R)
-            ],
-            ret: .Cn[%mem.M,%matrix.Mat (2,(m, l),R)]
-        ]
-    = {
-        .let zero_64 = 0.0:(%math.F (52,11));
-        .let zero_real = %math.conv.f2f (p,e) zero_64;
-        ret (
+    .fn !(mem: %mem.M, M: %matrix.Mat (2,(m, k), R), N: %matrix.Mat (2,(k, l), R)):
+            [%mem.M, %matrix.Mat (2,(m, l), R)] =
+        .let zero_64   = 0.0:(%math.F (52,11));
+        .let zero_real = %math.conv.f2f pe zero_64;
+        return (
             %matrix.map_reduce
                 (2, (m, l), R,
                     2,
                     (2, 2),
-                    (R,R),
-                    ((m,k),(k,l))
+                    (R, R),
+                    ((m, k), (k, l))
                 )
                 (
                     mem,
                     zero_real,
                     prod_comb,
                     (
-                        ((0,2), M),
-                        ((2,1), N)
+                        ((0, 2), M),
+                        ((2, 1), N)
                     )
                 )
-        )
-    };
-    inner_matrix_prod
-};
+        );
 ///
 /// ### transpose
 ///

--- a/dialects/mem/mem.thorin
+++ b/dialects/mem/mem.thorin
@@ -21,7 +21,7 @@
 /// At the moment, the *address space* is not really used and a placeholder for future work.
 .ax %mem.Ptr: [*, .Nat] -> *;
 
-.lam %mem.Ptr0 T: * -> * = %mem.Ptr (T, 0);
+.lam %mem.Ptr0 T: * : * = %mem.Ptr (T, 0);
 ///
 /// ## Operations w/ Side Effects
 ///
@@ -86,10 +86,10 @@
 /// @warning Use with caution since you completely remove the `%%mem.M` dependency.
 ///
 .let %mem.m = ⊤:%mem.M;
-.lam %mem.ignore!.(O: *)!(_: %mem.M, o: O) -> O = o;
+.lam %mem.ignore!.(O: *)!(_: %mem.M, o: O): O = o;
 .lam %mem.rm!(n: .Nat, Is: «n; *», O: *)
             !(f: [%mem.M, «i: n; Is#i»] -> [%mem.M, O])
-            !(is: «i: n; Is#i») -> O
+            !(is: «i: n; Is#i»): O
                 = %mem.ignore (f (%mem.m, is));
 ///
 /// ## Passes and Phases

--- a/dialects/opt/opt.thorin
+++ b/dialects/opt/opt.thorin
@@ -20,8 +20,8 @@
 /// ## Passes, Phases, and Pipelines
 ///
 /// ### Pipelines
-/// 
-.lam .extern _default_compile [] -> %compile.Pipeline = {
+///
+.lam .extern _default_compile []: %compile.Pipeline = {
     .let nullptr   = %compile.nullptr_pass;
     .let nullphase = %compile.single_pass_phase nullptr;
     %compile.pipe
@@ -30,7 +30,7 @@
         (%compile.single_pass_phase %compile.eta_red_pass)
         (%compile.single_pass_phase (%compile.tail_rec_elim_pass nullptr))
         // optimize
-        (%compile.pass_phase 
+        (%compile.pass_phase
             (%compile.combine_pass_list (⊤:.Nat)
             (
                 optimization_pass_list,
@@ -58,7 +58,7 @@
         (%compile.single_pass_phase %compile.lam_spec_pass)
         (plugin_cond_phase (%compile.autodiff_plugin, ad_cleanup_phase))
         // CodeGenPrep
-        (%compile.pass_phase 
+        (%compile.pass_phase
             (%compile.combine_pass_list (⊤:.Nat)
             (
                 %compile.pass_list

--- a/docs/langref.md
+++ b/docs/langref.md
@@ -165,9 +165,9 @@ The following tables comprise all production rules:
 | LHS | RHS                                                                                                                                                  | Comment                              | Thorin Class                                        |
 |-----|------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|-----------------------------------------------------|
 | d   | `.let`   (p \| A)  `=` e `;`                                                                                                                         | let                                  | -                                                   |
-| d   | `.lam`   n (`.`? p)+ `→` e<sub>codom</sub> ( `=` d\* e)? `;`                                                                                         | lambda declaration<sup>s</sup>       | [Lam](@ref thorin::Lam)                             |
+| d   | `.lam`   n (`.`? p)+ (`:` e<sub>codom</sub>)? ( `=` d\* e)? `;`                                                                                      | lambda declaration<sup>s</sup>       | [Lam](@ref thorin::Lam)                             |
 | d   | `.con`   n (`.`? p)+                       ( `=` d\* e)? `;`                                                                                         | continuation declaration<sup>s</sup> | [Lam](@ref thorin::Lam)                             |
-| d   | `.fun`   n (`.`? p)+ `→` e<sub>ret</sub>   ( `=` d\* e)? `;`                                                                                         | function declaration<sup>s</sup>     | [Lam](@ref thorin::Lam)                             |
+| d   | `.fun`   n (`.`? p)+ (`:` e<sub>ret</sub>)?   ( `=` d\* e)? `;`                                                                                      | function declaration<sup>s</sup>     | [Lam](@ref thorin::Lam)                             |
 | d   | `.Pi`    n (`:` e<sub>type</sub>)? (`=` e)? `;`                                                                                                      | Pi declaration                       | [Pi](@ref thorin::Pi)                               |
 | d   | `.Sigma` n (`:` e<sub>type</sub> )? (`,` L<sub>arity</sub>)? (`=` b<sub>[ ]</sub>)? `;`                                                              | sigma declaration                    | [Sigma](@ref thorin::Sigma)                         |
 | d   | `.ax`    A `:` e<sub>type</sub> (`(` sa `,` ... `,` sa `)`)? <br> (`,` 𝖨<sub>normalizer</sub>)? (`,` L<sub>curry</sub>)? (`,` L<sub>trip</sub>)? `;` | axiom                                | [Axiom](@ref thorin::Axiom)                         |
@@ -270,18 +270,18 @@ This is particularly useful, when dealing with memory:
 
 #### Functions
 
-| LHS | RHS                                                         | Comment                                        | Thorin Class            |
-|-----|-------------------------------------------------------------|------------------------------------------------|-------------------------|
-| e   | e<sub>dom</sub> `→` e<sub>codom</sub>                       | function type                                  | [Pi](@ref thorin::Pi)   |
-| e   | `Π`   `.`? b (`.`? b<sub>[ ]</sub>)\* `→` e<sub>codom</sub> | dependent function type<sup>s</sup>            | [Pi](@ref thorin::Pi)   |
-| e   | `.Cn` `.`? b (`.`? b<sub>[ ]</sub>)\*                       | continuation type<sup>s</sup>                  | [Pi](@ref thorin::Pi)   |
-| e   | `.Fn` `.`? b (`.`? b<sub>[ ]</sub>)\* `→` e<sub>codom</sub> | returning continuation type<sup>s</sup>        | [Pi](@ref thorin::Pi)   |
-| e   | `λ`   (`.`? p)+ (`→` e<sub>codom</sub>)? `=` d\* e          | lambda expression<sup>s</sup>                  | [Lam](@ref thorin::Lam) |
-| e   | `.cn` (`.`? p)+                          `=` d\* e          | continuation expression<sup>s</sup>            | [Lam](@ref thorin::Lam) |
-| e   | `.fn` (`.`? p)+ (`→` e<sub>codom</sub>)? `=` d\* e          | function expression<sup>s</sup>                | [Lam](@ref thorin::Lam) |
-| e   | e e                                                         | application                                    | [App](@ref thorin::App) |
-| e   | e `@` e                                                     | application making implicit arguments explicit | [App](@ref thorin::App) |
-| e   | `.ret` p `=` e `$` e `;` d\* e                              | ret expresison                                 | [App](@ref thorin::App) |
+| LHS | RHS                                                            | Comment                                        | Thorin Class            |
+|-----|----------------------------------------------------------------|------------------------------------------------|-------------------------|
+| e   | e<sub>dom</sub> `→` e<sub>codom</sub>                          | function type                                  | [Pi](@ref thorin::Pi)   |
+| e   | `Π`   `.`? b (`.`? b<sub>[ ]</sub>)\* (`:` e<sub>codom</sub>)? | dependent function type<sup>s</sup>            | [Pi](@ref thorin::Pi)   |
+| e   | `.Cn` `.`? b (`.`? b<sub>[ ]</sub>)\*                          | continuation type<sup>s</sup>                  | [Pi](@ref thorin::Pi)   |
+| e   | `.Fn` `.`? b (`.`? b<sub>[ ]</sub>)\* (`:` e<sub>ret</sub>)?   | returning continuation type<sup>s</sup>        | [Pi](@ref thorin::Pi)   |
+| e   | `λ`   (`.`? p)+ (`→` e<sub>codom</sub>)? `=` d\* e             | lambda expression<sup>s</sup>                  | [Lam](@ref thorin::Lam) |
+| e   | `.cn` (`.`? p)+                          `=` d\* e             | continuation expression<sup>s</sup>            | [Lam](@ref thorin::Lam) |
+| e   | `.fn` (`.`? p)+ (`→` e<sub>codom</sub>)? `=` d\* e             | function expression<sup>s</sup>                | [Lam](@ref thorin::Lam) |
+| e   | e e                                                            | application                                    | [App](@ref thorin::App) |
+| e   | e `@` e                                                        | application making implicit arguments explicit | [App](@ref thorin::App) |
+| e   | `.ret` p `=` e `$` e `;` d\* e                                 | ret expresison                                 | [App](@ref thorin::App) |
 
 #### Tuples
 
@@ -307,11 +307,7 @@ Expressions nesting is disambiguated according to the following precedence table
 | 3     | e e        | application                                    | left-to-right |
 | 3     | e `@` e    | application making implicit arguments explicit | left-to-right |
 | 4     | `Π` b      | domain of a dependent function type            | -             |
-| 5     | `.fun` n p | function declaration                           | -             |
-| 5     | `.lam` n p | lambda declaration                             | -             |
-| 5     | `.fn` p    | function expression                            | -             |
-| 5     | `λ` p      | lambda expression                              | -             |
-| 6     | e `→` e    | function type                                  | right-to-left |
+| 5     | e `→` e    | function type                                  | right-to-left |
 
 @note The domain of a dependent function type binds slightly stronger than `→`.
 This has the effect that
@@ -326,7 +322,6 @@ Otherwise, `→` would be consumed by the domain:
 ```
 Π T: (* → (T → T)) ↯
 ```
-A similar situation occurs for a `.lam` declaration.
 
 ## Summary: Functions & Types
 
@@ -342,9 +337,9 @@ The following table summarizes the different tokens used for functions declarati
 
 The following function *declarations* are all equivalent:
 ```
-.lam f(T: *)((x y: T), return: T → ⊥) → ⊥ = return x;
-.con f(T: *)((x y: T), return: .Cn T)     = return x;
-.fun f(T: *) (x y: T) → T                 = return x;
+.lam f(T: *)((x y: T), return: T → ⊥): ⊥ = return x;
+.con f(T: *)((x y: T), return: .Cn T)    = return x;
+.fun f(T: *) (x y: T): T                 = return x;
 ```
 
 ### Expressions
@@ -352,10 +347,10 @@ The following function *declarations* are all equivalent:
 The following function *expressions* are all equivalent.
 What is more, since they are bound by a *let declaration*, they have the exact same effect as the function *declarations* above:
 ```
-.let f =   λ (T: *)((x y: T), return: T → ⊥) → ⊥ = return x;
-.let f = .lm (T: *)((x y: T), return: T → ⊥) → ⊥ = return x;
-.let f = .cn (T: *)((x y: T), return: .Cn T)     = return x;
-.let f = .fn (T: *) (x y: T) → T                 = return x;
+.let f =   λ (T: *)((x y: T), return: T → ⊥): ⊥ = return x;
+.let f = .lm (T: *)((x y: T), return: T → ⊥): ⊥ = return x;
+.let f = .cn (T: *)((x y: T), return: .Cn T)    = return x;
+.let f = .fn (T: *) (x y: T): T                 = return x;
 ```
 
 ### Applications

--- a/lit/autodiff/general/ds_inline.thorin
+++ b/lit/autodiff/general/ds_inline.thorin
@@ -4,20 +4,13 @@
 .plugin core;
 
 
-.lam f [a:%core.I32] -> %core.I32 = {
-    .let b = %core.wrap.mul 0 (2:%core.I32, a);
-    b
-};
+.lam f [a:%core.I32]: %core.I32 =
+    %core.wrap.mul 0 (2:%core.I32, a);
 
-.con .extern main [mem : %mem.M, argc : %core.I32, argv : %mem.Ptr (%mem.Ptr (%core.I8, 0), 0), return : .Cn [%mem.M, %core.I32]] = {
-
-    .con ret_cont r::[%core.I32] = {
-        return (mem, r)
-    };
-
+.con .extern main [mem : %mem.M, argc : %core.I32, argv : %mem.Ptr (%mem.Ptr (%core.I8, 0), 0), return : .Cn [%mem.M, %core.I32]] =
+    .con ret_cont r::[%core.I32] = return (mem, r);
     .let c = 42:%core.I32;
     .let r = f c;
-    ret_cont r
-};
+    ret_cont r;
 
 // CHECK-DAG: return{{.*}}84

--- a/lit/clos/malloc.thorin
+++ b/lit/clos/malloc.thorin
@@ -7,7 +7,7 @@
 .con f [mem: %mem.M, x: %core.I32, return: .Cn [%mem.M, %core.I32]] = return (mem, %core.wrap.add 0 (x, 42:%core.I32));
 .con g [mem: %mem.M, x: %core.I32, return: .Cn [%mem.M, %core.I32]] = return (mem, 1:%core.I32);
 
-.fun .extern main(mem: %mem.M, argc: %core.I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; %core.I8», 0)», 0)) -> [%mem.M, %core.I32] = {
+.fun .extern main(mem: %mem.M, argc: %core.I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; %core.I8», 0)», 0)): [%mem.M, %core.I32] = {
     .con h(mem: %mem.M, x: %core.I32, return: .Cn [%mem.M, %core.I32]) = return (mem, %core.wrap.add 0 (x, argc));
 
     .let pb_type  = .Cn [%mem.M, %core.I32, .Cn [%mem.M, %core.I32]];

--- a/lit/compile/default.thorin
+++ b/lit/compile/default.thorin
@@ -10,7 +10,7 @@
 .con .extern main [mem : %mem.M, argc : %core.I32, argv : %mem.Ptr (%mem.Ptr (%core.I8, 0), 0), return : .Cn [%mem.M, %core.I32]] =
     f (mem, 42:%core.I32, return);
 
-.lam .extern _compile [] -> %compile.Pipeline = default_core_pipeline;
+.lam .extern _compile(): %compile.Pipeline = default_core_pipeline;
 
 // CHECK-DAG: .con return
 // CHECK-DAG: return{{.*}}42

--- a/lit/compile/id.thorin
+++ b/lit/compile/id.thorin
@@ -7,7 +7,7 @@
 .con .extern main [mem : %mem.M, argc : %core.I32, argv : %mem.Ptr (%mem.Ptr (%core.I8, 0), 0), return : .Cn [%mem.M, %core.I32]] =
     return (mem, 42:%core.I32);
 
-.lam .extern _compile [] -> %compile.Pipeline =
+.lam .extern _compile(): %compile.Pipeline =
     %compile.pipe
         (%compile.single_pass_phase %compile.internal_cleanup_pass)
         // (%compile.debug_phase 1)

--- a/lit/compile/opt.thorin
+++ b/lit/compile/opt.thorin
@@ -10,7 +10,7 @@
 .con .extern main [mem : %mem.M, argc : %core.I32, argv : %mem.Ptr (%mem.Ptr (%core.I8, 0), 0), return : .Cn [%mem.M, %core.I32]] =
     f (mem, 42:%core.I32, return);
 
-.lam .extern _compile [] -> %compile.Pipeline =
+.lam .extern _compile(): %compile.Pipeline =
     %compile.pipe
         (%compile.single_pass_phase %compile.internal_cleanup_pass)
         optimization_phase;

--- a/lit/compile/ret_wrap.thorin
+++ b/lit/compile/ret_wrap.thorin
@@ -10,7 +10,7 @@
     f (mem, 42:%core.I32, return);
 
 
-.lam .extern _compile [] -> %compile.Pipeline =
+.lam .extern _compile(): %compile.Pipeline =
     %compile.pipe
         (%compile.single_pass_phase %compile.internal_cleanup_pass)
         (%compile.passes_to_phase 1 %compile.ret_wrap_pass);

--- a/lit/compile/two_phase.thorin
+++ b/lit/compile/two_phase.thorin
@@ -10,7 +10,7 @@
 .con .extern main [mem : %mem.M, argc : %core.I32, argv : %mem.Ptr (%mem.Ptr (%core.I8, 0), 0), return : .Cn [%mem.M, %core.I32]] =
     f (mem, 42:%core.I32, return);
 
-.lam .extern _compile [] -> %compile.Pipeline =
+.lam .extern _compile(): %compile.Pipeline =
     %compile.pipe
         (%compile.single_pass_phase %compile.internal_cleanup_pass)
         (%compile.passes_to_phase 1 %compile.ret_wrap_pass)

--- a/lit/compile/unused.thorin
+++ b/lit/compile/unused.thorin
@@ -7,7 +7,7 @@
 .con .extern main [mem : %mem.M, argc : %core.I32, argv : %mem.Ptr (%mem.Ptr (%core.I8, 0), 0), return : .Cn [%mem.M, %core.I32]] =
     return (mem, 42:%core.I32);
 
-.lam .extern _unused_compile [] -> %compile.Pipeline =
+.lam .extern _unused_compile(): %compile.Pipeline =
     %compile.pipe (%compile.single_pass_phase %compile.internal_cleanup_pass);
 
 // CHECK-DAG: return{{.*}}42

--- a/lit/core/1tuple.thorin
+++ b/lit/core/1tuple.thorin
@@ -3,5 +3,5 @@
 // RUN: clang %t.ll -o %t -Wno-override-module -c
 .plugin core;
 
-.fun .extern foo(mem: %mem.M, p: %mem.Ptr0 «23; %core.I32») -> [%mem.M, %mem.Ptr0 %core.I32] =
+.fun .extern foo(mem: %mem.M, p: %mem.Ptr0 «23; %core.I32»): [%mem.M, %mem.Ptr0 %core.I32] =
     return (mem, %core.bitcast (%mem.Ptr0 %core.I32) p);

--- a/lit/core/idx.thorin
+++ b/lit/core/idx.thorin
@@ -2,8 +2,8 @@
 
 .plugin core;
 
-.lam f0!(s: .Nat, i: .Nat) -> .Idx s = %core.idx s 0 i;
-.lam f1!(s: .Nat, i: .Nat) -> .Idx s = %core.idx s 1 i;
+.lam f0!(s: .Nat, i: .Nat): .Idx s = %core.idx s 0 i;
+.lam f1!(s: .Nat, i: .Nat): .Idx s = %core.idx s 1 i;
 
 .lam .extern g0() = f0(42, 23);
 .lam .extern g1() = f1(42, 23);

--- a/lit/direct/2out_2.thorin.disabled
+++ b/lit/direct/2out_2.thorin.disabled
@@ -10,10 +10,10 @@ old var access
 .import core;
 .import direct;
 .import mem;
-.lam Uf_661956 _661974: %core.I32 → ★ = {
+.lam Uf_661956 _661974: %core.I32: ★ = {
     %core.I32
 };
-.lam Uf_662044 _662062: «2; %core.I32» → ★ = {
+.lam Uf_662044 _662062: «2; %core.I32»: ★ = {
     [%core.I32, .Cn [%core.I32, .Cn «2; %core.I32»]]
 };
 .con eta_inner_mul_deriv_cps_662100 _662101::[__662109::[_662113: %core.I32, _662117: %core.I32], ret_662103: .Cn [%core.I32, .Cn [%core.I32, .Cn «2; %core.I32»]]] = {

--- a/lit/direct/ad_mem.thorin
+++ b/lit/direct/ad_mem.thorin
@@ -4,12 +4,9 @@
 .plugin core;
 .plugin direct;
 
-.lam Uf_690595 _690612: %core.I32 → ★ = {
-    [%mem.M, %core.I32]
-};
-.lam Uf_690659 _690676: «2; %core.I32» → ★ = {
-    [%core.I32, .Cn [%core.I32, .Cn «2; %core.I32»]]
-};
+.lam Uf_690595(_690612: %core.I32): ★ = [%mem.M, %core.I32];
+.lam Uf_690659(_690676: «2; %core.I32»): ★ = [%core.I32, .Cn [%core.I32, .Cn «2; %core.I32»]];
+
 .con eta_inner_mul_deriv_cps_690710 _690711::[__690716::[_690720: %core.I32, _690724: %core.I32], ret_690713: .Cn [%core.I32, .Cn [%core.I32, .Cn «2; %core.I32»]]] @(0:(.Idx 2)) = {
     .con mul_pb_690728 __690729::[s_690734: %core.I32, pb_ret_690731: .Cn «2; %core.I32»] @(1:(.Idx 2)) = {
         .let _690746: %core.I32 = %core.wrap.mul 0 (__690716#1:(.Idx 2), s_690734);
@@ -19,7 +16,7 @@
     .let _690727: %core.I32 = %core.wrap.mul 0 __690716;
     ret_690713 (_690727, mul_pb_690728)
 };
-.lam Uf_691251 _691268: «2; %core.I32» → ★ = {
+.lam Uf_691251 _691268: «2; %core.I32»: ★ = {
     [%core.I32, .Cn [%core.I32, .Cn «2; %core.I32»]]
 };
 .con eta_inner_mul_deriv_cps_691294 _691295::[__691299::[_691303: %core.I32, _691307: %core.I32], ret_691297: .Cn [%core.I32, .Cn [%core.I32, .Cn «2; %core.I32»]]] @(0:(.Idx 2)) = {
@@ -31,28 +28,28 @@
     .let _691310: %core.I32 = %core.wrap.mul 0 __691299;
     ret_691297 (_691310, mul_pb_691311)
 };
-.lam Uf_691363 _691380: %core.I32 → ★ = {
+.lam Uf_691363 _691380: %core.I32 : ★ = {
     [%mem.M, %core.I32]
 };
 .con zero_pb_691406 _691407::[%core.I32, _691409: .Cn [%mem.M, %core.I32]] @(1:(.Idx 2)) = {
     _691409 (⊥:%mem.M, 0:(%core.I32))
 };
-.lam Uf_691429 _691446: %core.I32 → ★ = {
+.lam Uf_691429 _691446: %core.I32 : ★ = {
     [%mem.M, %core.I32]
 };
 .con extract_pb_691470 _691471::[s_691476: %core.I32, _691473: .Cn [%mem.M, %core.I32]] @(1:(.Idx 2)) = {
     _691473 (⊥:%mem.M, s_691476)
 };
-.lam Uf_691899 _691916: %core.I32 → ★ = {
+.lam Uf_691899 _691916: %core.I32 : ★ = {
     [%mem.M, %core.I32]
 };
 .con zero_pb_691934 _691935::[%core.I32, _691937: .Cn [%mem.M, %core.I32]] @(1:(.Idx 2)) = {
     _691937 (⊥:%mem.M, 0:(%core.I32))
 };
-.lam Uf_691949 _691966: %core.I32 → ★ = {
+.lam Uf_691949 _691966: %core.I32 : ★ = {
     [%mem.M, %core.I32]
 };
-.lam Uf_692052 _692069: %mem.M → ★ = {
+.lam Uf_692052 _692069: %mem.M : ★ = {
     [%mem.M, %core.I32]
 };
 .con zero_pb_692087 _692088::[%mem.M, _692090: .Cn [%mem.M, %core.I32]] @(1:(.Idx 2)) = {

--- a/lit/direct/ad_mem.thorin.disabled
+++ b/lit/direct/ad_mem.thorin.disabled
@@ -4,10 +4,10 @@
 .plugin core;
 .plugin direct;
 
-.lam Uf_690595 _690612: %core.I32 → ★ = {
+.lam Uf_690595 _690612: %core.I32 : ★ = {
     [%mem.M, %core.I32]
 };
-.lam Uf_690659 _690676: «2; %core.I32» → ★ = {
+.lam Uf_690659 _690676: «2; %core.I32» : ★ = {
     [%core.I32, .Cn [%core.I32, .Cn «2; %core.I32»]]
 };
 .con eta_inner_mul_deriv_cps_690710 _690711::[__690716::[_690720: %core.I32, _690724: %core.I32], ret_690713: .Cn [%core.I32, .Cn [%core.I32, .Cn «2; %core.I32»]]] @(0:(.Idx 2)) = {
@@ -19,7 +19,7 @@
     .let _690727: %core.I32 = %core.wrap.mul %core.i32 0 __690716;
     ret_690713 (_690727, mul_pb_690728)
 };
-.lam Uf_691251 _691268: «2; %core.I32» → ★ = {
+.lam Uf_691251 _691268: «2; %core.I32» : ★ = {
     [%core.I32, .Cn [%core.I32, .Cn «2; %core.I32»]]
 };
 .con eta_inner_mul_deriv_cps_691294 _691295::[__691299::[_691303: %core.I32, _691307: %core.I32], ret_691297: .Cn [%core.I32, .Cn [%core.I32, .Cn «2; %core.I32»]]] @(0:(.Idx 2)) = {
@@ -31,28 +31,28 @@
     .let _691310: %core.I32 = %core.wrap.mul %core.i32 0 __691299;
     ret_691297 (_691310, mul_pb_691311)
 };
-.lam Uf_691363 _691380: %core.I32 → ★ = {
+.lam Uf_691363 _691380: %core.I32 : ★ = {
     [%mem.M, %core.I32]
 };
 .con zero_pb_691406 _691407::[%core.I32, _691409: .Cn [%mem.M, %core.I32]] @(1:(.Idx 2)) = {
     _691409 (⊥:%mem.M, 0:(%core.I32))
 };
-.lam Uf_691429 _691446: %core.I32 → ★ = {
+.lam Uf_691429 _691446: %core.I32 : ★ = {
     [%mem.M, %core.I32]
 };
 .con extract_pb_691470 _691471::[s_691476: %core.I32, _691473: .Cn [%mem.M, %core.I32]] @(1:(.Idx 2)) = {
     _691473 (⊥:%mem.M, s_691476)
 };
-.lam Uf_691899 _691916: %core.I32 → ★ = {
+.lam Uf_691899 _691916: %core.I32 : ★ = {
     [%mem.M, %core.I32]
 };
 .con zero_pb_691934 _691935::[%core.I32, _691937: .Cn [%mem.M, %core.I32]] @(1:(.Idx 2)) = {
     _691937 (⊥:%mem.M, 0:(%core.I32))
 };
-.lam Uf_691949 _691966: %core.I32 → ★ = {
+.lam Uf_691949 _691966: %core.I32 : ★ = {
     [%mem.M, %core.I32]
 };
-.lam Uf_692052 _692069: %mem.M → ★ = {
+.lam Uf_692052 _692069: %mem.M : ★ = {
     [%mem.M, %core.I32]
 };
 .con zero_pb_692087 _692088::[%mem.M, _692090: .Cn [%mem.M, %core.I32]] @(1:(.Idx 2)) = {

--- a/lit/direct/ds2cps.thorin
+++ b/lit/direct/ds2cps.thorin
@@ -5,13 +5,10 @@
 .plugin direct;
 
 
-.lam f [a:%core.I32] -> %core.I32 = {
-    %core.wrap.add 0 (2:%core.I32, a)
-};
+.lam f(a :%core.I32): %core.I32 = %core.wrap.add 0 (2:%core.I32, a);
 
-.con .extern main [mem : %mem.M, argc : %core.I32, argv : %mem.Ptr (%mem.Ptr (%core.I8, 0), 0), return : .Cn [%mem.M, %core.I32]] = {
+.fun .extern main(mem: %mem.M, argc: %core.I32, argv: %mem.Ptr (%mem.Ptr (%core.I8, 0), 0)): [%mem.M, %core.I32] =
     .let c = f 40:%core.I32;
-    return (mem, c)
-};
+    return (mem, c);
 
 // CHECK-DAG: return{{.*}}42

--- a/lit/direct/ds2cps_ax_cps2ds.thorin
+++ b/lit/direct/ds2cps_ax_cps2ds.thorin
@@ -4,7 +4,6 @@
 .plugin core;
 .plugin direct;
 
-
 .con f [a:%core.I32, return: .Cn %core.I32] = {
     .let b = %core.wrap.add 0 (2:%core.I32, a);
     return b

--- a/lit/direct/ds2cps_ax_cps2ds_dependent2.thorin
+++ b/lit/direct/ds2cps_ax_cps2ds_dependent2.thorin
@@ -4,22 +4,16 @@
 .plugin core;
 .plugin direct;
 
-.lam f [n:.Nat, w:.Nat] -> .Cn[.Idx n, .Cn[.Idx n]] = {
-    .con f_cont [a:(.Idx n), return: .Cn (.Idx n)] = {
+.lam f(n: .Nat, w: .Nat): .Fn .Idx n -> .Idx n =
+    .fn (a: .Idx n): .Idx n =
         .let b = %core.conv.u n 42:%core.I32;
         .let c = %core.wrap.add w (a,b);
-        return c
-    };
-    f_cont
-};
+        return c;
 
-.lam U [a:%core.I32] -> * = {
-    %core.I32
-};
+.lam U(a :%core.I32): * = %core.I32;
 
-.con .extern main [mem : %mem.M, argc : %core.I32, argv : %mem.Ptr (%mem.Ptr (%core.I8, 0), 0), return : .Cn [%mem.M, %core.I32]] = {
+.fun .extern main(mem: %mem.M, argc: %core.I32, argv: %mem.Ptr (%mem.Ptr (%core.I8, 0), 0)): [%mem.M, %core.I32] =
     .let c = %direct.cps2ds_dep (%core.I32,U) (f (%core.i32, 0)) 5:%core.I32;
-    return (mem, c)
-};
+    return (mem, c);
 
 // CHECK-DAG: return{{.*}}47

--- a/lit/direct/ds2cps_mixed.thorin
+++ b/lit/direct/ds2cps_mixed.thorin
@@ -5,17 +5,12 @@
 .plugin direct;
 
 
-.lam f [a:%core.I32] -> %core.I32 = {
-    %core.wrap.add 0 (2:%core.I32, a)
-};
+.lam f(a :%core.I32): %core.I32 = %core.wrap.add 0 (2:%core.I32, a);
 
-.con h [mem : %mem.M, a : %core.I32, return : .Cn [%mem.M, %core.I32]] = {
-    .let c = f a;
-    return (mem, c)
-};
+.fun h(mem: %mem.M, a: %core.I32): [%mem.M, %core.I32] =
+    return (mem, f a);
 
-.con .extern main [mem : %mem.M, argc : %core.I32, argv : %mem.Ptr (%mem.Ptr (%core.I8, 0), 0), return : .Cn [%mem.M, %core.I32]] = {
-    h (mem, 40:%core.I32, return)
-};
+.fun .extern main(mem: %mem.M, argc: %core.I32, argv: %mem.Ptr0 (%mem.Ptr0 %core.I8)): [%mem.M, %core.I32] =
+    h ((mem, 40:%core.I32), return);
 
 // CHECK-DAG: return{{.*}}42

--- a/lit/direct/ds2cps_mixed2.thorin
+++ b/lit/direct/ds2cps_mixed2.thorin
@@ -7,9 +7,7 @@
 .plugin direct;
 
 
-.lam f [a:%core.I32] -> %core.I32 = {
-    %core.wrap.add 0 (2:%core.I32, a)
-};
+.lam f [a:%core.I32]: %core.I32 = %core.wrap.add 0 (2:%core.I32, a);
 
 .con h [mem : %mem.M, a : %core.I32, return : .Cn [%mem.M, %core.I32]] = {
     .let c = f a;

--- a/lit/direct/ds2cps_mixed_tuple.thorin
+++ b/lit/direct/ds2cps_mixed_tuple.thorin
@@ -6,18 +6,14 @@
 .plugin core;
 .plugin direct;
 
+.lam f [a:%core.I32]: [%core.I32, %core.I32] =
+    (%core.wrap.add 0 (2:%core.I32, a), %core.wrap.add %core.i32 (3:%core.I32, a));
 
-.lam f [a:%core.I32] -> [%core.I32, %core.I32] = {
-    (%core.wrap.add 0 (2:%core.I32, a), %core.wrap.add %core.i32 (3:%core.I32, a))
-};
-
-.con h [mem : %mem.M, a : %core.I32, return : .Cn [%mem.M, %core.I32]] = {
+.con h [mem : %mem.M, a : %core.I32, return : .Cn [%mem.M, %core.I32]] =
     .let c = f a;
-    return (mem, %core.wrap.add 0 (c#0:(.Idx 2), c#1:(.Idx 2)))
-};
+    return (mem, %core.wrap.add 0 (c#0:(.Idx 2), c#1:(.Idx 2)));
 
-.con .extern main [mem : %mem.M, argc : %core.I32, argv : %mem.Ptr (%mem.Ptr (%core.I8, 0), 0), return : .Cn [%mem.M, %core.I32]] = {
-    h (mem, 40:%core.I32, return)
-};
+.fun .extern main(mem: %mem.M, argc: %core.I32, argv: %mem.Ptr0 (%mem.Ptr0 %core.I8)): [%mem.M, %core.I32] =
+    h (mem, 40:%core.I32, return);
 
 // CHECK-DAG: return{{.*}}85

--- a/lit/direct/mut_dom_bug.thorin
+++ b/lit/direct/mut_dom_bug.thorin
@@ -3,8 +3,8 @@
 
 .lam ForBody [n: .Nat] = [%mem.M, .Idx n] -> %mem.M;
 
-.lam For .[n: .Nat] [start: .Idx n, end: .Idx n] [mem: %mem.M] [it: ForBody n] -> %mem.M = {
-    .lam loop [mem: %mem.M, i: .Idx n] @(%core.pe.known (.Idx n) i) -> [%mem.M, .Idx n] = {
+.lam For .[n: .Nat] [start: .Idx n, end: .Idx n] [mem: %mem.M] [it: ForBody n]: %mem.M = {
+    .lam loop [mem: %mem.M, i: .Idx n] @(%core.pe.known (.Idx n) i) : [%mem.M, .Idx n] = {
         .let `mem = it (mem, i);
 
         .let j   = %core.wrap.add 0 (i, %core.idx n 0 1);
@@ -17,7 +17,7 @@
 };
 
 .con .extern main [mem: %mem.M, ret: .Cn [%mem.M, %core.I32]] = {
-    .let `mem = For (0_123, 122_123) mem (.lm [mem: %mem.M, i: .Idx 123] -> %mem.M = {
+    .let `mem = For (0_123, 122_123) mem (.lm [mem: %mem.M, i: .Idx 123]: %mem.M = {
         // do stuff
         mem
     });

--- a/lit/error/filter2.thorin
+++ b/lit/error/filter2.thorin
@@ -1,3 +1,3 @@
 // RUN: (! %thorin %s 2>&1) | FileCheck %s
-.lam f!() -> [];
+.lam f!(): [];
 // CHECK: error: cannot specify filter of a function declaration

--- a/lit/ext_names.thorin
+++ b/lit/ext_names.thorin
@@ -5,7 +5,7 @@
 
 .Sigma %foo.Shape: □, 3 = [n: .Nat, S: «n; .Nat», T: *];
 .ax %foo.len: %foo.Shape -> .Nat, normalize_len;
-.lam %foo.Ptr s: %foo.Shape -> * = %mem.Ptr0 «%foo.len s; s#T»;
-.lam %foo.Idx s: %foo.Shape -> * = .Idx (%foo.len s);
+.lam %foo.Ptr s: %foo.Shape: * = %mem.Ptr0 «%foo.len s; s#T»;
+.lam %foo.Idx s: %foo.Shape: * = .Idx (%foo.len s);
 
-.lam get(s: %foo.Shape)(mem: %mem.M, p: %foo.Ptr s, i: %foo.Idx s) -> [%mem.M, s#T] = (mem, .bot:(s#T) /* dummy impl */);
+.lam get(s: %foo.Shape)(mem: %mem.M, p: %foo.Ptr s, i: %foo.Idx s): [%mem.M, s#T] = (mem, .bot:(s#T) /* dummy impl */);

--- a/lit/fun.thorin
+++ b/lit/fun.thorin
@@ -3,21 +3,21 @@
 
 .plugin core;
 
-.lam Ptr(T: *) -> * = %mem.Ptr (T, 0);
+.lam Ptr(T: *): * = %mem.Ptr (T, 0);
 
-.fun foo(mem: %mem.M, x: %core.I32)@(%core.icmp.e (x, 23:%core.I32)) -> [%mem.M, %core.I32] =
+.fun foo(mem: %mem.M, x: %core.I32)@(%core.icmp.e (x, 23:%core.I32)): [%mem.M, %core.I32] =
     return (mem, %core.wrap.add 0 (x, 1:%core.I32));
 
-.fun .extern main(mem: %mem.M, argc: %core.I32, argv: Ptr (Ptr %core.I8)) -> [%mem.M, %core.I32] =
+.fun .extern main(mem: %mem.M, argc: %core.I32, argv: Ptr (Ptr %core.I8)): [%mem.M, %core.I32] =
     .ret (`mem, x) = foo $ (mem, 23:%core.I32);
     .ret (`mem, y) = foo $ (mem, 23:%core.I32);
     return (mem, %core.wrap.add 0 (x, y));
 
-.lam f1(T: *)((x y: T), return: T -> ⊥) -> ⊥ = return x;
-.con f2(T: *)((x y: T), return: .Cn T)       = return x;
-.fun f3(T: *) (x y: T)                       = return x;
+.lam f1(T: *)((x y: T), return: T -> ⊥): ⊥ = return x;
+.con f2(T: *)((x y: T), return: .Cn T)     = return x;
+.fun f3(T: *) (x y: T)                     = return x;
 
-.let g1 = .lm (T: *)((x y: T), return: T -> ⊥) -> ⊥ = return x;
+.let g1 = .lm (T: *)((x y: T), return: T -> ⊥): ⊥ = return x;
 .let g2 = .cn (T: *)((x y: T), return: .Cn T)       = return x;
 .let g3 = .fn (T: *) (x y: T)                       = return x;
 
@@ -25,7 +25,7 @@
 .let F2 =.Cn[T:*][T, T][.Cn T];
 .let F3 =.Fn[T:*][T, T] -> T;
 
-.fun bar(cond: .Bool) -> .Nat =
+.fun bar(cond: .Bool): .Nat =
     .con t() =
         .ret res = f1 .Nat $ (23, 42);
         return res;

--- a/lit/main_loop.thorin
+++ b/lit/main_loop.thorin
@@ -6,7 +6,7 @@
 
 .plugin core;
 
-.fun .extern main(mem: %mem.M, argc: %core.I32, argv: %mem.Ptr0 (%mem.Ptr0 %core.I8)) -> [%mem.M, %core.I32] =
+.fun .extern main(mem: %mem.M, argc: %core.I32, argv: %mem.Ptr0 (%mem.Ptr0 %core.I8)): [%mem.M, %core.I32] =
     .con loop(mem: %mem.M, i: %core.I32, acc: %core.I32) =
         .let cond = %core.icmp.ul (i, argc);
         .con body m: %mem.M =

--- a/lit/matrix/transpose_init.thorin
+++ b/lit/matrix/transpose_init.thorin
@@ -4,7 +4,7 @@
 .plugin core;
 .plugin matrix;
 
-.lam ex_internal_mapRed_matrix_transpose![[k: .Nat, l: .Nat], T:*] -> .Cn[[%mem.M, %matrix.Mat (2,(k, l),T)], .Cn [%mem.M, %matrix.Mat (2,(l, k),T)] ] =
+.lam ex_internal_mapRed_matrix_transpose![[k: .Nat, l: .Nat], T:*]: .Cn[[%mem.M, %matrix.Mat (2,(k, l),T)], .Cn [%mem.M, %matrix.Mat (2,(l, k),T)] ] =
     // TODO: or use generalized addition function
     // ignore acc
     .con transpose_comb [[mem:%mem.M, acc:T, [a:T]], ret:.Cn[%mem.M,T]] = ret (mem, a);

--- a/lit/mem/add_top_mem.thorin
+++ b/lit/mem/add_top_mem.thorin
@@ -9,7 +9,7 @@
     f (⊤:%mem.M, argc,return)
 };
 
-.lam .extern _compile [] -> %compile.Pipeline =
+.lam .extern _compile []: %compile.Pipeline =
     %compile.pipe
         (%compile.single_pass_phase %compile.internal_cleanup_pass)
         // optimization_phase

--- a/lit/mem/add_top_mem2.thorin
+++ b/lit/mem/add_top_mem2.thorin
@@ -10,7 +10,7 @@
 .con .extern main [mem : %mem.M, argc : %core.I32, argv : %mem.Ptr (%mem.Ptr (%core.I8, 0), 0), return : .Cn [%mem.M, %core.I32]] =
     f (⊤:%mem.M, argc, return);
 
-.lam .extern _compile [] -> %compile.Pipeline =
+.lam .extern _compile(): %compile.Pipeline =
     %compile.pipe
         (%compile.single_pass_phase %compile.internal_cleanup_pass)
         // optimization_phase

--- a/lit/mem/mem_rm.thorin
+++ b/lit/mem/mem_rm.thorin
@@ -3,5 +3,5 @@
 // RUN: clang %t.ll -S -emit-llvm -Wno-override-module -o -
 .plugin core;
 
-.fun .extern f ab::(a b: %core.I32) -> %core.I32 =
+.fun .extern f ab::(a b: %core.I32): %core.I32 =
     return (%mem.rm (2, ‹2; %core.I32›, %core.I32) (%core.div.sdiv @ %core.i32) ab);

--- a/lit/prec.thorin
+++ b/lit/prec.thorin
@@ -1,5 +1,5 @@
 // RUN: %thorin %s -o - | FileCheck %s
 
-.lam .extern f x: .Nat -> .Nat = x;
+.lam .extern f x: .Nat : .Nat = x;
 
-// CHECK-DAG: .lam .extern f x_{{[0-9]+}}: .Nat → .Nat =
+// CHECK-DAG: .lam .extern f x_{{[0-9]+}}: .Nat: .Nat =

--- a/lit/ptrn.thorin
+++ b/lit/ptrn.thorin
@@ -2,6 +2,6 @@
 // RUN: %thorin %s --output-ll %t.ll -o -
 .plugin core;
 
-.lam PtrN(n: .Nat, T: *) -> * = (PtrN (%core.nat.sub (n, 1), %mem.Ptr0 T), T)#(%core.ncmp.e (n, 0));
+.lam PtrN(n: .Nat, T: *): * = (PtrN (%core.nat.sub (n, 1), %mem.Ptr0 T), T)#(%core.ncmp.e (n, 0));
 
-.fun .extern foo(mem: %mem.M, p: PtrN (4, %core.I32)) -> [%mem.M, PtrN (3, %core.I32)] = return (%mem.load (mem, p));
+.fun .extern foo(mem: %mem.M, p: PtrN (4, %core.I32)): [%mem.M, PtrN (3, %core.I32)] = return (%mem.load (mem, p));

--- a/lit/rec.thorin
+++ b/lit/rec.thorin
@@ -1,10 +1,10 @@
 // RUN: %thorin %s --output-ll %t.ll -o - | FileCheck %s
 .plugin core;
 
-.lam is_even[.Nat] -> .Bool;
-.lam is_odd [.Nat] -> .Bool;
-.lam is_even!(i: .Nat) -> .Bool = (is_odd (%core.nat.sub (i, 1)), .tt)#(%core.ncmp.e (i, 0));
-.lam is_odd !(i: .Nat) -> .Bool = (is_even(%core.nat.sub (i, 1)), .ff)#(%core.ncmp.e (i, 0));
+.lam is_even[.Nat]: .Bool;
+.lam is_odd [.Nat]: .Bool;
+.lam is_even!(i: .Nat): .Bool = (is_odd (%core.nat.sub (i, 1)), .tt)#(%core.ncmp.e (i, 0));
+.lam is_odd !(i: .Nat): .Bool = (is_even(%core.nat.sub (i, 1)), .ff)#(%core.ncmp.e (i, 0));
 
-.fun .extern f() -> .Bool = return (is_even 4);
+.fun .extern f(): .Bool = return (is_even 4);
 // CHECK-DAG: return{{.*}}1:(.Idx 2)

--- a/lit/refly/refine.thorin
+++ b/lit/refly/refine.thorin
@@ -6,7 +6,7 @@
 .plugin core;
 .plugin refly;
 
-.fun .extern main(mem: %mem.M, argc: %core.I32, argv: %mem.Ptr (%mem.Ptr (%core.I8, 0), 0)) -> [%mem.M, %core.I32] = {
+.fun .extern main(mem: %mem.M, argc: %core.I32, argv: %mem.Ptr (%mem.Ptr (%core.I8, 0), 0)): [%mem.M, %core.I32] = {
     .let exp = %refly.reify <<4; .Nat>> (0, 1, 2, 3);
     .let new = %refly.refine (exp, 1, %refly.reify .Nat 42);
     .let tup = %refly.reflect <<4; .Nat>> new;

--- a/lit/sigma.thorin
+++ b/lit/sigma.thorin
@@ -21,9 +21,9 @@
 ];
 
 .Pi F = |~| .Nat -> F;
-.lam .extern f1 v: Vec1 -> %math.F64 = v#x;
-.lam .extern F1 v: vec1 -> %math.F64 = v#X;
-.lam .extern f2 v: Vec2 -> %math.F64 = v#y;
-.lam .extern f3 v: Vec3 -> %math.F64 = v#y;
-.lam .extern f4 v: Vec4 -> %math.F64 = v#y;
-.lam .extern f5 f: Foo  -> .Bool     = f#bar#b;
+.lam .extern f1 v: Vec1: %math.F64 = v#x;
+.lam .extern F1 v: vec1: %math.F64 = v#X;
+.lam .extern f2 v: Vec2: %math.F64 = v#y;
+.lam .extern f3 v: Vec3: %math.F64 = v#y;
+.lam .extern f4 v: Vec4: %math.F64 = v#y;
+.lam .extern f5 f: Foo : .Bool     = f#bar#b;

--- a/lit/str.thorin
+++ b/lit/str.thorin
@@ -4,10 +4,10 @@
 // RUN: %t | FileCheck %s
 .plugin core;
 
-.fun println_char[%mem.M, %core.I8] -> %mem.M;
-.fun print_str[%mem.M, %mem.Ptr0 «⊤:.Nat; %core.I8»] -> %mem.M;
+.fun println_char[%mem.M, %core.I8]: %mem.M;
+.fun print_str[%mem.M, %mem.Ptr0 «⊤:.Nat; %core.I8»]: %mem.M;
 
-.fun .extern main(mem: %mem.M, argc: %core.I32, argv: %mem.Ptr0 (%mem.Ptr0 %core.I8)) -> [%mem.M, %core.I32] =
+.fun .extern main(mem: %mem.M, argc: %core.I32, argv: %mem.Ptr0 (%mem.Ptr0 %core.I8)): [%mem.M, %core.I32] =
     .let (`mem, p1) = %mem.slot («15; %core.I8», 0) (mem, 0);
     .let  `mem      = %mem.store (mem, p1, "Hello, World!\n\0");
     .let p2         = %core.bitcast (%mem.Ptr0 «⊤:.Nat; %core.I8») p1;

--- a/thorin/dump.cpp
+++ b/thorin/dump.cpp
@@ -262,7 +262,7 @@ void Dumper::dump(Lam* lam) {
     if (Lam::isa_cn(lam))
         tab.println(os, ".con {}{} {}@({}) = {{", external(lam), id(lam), ptrn, lam->filter());
     else
-        tab.println(os, ".lam {}{} {} → {} = {{", external(lam), id(lam), ptrn, lam->type()->codom());
+        tab.println(os, ".lam {}{} {}: {} = {{", external(lam), id(lam), ptrn, lam->type()->codom());
 
     ++tab;
     if (lam->is_set()) {

--- a/thorin/fe/parser.cpp
+++ b/thorin/fe/parser.cpp
@@ -481,13 +481,13 @@ Lam* Parser::parse_lam(bool is_decl) {
         }
 
         funs.emplace_back(std::tuple(pi, lam, filter));
-    } while (!ahead().isa(Tag::T_arrow) && !ahead().isa(Tag::T_assign) && !ahead().isa(Tag::T_semicolon));
+    } while (!ahead().isa(Tag::T_colon) && !ahead().isa(Tag::T_assign) && !ahead().isa(Tag::T_semicolon));
 
     Ref codom;
     switch (tok.tag()) {
         case Tag::T_lm:
         case Tag::K_lam: {
-            codom = accept(Tag::T_arrow) ? parse_expr("return type of a "s + entity, Tok::Prec::Arrow)
+            codom = accept(Tag::T_colon) ? parse_expr("return type of a "s + entity)
                                          : world().mut_infer_type();
             break;
         }
@@ -499,7 +499,7 @@ Lam* Parser::parse_lam(bool is_decl) {
 
             codom          = world().type_bot();
             auto ret_track = tracker();
-            auto ret       = accept(Tag::T_arrow) ? parse_expr("return type of a "s + entity, Tok::Prec::Arrow)
+            auto ret       = accept(Tag::T_colon) ? parse_expr("return type of a "s + entity)
                                                   : world().mut_infer_type();
             auto ret_loc   = dom_p->loc() + ret_track.loc();
             auto last      = world().sigma({pi->dom(), world().cn(ret)});

--- a/thorin/fe/parser.cpp
+++ b/thorin/fe/parser.cpp
@@ -487,8 +487,7 @@ Lam* Parser::parse_lam(bool is_decl) {
     switch (tok.tag()) {
         case Tag::T_lm:
         case Tag::K_lam: {
-            codom = accept(Tag::T_colon) ? parse_expr("return type of a "s + entity)
-                                         : world().mut_infer_type();
+            codom = accept(Tag::T_colon) ? parse_expr("return type of a "s + entity) : world().mut_infer_type();
             break;
         }
         case Tag::K_cn:
@@ -499,13 +498,12 @@ Lam* Parser::parse_lam(bool is_decl) {
 
             codom          = world().type_bot();
             auto ret_track = tracker();
-            auto ret       = accept(Tag::T_colon) ? parse_expr("return type of a "s + entity)
-                                                  : world().mut_infer_type();
-            auto ret_loc   = dom_p->loc() + ret_track.loc();
-            auto last      = world().sigma({pi->dom(), world().cn(ret)});
-            auto new_pi    = world().mut_pi(pi->type(), pi->is_implicit())->set(ret_loc)->set_dom(last);
-            auto new_lam   = world().mut_lam(new_pi);
-            auto new_var   = new_lam->var()->set(ret_loc);
+            auto ret     = accept(Tag::T_colon) ? parse_expr("return type of a "s + entity) : world().mut_infer_type();
+            auto ret_loc = dom_p->loc() + ret_track.loc();
+            auto last    = world().sigma({pi->dom(), world().cn(ret)});
+            auto new_pi  = world().mut_pi(pi->type(), pi->is_implicit())->set(ret_loc)->set_dom(last);
+            auto new_lam = world().mut_lam(new_pi);
+            auto new_var = new_lam->var()->set(ret_loc);
 
             if (filter) {
                 // Rewrite filter - it may still use the old var.


### PR DESCRIPTION
Use `:` in `.lam`/`.lm`/`.fun`/`.fn` to separate (optional) return type instead of `->`:
```
.lam f(x y: .Nat): .Nat = x;
```
This is like in Lean or SML and resolves an ambiguity:
```
.lam f x: .Nat -> .Nat = x; 
// does it mean: 
.lam f(x: .Nat) -> .Nat = x;
// or:
.lam f(x: .Nat -> .Nat) = x;
```
And looks like this now:
```
.lam f x: .Nat : .Nat = x;
```
You still want to use parentheses in this case though...