### PR TITLE
Specialize (.Idx, .Idx)#cond to generate a select instruction.

### DIFF
--- a/dialects/core/be/ll.cpp
+++ b/dialects/core/be/ll.cpp
@@ -547,6 +547,26 @@ std::string Emitter::emit_bb(BB& bb, const Def* def) {
     } else if (auto extract = def->isa<Extract>()) {
         auto tuple = extract->tuple();
         auto index = extract->index();
+
+        world().VLOG("emit extract from tupl: {}, ex type: {}, tuple type: {}", extract, extract->type(),
+                     tuple->type());
+        // use select when extracting from 2-element integral tuples
+        // literal indices would be normalized away already, if it was possible
+        // As they aren't they likely depend on a var, which is implemented as array -> need extractvalue
+        if (auto app = extract->type()->isa<App>();
+            app && app->callee()->isa<Idx>() && !index->isa<Lit>() && tuple->type()->isa<Arr>()) {
+            if (auto arity = tuple->type()->isa_lit_arity(); arity && *arity == 2) {
+                world().VLOG("emit extract from integral tupl: {}, ex type: {}, tuple type: {}", extract,
+                             extract->type(), tuple->type());
+
+                auto t                = convert(extract->type());
+                auto [elem_a, elem_b] = tuple->projs<2>([&](auto e) { return emit_unsafe(e); });
+
+                return bb.assign(name, "select {} {}, {} {}, {} {}", convert(index->type()), emit(index), t, elem_b, t,
+                                 elem_a);
+            }
+        }
+
         auto v_tup = emit_unsafe(tuple);
 
         // this exact location is important: after emitting the tuple -> ordering of mem ops

--- a/dialects/core/be/ll.cpp
+++ b/dialects/core/be/ll.cpp
@@ -548,17 +548,12 @@ std::string Emitter::emit_bb(BB& bb, const Def* def) {
         auto tuple = extract->tuple();
         auto index = extract->index();
 
-        world().VLOG("emit extract from tupl: {}, ex type: {}, tuple type: {}", extract, extract->type(),
-                     tuple->type());
         // use select when extracting from 2-element integral tuples
         // literal indices would be normalized away already, if it was possible
         // As they aren't they likely depend on a var, which is implemented as array -> need extractvalue
         if (auto app = extract->type()->isa<App>();
             app && app->callee()->isa<Idx>() && !index->isa<Lit>() && tuple->type()->isa<Arr>()) {
             if (auto arity = tuple->type()->isa_lit_arity(); arity && *arity == 2) {
-                world().VLOG("emit extract from integral tupl: {}, ex type: {}, tuple type: {}", extract,
-                             extract->type(), tuple->type());
-
                 auto t                = convert(extract->type());
                 auto [elem_a, elem_b] = tuple->projs<2>([&](auto e) { return emit_unsafe(e); });
 

--- a/dialects/regex/regex.thorin
+++ b/dialects/regex/regex.thorin
@@ -102,9 +102,7 @@
     .let (`mem, char) = %mem.load (mem, ptr);
     .let in_range = %core.bit2.and_ 0 (%core.icmp.uge (char, lower),  %core.icmp.ule (char, upper));
     
-    .con if_tt() = return (mem, in_range, %core.conv.u n (%core.wrap.add 0 (%core.conv.u %core.i32 pos, 1:%core.I32)));
-    .con if_ff() = return (mem, in_range, pos);
-    (if_ff, if_tt)#in_range ()
+    return (mem, in_range, (pos, %core.conv.u n (%core.wrap.add 0 (%core.conv.u %core.i32 pos, 1:%core.I32)))#in_range)
 };
 .fun %regex.match_not(n: .Nat)(inner: (CPS_RE n))(mem: %mem.M, string: %mem.Ptr0 «n; %core.I8», pos: .Idx n): [%mem.M, .Bool, .Idx n] = {
     .con match_not_ret_inverted!(mem: %mem.M, in_range: .Bool, new_pos: .Idx n) = return (mem, %core.bit1.neg 0 in_range, new_pos);
@@ -115,69 +113,52 @@
     .let (`mem, char) = %mem.load (mem, ptr);
     .let isnt_0 = %core.icmp.ne (char, '\0');
 
-    .con if_tt() = return (mem, isnt_0, %core.conv.u n (%core.wrap.add 0 (%core.conv.u %core.i32 pos, 1:%core.I32)));
-    .con if_ff() = return (mem, isnt_0, pos);
-    (if_ff, if_tt)#isnt_0 ()
+    return (mem, isnt_0, (pos, %core.conv.u n (%core.wrap.add 0 (%core.conv.u %core.i32 pos, 1:%core.I32)))#isnt_0)
 };
 .fun %regex.match_conj(n: .Nat)(A: (CPS_RE n), B: (CPS_RE n))(mem: %mem.M, string: %mem.Ptr0 «n; %core.I8», pos: .Idx n): [%mem.M, .Bool, .Idx n] = {
-    .con match_conj_exit_true!(mem: %mem.M, new_pos: .Idx n) = return (mem, 1:.Bool, new_pos);
-
-    .con match_conj_exit_false!(mem: %mem.M, new_pos: .Idx n) = return (mem, 0:.Bool, pos);
-
-    .con match_conj_B_ret!(mem:%mem.M, matched:.Bool, new_pos:.Idx n) = (match_conj_exit_false, match_conj_exit_true)#matched (mem, new_pos);
+    .con match_conj_B_ret!(mem:%mem.M, matched:.Bool, new_pos:.Idx n) = return (mem, matched, (pos, new_pos)#matched);
 
     .con match_conj_A_ret!(mem:%mem.M, matched:.Bool, new_pos:.Idx n) = {
-        .con match_conj_call_B!(mem:%mem.M, new_pos:.Idx n) = B ((mem, string, new_pos), match_conj_B_ret);
+        .con match_conj_call_B!(mem:%mem.M, matched:.Bool, new_pos:.Idx n) = B ((mem, string, new_pos), match_conj_B_ret);
 
-        (match_conj_exit_false, match_conj_call_B)#matched (mem, new_pos)
+        (return, match_conj_call_B)#matched (mem, matched, (pos, new_pos)#matched)
     };
 
     A ((mem, string, pos), match_conj_A_ret)
 };
 .fun %regex.match_disj(n: .Nat)(A: (CPS_RE n), B: (CPS_RE n))(mem: %mem.M, string: %mem.Ptr0 «n; %core.I8», pos: .Idx n): [%mem.M, .Bool, .Idx n] = {
-    .con match_disj_exit_true!(mem: %mem.M, new_pos: .Idx n) = return (mem, 1:.Bool, new_pos);
-
-    .con match_disj_exit_false!(mem: %mem.M, new_pos: .Idx n) = return (mem, 0:.Bool, pos);
-
-    .con match_disj_B_ret!(mem:%mem.M, matched:.Bool, new_pos:.Idx n) = (match_disj_exit_false, match_disj_exit_true)#matched (mem, new_pos);
+    .con match_disj_B_ret!(mem:%mem.M, matched:.Bool, new_pos:.Idx n) = return (mem, matched, (pos, new_pos)#matched);
 
     .con match_disj_A_ret!(mem:%mem.M, matched:.Bool, new_pos:.Idx n) = {
-        .con match_disj_call_B!(mem:%mem.M, new_pos:.Idx n) = B ((mem, string, new_pos), match_disj_B_ret);
-        (match_disj_call_B, match_disj_exit_true)#matched (mem, new_pos)
+        .con match_disj_call_B!(mem:%mem.M, matched:.Bool, new_pos:.Idx n) = B ((mem, string, new_pos), match_disj_B_ret);
+        (match_disj_call_B, return)#matched (mem, matched, new_pos)
     };
 
     A ((mem, string, pos), match_disj_A_ret)
 };
 .fun %regex.match_optional(n: .Nat)(sub: (CPS_RE n))(mem: %mem.M, string: %mem.Ptr0 «n; %core.I8», pos: .Idx n): [%mem.M, .Bool, .Idx n] = {
-    .con match_optional_exit_true!(mem: %mem.M, new_pos: .Idx n) = return (mem, 1:.Bool, new_pos);
-
-    .con match_optional_exit_false!(mem: %mem.M, new_pos: .Idx n) = return (mem, 1:.Bool, pos);
-    .con match_optional_ret!(mem:%mem.M, matched:.Bool, new_pos:.Idx n) = (match_optional_exit_false, match_optional_exit_true)#matched (mem, new_pos);
+    .con match_optional_ret!(mem:%mem.M, matched:.Bool, new_pos:.Idx n) = return (mem, 1:.Bool, new_pos);
 
     sub ((mem, string, pos), match_optional_ret)
 };
 .fun %regex.match_star(n: .Nat)(sub: (CPS_RE n))(mem: %mem.M, string: %mem.Ptr0 «n; %core.I8», pos: .Idx n): [%mem.M, .Bool, .Idx n] = {
-    .con match_star_exit_false(mem: %mem.M, new_pos: .Idx n) = return (mem, 1:.Bool, new_pos);
     .con match_star_ret(mem:%mem.M, matched:.Bool, new_pos:.Idx n) = {
-        .con match_star_iter(mem: %mem.M, new_pos: .Idx n) = sub ((mem, string, new_pos), match_star_ret);
+        .con match_star_iter(mem: %mem.M, matched:.Bool, new_pos: .Idx n) = sub ((mem, string, new_pos), match_star_ret);
 
-        (match_star_exit_false, match_star_iter)#matched (mem, new_pos)
+        (return, match_star_iter)#matched (mem, 1:.Bool, new_pos)
     };
 
     sub ((mem, string, pos), match_star_ret)
 };
 .fun %regex.match_plus(n: .Nat)(sub: (CPS_RE n))(mem: %mem.M, string: %mem.Ptr0 «n; %core.I8», pos: .Idx n): [%mem.M, .Bool, .Idx n] = {
-    .con match_plus_exit_true!(mem: %mem.M, new_pos: .Idx n) = return (mem, 1:.Bool, new_pos);
-
     .con match_plus_ret!(mem:%mem.M, matched:.Bool, new_pos:.Idx n) = {
-        .con match_plus_iter!(mem: %mem.M, new_pos: .Idx n) = sub ((mem, string, new_pos), match_plus_ret);
-        (match_plus_exit_true, match_plus_iter)#matched (mem, new_pos)
+        .con match_plus_iter!(mem: %mem.M, matched: .Bool, new_pos: .Idx n) = sub ((mem, string, new_pos), match_plus_ret);
+        (return, match_plus_iter)#matched (mem, 1:.Bool, new_pos)
     };
 
-    .con match_plus_exit_false!(mem: %mem.M, new_pos: .Idx n) = return (mem, 0:.Bool, new_pos);
     .con match_plus_ret0!(mem:%mem.M, matched:.Bool, new_pos:.Idx n) = {
-        .con match_plus_iter0!(mem: %mem.M, new_pos: .Idx n) = sub ((mem, string, new_pos), match_plus_ret);
-        (match_plus_exit_false, match_plus_iter0)#matched (mem, new_pos)
+        .con match_plus_iter0!(mem: %mem.M, matched:.Bool, new_pos: .Idx n) = sub ((mem, string, new_pos), match_plus_ret);
+        (return, match_plus_iter0)#matched (mem, matched, new_pos)
     };
 
     sub ((mem, string, pos), match_plus_ret0)

--- a/lit/regex/match_woptionals.thorin
+++ b/lit/regex/match_woptionals.thorin
@@ -1,8 +1,9 @@
 // RUN: rm -f %t.ll ; \
 // RUN: %thorin %s -o - --output-ll %t.ll | FileCheck %s
 // RUN: clang %t.ll -o %t -Wno-override-module
-// RUN: %t "g1 "; test $? -eq 1
-// RUN: %t "# "; test $? -eq 1
+// RUN: %t "g "; test $? -eq 1
+// RUN: %t " "; test $? -eq 1
+// RUN: %t "# "; test $? -eq 0
 
 .import mem;
 .import core;
@@ -14,7 +15,7 @@
 .let I32 = .Idx _32;
 .let Top = ⊤:.Nat;
 
-.let re = %regex.quant.optional %regex.cls.w;
+.let re = %regex.conj 2 (%regex.quant.optional %regex.cls.w, %regex.cls.s);
 
 .con .extern main[mem: %mem.M, argc: I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .Idx 256», 0)», 0), exit : .Cn [%mem.M, I32]] = {
     .con handle_match [mem: %mem.M, matched: .Bool, match: %mem.Ptr(«Top; I8», 0)] = {

--- a/lit/regex/match_wstar.thorin
+++ b/lit/regex/match_wstar.thorin
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %thorin %s -o - --output-ll %t.ll | FileCheck %s
+// RUN: %thorin %s -o - --output-ll %t.ll --aggr-lam-spec | FileCheck %s
 // RUN: clang %t.ll -o %t -Wno-override-module
 // RUN: %t "g1 "; test $? -eq 1
 


### PR DESCRIPTION
Currently, we would generate an array, store that, calculate the offset with a GEP and then load from the GEP.
LLVM does an awful job optimizing this (potentially due to missing alias info or so).
That's why I initially resorted to actually using if/else in the regex impl, but that is also not optimized too neatly.
Therefore, I added a specialization for 2-element integral tuples (yeah, should work for a bunch of other types as well), to emit a `select` instruction instead.

On the regex benchmark, this gives a performance upgrade of ~14% speedup, leaving only a 13% slowdown compared to the manual version.
Old:
```
engine,average[us],min[us],max[us],deviation[%],
thorin,1119,1103,1150,4,
manual,861,839,891,6,
```
New:
```
engine,average[us],min[us],max[us],deviation[%],runs[us]
thorin,974,949,1009,6,
manual,857,835,894,6,
```

