### PR TITLE
introduced threshold for Scalerize Pass

### DIFF
--- a/dialects/clos/clos.thorin
+++ b/dialects/clos/clos.thorin
@@ -47,14 +47,14 @@
   %compile.pass_phase (%compile.pass_list
       eta_red
       eta_exp
-      (%compile.scalerize_pass eta_exp)
+      (%compile.scalerize_pass (eta_exp, %compile.scalerize_threshold))
   )
 };
 .let clos_opt2_phase = {
   .let nullptr = %compile.nullptr_pass;
   %compile.pass_phase (%compile.pass_list
       nullptr
-      (%compile.scalerize_pass nullptr)
+      (%compile.scalerize_pass (nullptr, %compile.scalerize_threshold))
       %clos.branch_clos_pass
       (%mem.copy_prop_pass (nullptr, nullptr, .tt))
       %clos.lower_typed_clos_prep_pass

--- a/dialects/compile/compile.thorin
+++ b/dialects/compile/compile.thorin
@@ -103,8 +103,9 @@
 .ax %compile.eta_red_pass: %compile.Pass;
 /// Eta expansion expects an instance of eta reduction as argument.
 .ax %compile.eta_exp_pass: %compile.Pass -> %compile.Pass;
-/// Scalerize expects an instance of eta expansion as argument.
-.ax %compile.scalerize_pass: %compile.Pass -> %compile.Pass;
+/// Scalerize expects an instance of eta expansion as argument and a threshold where scalarize should stop.
+.ax %compile.scalerize_pass: [%compile.Pass, .Nat] -> %compile.Pass;
+.let %compile.scalerize_threshold = 32;
 /// Tail recursion elimination expects an instance of eta reduction as argument.
 .ax %compile.tail_rec_elim_pass: %compile.Pass -> %compile.Pass;
 .ax %compile.lam_spec_pass: %compile.Pass;
@@ -123,7 +124,7 @@
         %compile.beta_red_pass
         eta_red
         eta_exp
-        (%compile.scalerize_pass eta_exp)
+        (%compile.scalerize_pass (eta_exp, %compile.scalerize_threshold))
         (%compile.tail_rec_elim_pass eta_red)
 };
 .let optimization_phase = {
@@ -136,7 +137,7 @@
     .let nullptr = %compile.nullptr_pass;
     %compile.pipe
         (%compile.single_pass_phase nullptr)
-        (%compile.single_pass_phase (%compile.scalerize_pass nullptr))
+        (%compile.single_pass_phase (%compile.scalerize_pass (nullptr, %compile.scalerize_threshold)))
         (%compile.single_pass_phase %compile.eta_red_pass)
         (%compile.single_pass_phase (%compile.tail_rec_elim_pass nullptr))
         optimization_phase

--- a/dialects/direct/passes/cps2ds.cpp
+++ b/dialects/direct/passes/cps2ds.cpp
@@ -131,7 +131,7 @@ const Def* CPS2DS::rewrite_body_(const Def* def) {
 
     if (auto tuple = def->isa<Tuple>()) {
         DefArray elements(tuple->ops(), [&](const Def* op) { return rewrite_body(op); });
-        return world().tuple(elements)->set(tuple->dbg());
+        return world().tuple(def->type(), elements)->set(tuple->dbg());
     }
 
     DefArray new_ops{def->ops(), [&](const Def* op) { return rewrite_body(op); }};

--- a/dialects/mem/mem.thorin
+++ b/dialects/mem/mem.thorin
@@ -107,7 +107,7 @@
 /// SSA pass expects eta expansion as argument
 .ax %mem.ssa_pass: %compile.Pass -> %compile.Pass;
 /// Copy propagation expects beta reduction and eta expansion as argument.
-.ax %mem.copy_prop_pass: [%compile.Pass,%compile.Pass, .Bool] -> %compile.Pass;
+.ax %mem.copy_prop_pass: [%compile.Pass, %compile.Pass, .Bool] -> %compile.Pass;
 .ax %mem.remem_elim_pass: %compile.Pass;
 .ax %mem.alloc2malloc_pass: %compile.Pass;
 .ax %mem.reshape_pass: %mem.reshape_mode -> %compile.Pass;

--- a/dialects/opt/opt.thorin
+++ b/dialects/opt/opt.thorin
@@ -27,7 +27,7 @@
     .let nullphase = %compile.single_pass_phase nullptr;
     %compile.pipe
         nullphase
-        (%compile.single_pass_phase (%compile.scalerize_pass nullptr))
+        (%compile.single_pass_phase (%compile.scalerize_pass (nullptr, %compile.scalerize_threshold)))
         (%compile.single_pass_phase %compile.eta_red_pass)
         (%compile.single_pass_phase (%compile.tail_rec_elim_pass nullptr))
         (%compile.single_pass_phase (plugin_cond_pass (%compile.regex_plugin, %regex.lower_regex)))

--- a/thorin/fe/parser.cpp
+++ b/thorin/fe/parser.cpp
@@ -366,7 +366,9 @@ Ref Parser::parse_tuple_expr() {
     auto track = tracker();
     DefVec ops;
     parse_list("tuple", Tag::D_paren_l, [&]() { ops.emplace_back(parse_expr("tuple element")); });
-    return world().tuple(ops)->set(track.loc());
+    auto ascr = accept(Tag::T_colon) ? parse_expr("type ascription of a tuple") : nullptr;
+
+    return (ascr ? world().tuple(ascr, ops) : world().tuple(ops))->set(track.loc());
 }
 
 Ref Parser::parse_type_expr() {

--- a/thorin/pass/rw/scalarize.h
+++ b/thorin/pass/rw/scalarize.h
@@ -18,9 +18,10 @@ class EtaExp;
 /// It will not flatten mutable @p Sigma%s or @p Arr%ays.
 class Scalerize : public RWPass<Scalerize, Lam> {
 public:
-    Scalerize(PassMan& man, EtaExp* eta_exp = nullptr)
+    Scalerize(PassMan& man, EtaExp* eta_exp, nat_t threshold)
         : RWPass(man, "scalerize")
-        , eta_exp_(eta_exp) {}
+        , eta_exp_(eta_exp)
+        , threshold_(threshold) {}
 
     Ref rewrite(Ref) override;
 
@@ -29,6 +30,7 @@ private:
     Lam* make_scalar(Ref def);
 
     EtaExp* eta_exp_;
+    nat_t threshold_;
     Lam2Lam tup2sca_;
 };
 

--- a/thorin/tuple.cpp
+++ b/thorin/tuple.cpp
@@ -9,14 +9,16 @@
 
 namespace thorin {
 
-const Def* Pack::shape() const {
-    if (auto arr = type()->isa<Arr>()) return arr->shape();
-    if (type() == world().sigma()) return world().lit_nat_0();
-    return world().lit_nat_1();
-}
-
 namespace {
-bool should_flatten(const Def* def) { return (def->is_term() ? def->type() : def)->isa<Sigma, Arr>(); }
+bool should_flatten(nat_t threshold, const Def* def) {
+    auto type = (def->is_term() ? def->type() : def);
+    if (type->isa<Sigma>()) return true;
+    if (auto arr = type->isa<Arr>()) {
+        if (auto a = arr->isa_lit_arity(); a && *a > threshold) return false;
+        return true;
+    }
+    return false;
+}
 
 bool mut_val_or_typ(const Def* def) {
     auto typ = def->is_term() ? def->type() : def;
@@ -35,6 +37,12 @@ const Def* unflatten(Defs defs, const Def* type, size_t& j, bool flatten_muts) {
 }
 } // namespace
 
+const Def* Pack::shape() const {
+    if (auto arr = type()->isa<Arr>()) return arr->shape();
+    if (type() == world().sigma()) return world().lit_nat_0();
+    return world().lit_nat_1();
+}
+
 bool is_unit(const Def* def) { return def->type() == def->world().sigma(); }
 
 std::string tuple2str(const Def* def) {
@@ -44,10 +52,11 @@ std::string tuple2str(const Def* def) {
     return std::string(array.begin(), array.end());
 }
 
-size_t flatten(DefVec& ops, const Def* def, bool flatten_muts) {
-    if (auto a = def->isa_lit_arity(); a && *a != 1 && should_flatten(def) && flatten_muts == mut_val_or_typ(def)) {
+size_t flatten(nat_t threshold, DefVec& ops, const Def* def, bool flatten_muts) {
+    if (auto a = def->isa_lit_arity();
+        a && *a != 1 && should_flatten(threshold, def) && flatten_muts == mut_val_or_typ(def)) {
         auto n = 0;
-        for (size_t i = 0; i != *a; ++i) n += flatten(ops, def->proj(*a, i), flatten_muts);
+        for (size_t i = 0; i != *a; ++i) n += flatten(threshold, ops, def->proj(*a, i), flatten_muts);
         return n;
     } else {
         ops.emplace_back(def);
@@ -55,10 +64,10 @@ size_t flatten(DefVec& ops, const Def* def, bool flatten_muts) {
     }
 }
 
-const Def* flatten(const Def* def) {
-    if (!should_flatten(def)) return def;
+const Def* flatten(nat_t threshold, const Def* def) {
+    if (!should_flatten(threshold, def)) return def;
     DefVec ops;
-    flatten(ops, def);
+    flatten(threshold, ops, def);
     return def->is_term() ? def->world().tuple(def->type(), ops) : def->world().sigma(ops);
 }
 

--- a/thorin/tuple.h
+++ b/thorin/tuple.h
@@ -153,9 +153,9 @@ bool is_unit(const Def*);
 std::string tuple2str(const Def*);
 
 /// Flattens a sigma/array/pack/tuple.
-const Def* flatten(const Def* def);
+const Def* flatten(nat_t threshold, const Def* def);
 /// Same as unflatten, but uses the operands of a flattened pack/tuple directly.
-size_t flatten(DefVec& ops, const Def* def, bool flatten_sigmas = true);
+size_t flatten(nat_t threshold, DefVec& ops, const Def* def, bool flatten_sigmas = true);
 
 /// Applies the reverse transformation on a pack/tuple, given the original type.
 const Def* unflatten(const Def* def, const Def* type);


### PR DESCRIPTION
If you are juggling around large tuples, compile time will explode. This threshold, will not scalarize tuples larger than the given threshold.