### PR TITLE
Avoid renaming externals in reshape

### DIFF
--- a/dialects/mem/passes/rw/reshape.cpp
+++ b/dialects/mem/passes/rw/reshape.cpp
@@ -138,11 +138,12 @@ Lam* Reshape::reshape_lam(Lam* old_lam) {
     auto new_ty = reshape_type(pi_ty)->as<Pi>();
 
     Lam* new_lam;
-    if (*old_lam->sym() == "main" || old_lam->is_external()) { 
+    if (*old_lam->sym() == "main") { 
         new_lam = old_lam;
     } else {
         new_lam = old_lam->stub(world(), new_ty);
-        new_lam->debug_suffix("_reshape");
+        if(!old_lam->is_external())
+            new_lam->debug_suffix("_reshape");
         old2new_[old_lam] = new_lam;
     }
 

--- a/dialects/mem/passes/rw/reshape.cpp
+++ b/dialects/mem/passes/rw/reshape.cpp
@@ -138,12 +138,12 @@ Lam* Reshape::reshape_lam(Lam* old_lam) {
     auto new_ty = reshape_type(pi_ty)->as<Pi>();
 
     Lam* new_lam;
-    if (*old_lam->sym() != "main") { // TODO I don't think this is correct. we should check for old_lam->is_external
+    if (*old_lam->sym() == "main" || old_lam->is_external()) { 
+        new_lam = old_lam;
+    } else {
         new_lam = old_lam->stub(world(), new_ty);
         new_lam->debug_suffix("_reshape");
         old2new_[old_lam] = new_lam;
-    } else {
-        new_lam = old_lam;
     }
 
     world().DLOG("Reshape lam: {} : {}", old_lam, pi_ty);


### PR DESCRIPTION
The `_reshape` suffix for reshape should not be applied to externals.


See #223