### PR TITLE
Feature/group

### DIFF
--- a/docs/langref.md
+++ b/docs/langref.md
@@ -180,16 +180,15 @@ The following tables comprise all production rules:
 
 Patterns allow you to decompose a value into its components like in [Standard ML](https://en.wikibooks.org/wiki/Standard_ML_Programming/Types#Tuples) or other functional languages.
 
-| LHS             | RHS                                                    | Comment                             |
-|-----------------|--------------------------------------------------------|-------------------------------------|
-| p               | <tt>\`</tt>? 𝖨 (`:` e<sub>type</sub> )?                | identifier `()`-pattern             |
-| p               | (<tt>\`</tt>? 𝖨 `::`)? `(` d\* g `,` ... `,` d\* g `)` | `()`-`()`-tuple pattern<sup>s</sup> |
-| p               | (<tt>\`</tt>? 𝖨 `::`)? b<sub>[ ]</sub>                 | `[]`-`()`-tuple pattern             |
-| g               | p                                                      | group                               |
-| g               | 𝖨+ `:` e                                               | group                               |
-| b               | (<tt>\`</tt>? 𝖨 `:`)? e<sub>type</sub>                 | identifier `[]`-pattern             |
-| b               | (<tt>\`</tt>? 𝖨 `::`)? b<sub>[ ]</sub>                 | `[]`-`[]`-tuple pattern             |
-| b<sub>[ ]</sub> | `[` d\* b `,` ... `,` d\* b `]`                        | `[]`-tuple pattern<sup>s</sup>      |
+| LHS             | RHS                                                                  | Comment                             |
+|-----------------|----------------------------------------------------------------------|-------------------------------------|
+| p               | <tt>\`</tt>? 𝖨 (`:` e<sub>type</sub> )?                              | identifier `()`-pattern             |
+| p               | (<tt>\`</tt>? 𝖨 `::`)? `(` d\* (p \| g) `,` ... `,` d\* (p \| g) `)` | `()`-`()`-tuple pattern<sup>s</sup> |
+| p               | (<tt>\`</tt>? 𝖨 `::`)? b<sub>[ ]</sub>                               | `[]`-`()`-tuple pattern             |
+| b               | (<tt>\`</tt>? 𝖨 `:`)? e<sub>type</sub>                               | identifier `[]`-pattern             |
+| b               | (<tt>\`</tt>? 𝖨 `::`)? b<sub>[ ]</sub>                               | `[]`-`[]`-tuple pattern             |
+| b<sub>[ ]</sub> | `[` d\* (b \| g) `,` ... `,` d\* (b \| g) `]`                        | `[]`-tuple pattern<sup>s</sup>      |
+| g               | 𝖨+ `:` e                                                             | group                               |
 
 #### ()-style vs []-style
 
@@ -207,8 +206,9 @@ For this reason there is no rule for a `()`-`[]`-pattern.
 
 #### Groups
 
-What is more, `()`-style patterns allow for *groups*:
+Tuple patterns allow for *groups*:
 * `(a b c: .Nat, d e: .Bool)` means `(a: .Nat, b: .Nat, c: .Nat, d: .Bool, e: .Bool)`.
+* `[a b c: .Nat, d e: .Bool]` means `[a: .Nat, b: .Nat, c: .Nat, d: .Bool, e: .Bool]`.
 
 You can introduce an optional name for the whole tuple pattern:
 ```

--- a/lit/group.thorin
+++ b/lit/group.thorin
@@ -1,2 +1,4 @@
 // RUN: %thorin %s -o -
 .lam f(a b: .Nat, x: «a; .Nat»): .Bool = .ff;
+.ax %foo.F: [p e: .Nat] -> *;
+.ax %foo.bar: Π.pe::[p e: .Nat][.Nat][a b: %foo.F pe] -> %foo.F (p, e);

--- a/thorin/fe/parser.cpp
+++ b/thorin/fe/parser.cpp
@@ -743,11 +743,10 @@ std::unique_ptr<TuplePtrn> Parser::parse_tuple_ptrn(Tracker track, bool rebind, 
         auto track = tracker();
         if (!ptrns.empty()) ptrns.back()->bind(scopes_, infers.back());
 
-        std::vector<Tok> sym_toks;
-        if (ahead(0).isa(Tag::M_id) && !ahead(1).isa(Tag::T_colon_colon))
+        if (ahead(0).isa(Tag::M_id) && ahead(1).isa(Tag::M_id)) {
+            std::vector<Tok> sym_toks;
             while (auto tok = accept(Tag::M_id)) sym_toks.emplace_back(*tok);
 
-        if (!sym_toks.empty()) {
             if (accept(Tag::T_colon)) { // identifier group: x y x: T
                 auto type = parse_expr("type of an identifier group within a tuple pattern");
 
@@ -759,23 +758,6 @@ std::unique_ptr<TuplePtrn> Parser::parse_tuple_ptrn(Tracker track, bool rebind, 
                     if (i != e - 1) ptrn->bind(scopes_, infers.back()); // last element will be bound above
                     ptrns.emplace_back(std::move(ptrn));
                 }
-            } else if (sym_toks.size() == 1) { // just "x"
-                auto ptrn
-                    = p ? std::make_unique<IdPtrn>(sym_toks.front().dbg(), false, nullptr)
-                        : std::make_unique<IdPtrn>(track.dbg(anonymous_), false, scopes_.find(sym_toks.front().dbg()));
-                auto type = ptrn->type(world(), def2fields_);
-
-                if (b) {
-                    // If we are able to parse more stuff, we got an expression instead of just a binder.
-                    if (auto expr = parse_infix_expr(track, type); expr != type) {
-                        ptrn = std::make_unique<IdPtrn>(track.dbg(anonymous_), false, expr);
-                        type = ptrn->type(world(), def2fields_);
-                    }
-                }
-
-                infers.emplace_back(world().mut_infer(type)->set(ptrn->sym()));
-                ops.emplace_back(type);
-                ptrns.emplace_back(std::move(ptrn));
             } else {
                 // "x y z" is a curried app and maybe the prefix of a longer type expression
                 auto lhs = scopes_.find(sym_toks.front().dbg());

--- a/thorin/fe/parser.h
+++ b/thorin/fe/parser.h
@@ -116,7 +116,6 @@ private:
     /// @name parse exprs
     ///@{
     Ref parse_expr(std::string_view ctxt, Tok::Prec = Tok::Prec::Bot);
-    Ref parse_bin_expr(std::string_view ctxt, Tok::Prec = Tok::Prec::Bot);
     Ref parse_primary_expr(std::string_view ctxt);
     Ref parse_infix_expr(Tracker, const Def* lhs, Tok::Prec = Tok::Prec::Bot);
     Ref parse_extract_expr(Tracker, const Def*, Tok::Prec);

--- a/thorin/fe/parser.h
+++ b/thorin/fe/parser.h
@@ -116,6 +116,7 @@ private:
     /// @name parse exprs
     ///@{
     Ref parse_expr(std::string_view ctxt, Tok::Prec = Tok::Prec::Bot);
+    Ref parse_bin_expr(std::string_view ctxt, Tok::Prec = Tok::Prec::Bot);
     Ref parse_primary_expr(std::string_view ctxt);
     Ref parse_infix_expr(Tracker, const Def* lhs, Tok::Prec = Tok::Prec::Bot);
     Ref parse_extract_expr(Tracker, const Def*, Tok::Prec);


### PR DESCRIPTION
This PR allows identifier groups also for `[]`-style patterns:
* `(a b c: .Nat, d e: .Bool)` means `(a: .Nat, b: .Nat, c: .Nat, d: .Bool, e: .Bool)` (formely).
* `[a b c: .Nat, d e: .Bool]` means `[a: .Nat, b: .Nat, c: .Nat, d: .Bool, e: .Bool]` (new).
