### PR TITLE
Refactor/regex

### DIFF
--- a/dialects/core/core.thorin
+++ b/dialects/core/core.thorin
@@ -68,8 +68,9 @@
 .let %core.mode.uS = 0b01; // no   signed wrap around
 .let %core.mode.Us = 0b10; // no unsigned wrap around
 .let %core.mode.US = 0b11; // no signed and unsigned wrap around
-.let %core.mode.nuw = %core.mode.Us;
-.let %core.mode.nsw = %core.mode.uS;
+.let %core.mode.nuw  = %core.mode.Us;
+.let %core.mode.nsw  = %core.mode.uS;
+.let %core.mode.nusw = %core.mode.US;
 ///
 /// ### %core.idx
 ///

--- a/dialects/core/core.thorin
+++ b/dialects/core/core.thorin
@@ -68,6 +68,8 @@
 .let %core.mode.uS = 0b01; // no   signed wrap around
 .let %core.mode.Us = 0b10; // no unsigned wrap around
 .let %core.mode.US = 0b11; // no signed and unsigned wrap around
+.let %core.mode.nuw = %core.mode.Us;
+.let %core.mode.nsw = %core.mode.uS;
 ///
 /// ### %core.idx
 ///

--- a/dialects/regex/passes/lower_regex.cpp
+++ b/dialects/regex/passes/lower_regex.cpp
@@ -22,7 +22,7 @@ Ref any_impl(Match<regex::any, Axiom> any_ax) {
 
 Ref range_impl(Match<regex::range, App> range_app) {
     auto& world = range_app->world();
-    return world.app(world.annex<regex::match_range>(), range_app->arg());
+    return world.call<regex::match_range>(range_app->arg());
 }
 
 Ref not_impl(Match<regex::not_, App> not_app) {

--- a/dialects/regex/passes/lower_regex.cpp
+++ b/dialects/regex/passes/lower_regex.cpp
@@ -47,7 +47,7 @@ Ref rewrite_arg(Ref def, Ref n) {
     if (auto _not   = thorin::match<not_ >(def)) new_app = world.call<regex::match_not  >(n, rewrite_args( _not->arg(), n));
     if (auto _conj  = thorin::match<conj >(def)) new_app = world.call<regex::match_conj >(n, rewrite_args(_conj->arg(), n));
     if (auto _disj  = thorin::match<disj >(def)) new_app = world.call<regex::match_disj >(n, rewrite_args(_disj->arg(), n));
-    if (auto _quant = thorin::match<quant>(def)) new_app = world.iapp(world.app(quant_impl(_quant), n), rewrite_args(_quant->arg(), n));
+    if (auto _quant = thorin::match<quant>(def)) new_app = world.call_(quant_impl(_quant), n, rewrite_args(_quant->arg(), n));
     // clang-format on
     return new_app;
 }
@@ -66,7 +66,7 @@ Ref LowerRegex::rewrite(Ref def) {
         if (auto _not   = thorin::match<not_ >(app->callee())) new_app = wrap_in_cps2ds(world.call<match_not  >(n, rewrite_args( _not->arg(), n)));
         if (auto _conj  = thorin::match<conj >(app->callee())) new_app = wrap_in_cps2ds(world.call<match_conj >(n, rewrite_args(_conj->arg(), n)));
         if (auto _disj  = thorin::match<disj >(app->callee())) new_app = wrap_in_cps2ds(world.call<match_disj >(n, rewrite_args(_disj->arg(), n)));
-        if (auto _quant = thorin::match<quant>(app->callee())) new_app = wrap_in_cps2ds(world.app(world.iapp(quant_impl(_quant), n), rewrite_args(_quant->arg(), n)));
+        if (auto _quant = thorin::match<quant>(app->callee())) new_app = wrap_in_cps2ds(world.call_(quant_impl(_quant), n, rewrite_args(_quant->arg(), n)));
         // clang-format on
     }
 

--- a/dialects/regex/passes/lower_regex.cpp
+++ b/dialects/regex/passes/lower_regex.cpp
@@ -16,15 +16,9 @@ Ref rewrite_arg(Ref ref, Ref n);
 Ref wrap_in_cps2ds(Ref callee) { return direct::op_cps2ds_dep(callee); }
 
 Ref rewrite_args(Ref arg, Ref n) {
-    if (arg->as_lit_arity() > 1) {
-        auto args = arg->projs();
-        std::vector<const Def*> new_args;
-        new_args.reserve(arg->as_lit_arity());
-        for (auto sub_arg : args) new_args.push_back(rewrite_arg(sub_arg, n));
-        return arg->world().tuple(new_args);
-    } else {
-        return rewrite_arg(arg, n);
-    }
+    size_t num = arg->num_projs();
+    DefArray new_args(num, [=](size_t i) { return rewrite_arg(arg->proj(num, i), n); });
+    return arg->world().tuple(new_args);
 }
 
 Ref rewrite_arg(Ref def, Ref n) {
@@ -32,14 +26,14 @@ Ref rewrite_arg(Ref def, Ref n) {
     const Def* new_app = def;
 
     // clang-format off
-    if (auto _any   = thorin::match<any  >(def)) new_app = world.call<regex::match_any  >(n);
-    if (auto _range = thorin::match<range>(def)) new_app = world.call<regex::match_range>(_range->arg(), n);
-    if (auto _not   = thorin::match<not_ >(def)) new_app = world.call<regex::match_not  >(n, rewrite_args( _not->arg(), n));
-    if (auto _conj  = thorin::match<conj >(def)) new_app = world.call<regex::match_conj >(n, rewrite_args(_conj->arg(), n));
-    if (auto _disj  = thorin::match<disj >(def)) new_app = world.call<regex::match_disj >(n, rewrite_args(_disj->arg(), n));
-    if (auto opt    = thorin::match(quant::optional, def)) new_app = world.call<regex::match_optional>(n, rewrite_args( opt->arg(), n));
-    if (auto star   = thorin::match(quant::star,     def)) new_app = world.call<regex::match_star    >(n, rewrite_args(star->arg(), n));
-    if (auto plus   = thorin::match(quant::plus,     def)) new_app = world.call<regex::match_plus    >(n, rewrite_args(plus->arg(), n));
+    if (auto any   = thorin::match<regex::any  >(   def)) new_app = world.call<regex::match_any     >(n);
+    if (auto range = thorin::match<regex::range>(   def)) new_app = world.call<regex::match_range   >(range->arg(), n);
+    if (auto not_  = thorin::match<regex::not_ >(   def)) new_app = world.call<regex::match_not     >(n, rewrite_args(not_->arg(), n));
+    if (auto conj  = thorin::match<regex::conj >(   def)) new_app = world.call<regex::match_conj    >(n, rewrite_args(conj->arg(), n));
+    if (auto disj  = thorin::match<regex::disj >(   def)) new_app = world.call<regex::match_disj    >(n, rewrite_args(disj->arg(), n));
+    if (auto opt   = thorin::match(quant::optional, def)) new_app = world.call<regex::match_optional>(n, rewrite_args(opt ->arg(), n));
+    if (auto star  = thorin::match(quant::star,     def)) new_app = world.call<regex::match_star    >(n, rewrite_args(star->arg(), n));
+    if (auto plus  = thorin::match(quant::plus,     def)) new_app = world.call<regex::match_plus    >(n, rewrite_args(plus->arg(), n));
     // clang-format on
     return new_app;
 }
@@ -47,20 +41,19 @@ Ref rewrite_arg(Ref def, Ref n) {
 } // namespace
 
 Ref LowerRegex::rewrite(Ref def) {
-    auto& world        = def->world();
     const Def* new_app = def;
 
     if (auto app = def->isa<App>()) {
         const auto n = app->arg();
         // clang-format off
-        if (auto _any   = thorin::match<any  >(app->callee())) new_app = wrap_in_cps2ds(world.call<match_any  >(n));
-        if (auto _range = thorin::match<range>(app->callee())) new_app = wrap_in_cps2ds(world.call<match_range>(_range->arg(), n));
-        if (auto _not   = thorin::match<not_ >(app->callee())) new_app = wrap_in_cps2ds(world.call<match_not  >(n, rewrite_args( _not->arg(), n)));
-        if (auto _conj  = thorin::match<conj >(app->callee())) new_app = wrap_in_cps2ds(world.call<match_conj >(n, rewrite_args(_conj->arg(), n)));
-        if (auto _disj  = thorin::match<disj >(app->callee())) new_app = wrap_in_cps2ds(world.call<match_disj >(n, rewrite_args(_disj->arg(), n)));
-        if (auto opt    = thorin::match(quant::optional, app->callee())) new_app = wrap_in_cps2ds(world.call<match_optional>(n, rewrite_args( opt->arg(), n)));
-        if (auto star   = thorin::match(quant::star,     app->callee())) new_app = wrap_in_cps2ds(world.call<match_star    >(n, rewrite_args(star->arg(), n)));
-        if (auto plus   = thorin::match(quant::plus,     app->callee())) new_app = wrap_in_cps2ds(world.call<match_plus    >(n, rewrite_args(plus->arg(), n)));
+        if (auto any   = thorin::match<regex::any  >(   app->callee())) new_app = wrap_in_cps2ds(world().call<match_any     >(n));
+        if (auto range = thorin::match<regex::range>(   app->callee())) new_app = wrap_in_cps2ds(world().call<match_range   >(range->arg(), n));
+        if (auto not_  = thorin::match<regex::not_ >(   app->callee())) new_app = wrap_in_cps2ds(world().call<match_not     >(n, rewrite_args(not_->arg(), n)));
+        if (auto conj  = thorin::match<regex::conj >(   app->callee())) new_app = wrap_in_cps2ds(world().call<match_conj    >(n, rewrite_args(conj->arg(), n)));
+        if (auto disj  = thorin::match<regex::disj >(   app->callee())) new_app = wrap_in_cps2ds(world().call<match_disj    >(n, rewrite_args(disj->arg(), n)));
+        if (auto opt   = thorin::match(quant::optional, app->callee())) new_app = wrap_in_cps2ds(world().call<match_optional>(n, rewrite_args(opt ->arg(), n)));
+        if (auto star  = thorin::match(quant::star,     app->callee())) new_app = wrap_in_cps2ds(world().call<match_star    >(n, rewrite_args(star->arg(), n)));
+        if (auto plus  = thorin::match(quant::plus,     app->callee())) new_app = wrap_in_cps2ds(world().call<match_plus    >(n, rewrite_args(plus->arg(), n)));
         // clang-format on
     }
 

--- a/dialects/regex/regex.thorin
+++ b/dialects/regex/regex.thorin
@@ -23,7 +23,7 @@
 .lam Res(n: .Nat): * = [%mem.M, .Bool, .Idx n];
 .let RE = Π[n: .Nat][%mem.M, Str n, .Idx n] -> Res n;
 .lam FnRE(n: .Nat): * = .Fn [%mem.M, Str n, .Idx n] -> Res n;
-
+///
 /// ## Meta
 ///
 /// ### %regex.conj
@@ -49,14 +49,12 @@
 /// Use: `%regex.range ('a', 'z')` to match all lower case letters.
 ///
 .ax %regex.range: Π <<2; %core.I8>> -> RE, normalize_range, 1;
-
 ///
 /// ### %regex.lit
 ///
 /// Wraps a literal.
 ///
 .lam %regex.lit(val: Char) = %regex.range (val, val);
-
 ///
 /// ### %regex.not
 ///
@@ -82,24 +80,21 @@
 .let %regex.cls.W = %regex.not_ %regex.cls.w;
 .let %regex.cls.s = %regex.disj 3 (%regex.range ('\t', '\n'), %regex.lit '\r', %regex.lit ' ');
 .let %regex.cls.S = %regex.not_ %regex.cls.s;
-
 ///
 /// ### %regex.any
 ///
 /// Match any character.
 ///
 .ax %regex.any: RE, normalize_any, 0;
-
+///
 /// ## Quantifiers
 ///
 /// ### %regex.quant.*
 ///
 .ax %regex.quant(optional,star,plus): Π RE -> RE, normalize_quant, 1;
-
 ///
 /// ## Implementation
 ///
-
 .fun %regex.match_range(lower upper: Char)(n: .Nat)(mem: %mem.M, string: Str n, pos: .Idx n): Res n =
     .let ptr          = %mem.lea (n, ‹n; Char›, 0) (string, pos);
     .let (`mem, char) = %mem.load (mem, ptr);
@@ -146,13 +141,12 @@
     .con match_plus_ret!(mem: %mem.M, matched: .Bool, new_pos: .Idx n) =
         .con match_plus_iter!(mem: %mem.M, matched: .Bool, new_pos: .Idx n) = sub ((mem, string, new_pos), match_plus_ret);
         (return, match_plus_iter)#matched (mem, .tt, new_pos);
-
     .con match_plus_ret0!(mem: %mem.M, matched: .Bool, new_pos: .Idx n) =
         .con match_plus_iter0!(mem: %mem.M, matched: .Bool, new_pos: .Idx n) = sub ((mem, string, new_pos), match_plus_ret);
         (return, match_plus_iter0)#matched (mem, matched, new_pos);
 
     sub ((mem, string, pos), match_plus_ret0);
-
+///
 /// ## Passes and Phases
 ///
 /// ### Passes

--- a/dialects/regex/regex.thorin
+++ b/dialects/regex/regex.thorin
@@ -8,33 +8,37 @@
 ///
 /// ## Dependencies
 ///
-.import core;
-.import mem;
 .import compile;
+.plugin core;
+.plugin mem;
 .plugin direct;
 ///
 /// ## Types
 ///
 /// ### RE
 ///
+.let Char = %core.I8;
+.lam Str(n: .Nat): * = %mem.Ptr0 «n; Char»;
 /// A regular expression matcher.
-.let RE = Π[n: .Nat][%mem.M, %mem.Ptr0 «n; %core.I8», .Idx n] -> [%mem.M, .Bool, .Idx n];
+.lam Res(n: .Nat): * = [%mem.M, .Bool, .Idx n];
+.let RE = Π[n: .Nat][%mem.M, Str n, .Idx n] -> Res n;
+.lam FnRE(n: .Nat): * = .Fn [%mem.M, Str n, .Idx n] -> Res n;
 
 /// ## Meta
 ///
 /// ### %regex.conj
-/// 
+///
 /// A sequence of RE's, e.g. `\d\d\d` matching 3 digits:
 /// `%regex.conj (%regex.cls.d, %regex.cls.d, %regex.cls.d)
 ///
-.ax %regex.conj: Π[n: .Nat][<<n; RE>>] -> RE, normalize_conj, 2;
+.ax %regex.conj: Π[n: .Nat][«n; RE»] -> RE, normalize_conj, 2;
 
 ///
 /// ### %regex.disj
 ///
 /// Match any of the sub expressions: `[0123456789]`
 ///
-.ax %regex.disj: Π[n: .Nat][<<n; RE>>] -> RE, normalize_disj, 2;
+.ax %regex.disj: Π[n: .Nat][«n; RE»] -> RE, normalize_disj, 2;
 
 ///
 /// ## Values
@@ -51,7 +55,7 @@
 ///
 /// Wraps a literal.
 ///
-.lam %regex.lit(val:%core.I8) = %regex.range (val, val);
+.lam %regex.lit(val: Char) = %regex.range (val, val);
 
 ///
 /// ### %regex.not
@@ -62,7 +66,7 @@
 
 ///
 /// ### %regex.cls.*
-/// 
+///
 /// | Subtag | Matches |
 /// | ------ | ------- |
 /// | `d`    | digits `[0-9]`|
@@ -76,7 +80,7 @@
 .let %regex.cls.D = %regex.not_ %regex.cls.d;
 .let %regex.cls.w = %regex.disj 4 (%regex.range ('0', '9'), %regex.range ('a', 'z'), %regex.range ('A', 'Z'), %regex.lit '_');
 .let %regex.cls.W = %regex.not_ %regex.cls.w;
-.let %regex.cls.s = %regex.disj 3 (%regex.range (9:%core.I8, 10:%core.I8), %regex.lit 13:%core.I8, %regex.lit 32:%core.I8);
+.let %regex.cls.s = %regex.disj 3 (%regex.range ('\t', '\n'), %regex.lit '\r', %regex.lit ' ');
 .let %regex.cls.S = %regex.not_ %regex.cls.s;
 
 ///
@@ -95,78 +99,62 @@
 ///
 /// ## Implementation
 ///
-.lam CPS_RE[n: .Nat] = .Cn [[%mem.M, %mem.Ptr0 «n; %core.I8», .Idx n], .Cn[%mem.M, .Bool, .Idx n]];
 
-.fun %regex.match_range(lower:%core.I8, upper:%core.I8)(n: .Nat)(mem: %mem.M, string: %mem.Ptr0 «n; %core.I8», pos: .Idx n) : [%mem.M, .Bool, .Idx n] = {
-    .let ptr = %mem.lea (n, ‹n; %core.I8›, 0) (string, pos);
+.fun %regex.match_range(lower upper: Char)(n: .Nat)(mem: %mem.M, string: Str n, pos: .Idx n): Res n =
+    .let ptr          = %mem.lea (n, ‹n; Char›, 0) (string, pos);
     .let (`mem, char) = %mem.load (mem, ptr);
-    .let in_range = %core.bit2.and_ 0 (%core.icmp.uge (char, lower),  %core.icmp.ule (char, upper));
-    
-    return (mem, in_range, (pos, %core.conv.u n (%core.wrap.add 0 (%core.conv.u %core.i32 pos, 1:%core.I32)))#in_range)
-};
-.fun %regex.match_not(n: .Nat)(inner: (CPS_RE n))(mem: %mem.M, string: %mem.Ptr0 «n; %core.I8», pos: .Idx n): [%mem.M, .Bool, .Idx n] = {
+    .let in_range     = %core.bit2.and_ 0 (%core.icmp.uge (char, lower),  %core.icmp.ule (char, upper));
+    .let pos_1        = %core.wrap.add %core.mode.nuw (pos, %core.idx n %core.mode.nuw 1);
+    return (mem, in_range, (pos, pos_1)#in_range);
+
+.fun %regex.match_not(n: .Nat)(inner: FnRE n)(mem: %mem.M, string: Str n, pos: .Idx n): Res n =
     .con match_not_ret_inverted!(mem: %mem.M, in_range: .Bool, new_pos: .Idx n) = return (mem, %core.bit1.neg 0 in_range, new_pos);
-    inner ((mem, string, pos), match_not_ret_inverted)
-};
-.fun %regex.match_any(n: .Nat)(mem: %mem.M, string: %mem.Ptr0 «n; %core.I8», pos: .Idx n): [%mem.M, .Bool, .Idx n] = {
-    .let ptr = %mem.lea (n, ‹n; %core.I8›, 0) (string, pos);
+    inner ((mem, string, pos), match_not_ret_inverted);
+
+.fun %regex.match_any(n: .Nat)(mem: %mem.M, string: Str n, pos: .Idx n): Res n =
+    .let ptr          = %mem.lea (n, ‹n; Char›, 0) (string, pos);
     .let (`mem, char) = %mem.load (mem, ptr);
-    .let isnt_0 = %core.icmp.ne (char, '\0');
+    .let isnt_0       = %core.icmp.ne (char, '\0');
+    .let pos_1        = %core.wrap.add %core.mode.nuw (pos, %core.idx n %core.mode.nuw 1);
+    return (mem, isnt_0, (pos, pos_1)#isnt_0);
 
-    return (mem, isnt_0, (pos, %core.conv.u n (%core.wrap.add 0 (%core.conv.u %core.i32 pos, 1:%core.I32)))#isnt_0)
-};
-.fun %regex.match_conj(n: .Nat)(A: (CPS_RE n), B: (CPS_RE n))(mem: %mem.M, string: %mem.Ptr0 «n; %core.I8», pos: .Idx n): [%mem.M, .Bool, .Idx n] = {
-    .con match_conj_B_ret!(mem:%mem.M, matched:.Bool, new_pos:.Idx n) = return (mem, matched, (pos, new_pos)#matched);
+.fun %regex.match_conj(n: .Nat)(A B: FnRE n)(mem: %mem.M, string: Str n, pos: .Idx n): Res n =
+    .con match_conj_B_ret!(mem: %mem.M, matched: .Bool, new_pos: .Idx n) = return (mem, matched, (pos, new_pos)#matched);
+    .con match_conj_A_ret!(mem: %mem.M, matched: .Bool, new_pos: .Idx n) =
+        .con match_conj_call_B!(mem: %mem.M, matched: .Bool, new_pos: .Idx n) = B ((mem, string, new_pos), match_conj_B_ret);
+        (return, match_conj_call_B)#matched (mem, matched, (pos, new_pos)#matched);
+    A ((mem, string, pos), match_conj_A_ret);
 
-    .con match_conj_A_ret!(mem:%mem.M, matched:.Bool, new_pos:.Idx n) = {
-        .con match_conj_call_B!(mem:%mem.M, matched:.Bool, new_pos:.Idx n) = B ((mem, string, new_pos), match_conj_B_ret);
+.fun %regex.match_disj(n: .Nat)(A B: FnRE n)(mem: %mem.M, string: Str n, pos: .Idx n): Res n =
+    .con match_disj_B_ret!(mem: %mem.M, matched: .Bool, new_pos: .Idx n) = return (mem, matched, (pos, new_pos)#matched);
+    .con match_disj_A_ret!(mem: %mem.M, matched: .Bool, new_pos: .Idx n) =
+        .con match_disj_call_B!(mem: %mem.M, matched: .Bool, new_pos: .Idx n) = B ((mem, string, new_pos), match_disj_B_ret);
+        (match_disj_call_B, return)#matched (mem, matched, new_pos);
+    A ((mem, string, pos), match_disj_A_ret);
 
-        (return, match_conj_call_B)#matched (mem, matched, (pos, new_pos)#matched)
-    };
+.fun %regex.match_optional(n: .Nat)(sub: FnRE n)(mem: %mem.M, string: Str n, pos: .Idx n): Res n =
+    .con match_optional_ret!(mem: %mem.M, matched: .Bool, new_pos: .Idx n) = return (mem, .tt, new_pos);
+    sub ((mem, string, pos), match_optional_ret);
 
-    A ((mem, string, pos), match_conj_A_ret)
-};
-.fun %regex.match_disj(n: .Nat)(A: (CPS_RE n), B: (CPS_RE n))(mem: %mem.M, string: %mem.Ptr0 «n; %core.I8», pos: .Idx n): [%mem.M, .Bool, .Idx n] = {
-    .con match_disj_B_ret!(mem:%mem.M, matched:.Bool, new_pos:.Idx n) = return (mem, matched, (pos, new_pos)#matched);
+.fun %regex.match_star(n: .Nat)(sub: FnRE n)(mem: %mem.M, string: Str n, pos: .Idx n): Res n =
+    .con match_star_ret(mem: %mem.M, matched: .Bool, new_pos: .Idx n) =
+        .con match_star_iter(mem: %mem.M, matched: .Bool, new_pos: .Idx n) = sub ((mem, string, new_pos), match_star_ret);
+        (return, match_star_iter)#matched (mem, .tt, new_pos);
+    sub ((mem, string, pos), match_star_ret);
 
-    .con match_disj_A_ret!(mem:%mem.M, matched:.Bool, new_pos:.Idx n) = {
-        .con match_disj_call_B!(mem:%mem.M, matched:.Bool, new_pos:.Idx n) = B ((mem, string, new_pos), match_disj_B_ret);
-        (match_disj_call_B, return)#matched (mem, matched, new_pos)
-    };
-
-    A ((mem, string, pos), match_disj_A_ret)
-};
-.fun %regex.match_optional(n: .Nat)(sub: (CPS_RE n))(mem: %mem.M, string: %mem.Ptr0 «n; %core.I8», pos: .Idx n): [%mem.M, .Bool, .Idx n] = {
-    .con match_optional_ret!(mem:%mem.M, matched:.Bool, new_pos:.Idx n) = return (mem, 1:.Bool, new_pos);
-
-    sub ((mem, string, pos), match_optional_ret)
-};
-.fun %regex.match_star(n: .Nat)(sub: (CPS_RE n))(mem: %mem.M, string: %mem.Ptr0 «n; %core.I8», pos: .Idx n): [%mem.M, .Bool, .Idx n] = {
-    .con match_star_ret(mem:%mem.M, matched:.Bool, new_pos:.Idx n) = {
-        .con match_star_iter(mem: %mem.M, matched:.Bool, new_pos: .Idx n) = sub ((mem, string, new_pos), match_star_ret);
-
-        (return, match_star_iter)#matched (mem, 1:.Bool, new_pos)
-    };
-
-    sub ((mem, string, pos), match_star_ret)
-};
-.fun %regex.match_plus(n: .Nat)(sub: (CPS_RE n))(mem: %mem.M, string: %mem.Ptr0 «n; %core.I8», pos: .Idx n): [%mem.M, .Bool, .Idx n] = {
-    .con match_plus_ret!(mem:%mem.M, matched:.Bool, new_pos:.Idx n) = {
+.fun %regex.match_plus(n: .Nat)(sub: FnRE n)(mem: %mem.M, string: Str n, pos: .Idx n): Res n =
+    .con match_plus_ret!(mem: %mem.M, matched: .Bool, new_pos: .Idx n) =
         .con match_plus_iter!(mem: %mem.M, matched: .Bool, new_pos: .Idx n) = sub ((mem, string, new_pos), match_plus_ret);
-        (return, match_plus_iter)#matched (mem, 1:.Bool, new_pos)
-    };
+        (return, match_plus_iter)#matched (mem, .tt, new_pos);
 
-    .con match_plus_ret0!(mem:%mem.M, matched:.Bool, new_pos:.Idx n) = {
-        .con match_plus_iter0!(mem: %mem.M, matched:.Bool, new_pos: .Idx n) = sub ((mem, string, new_pos), match_plus_ret);
-        (return, match_plus_iter0)#matched (mem, matched, new_pos)
-    };
+    .con match_plus_ret0!(mem: %mem.M, matched: .Bool, new_pos: .Idx n) =
+        .con match_plus_iter0!(mem: %mem.M, matched: .Bool, new_pos: .Idx n) = sub ((mem, string, new_pos), match_plus_ret);
+        (return, match_plus_iter0)#matched (mem, matched, new_pos);
 
-    sub ((mem, string, pos), match_plus_ret0)
-};
+    sub ((mem, string, pos), match_plus_ret0);
 
 /// ## Passes and Phases
-/// 
+///
 /// ### Passes
-/// 
+///
 .ax %regex.lower_regex: %compile.Pass;
-

--- a/dialects/regex/regex.thorin
+++ b/dialects/regex/regex.thorin
@@ -17,12 +17,13 @@
 ///
 /// ### RE
 ///
+/// Char & String
 .let Char = %core.I8;
 .lam Str(n: .Nat): * = %mem.Ptr0 «n; Char»;
 /// A regular expression matcher.
-.lam Res(n: .Nat): * = [%mem.M, .Bool, .Idx n];
-.let RE = Π[n: .Nat][%mem.M, Str n, .Idx n] -> Res n;
+.lam Res (n: .Nat): * = [%mem.M, .Bool, .Idx n];
 .lam FnRE(n: .Nat): * = .Fn [%mem.M, Str n, .Idx n] -> Res n;
+.let RE = Π[n: .Nat][%mem.M, Str n, .Idx n] -> Res n;
 ///
 /// ## Meta
 ///
@@ -32,14 +33,12 @@
 /// `%regex.conj (%regex.cls.d, %regex.cls.d, %regex.cls.d)
 ///
 .ax %regex.conj: Π[n: .Nat][«n; RE»] -> RE, normalize_conj, 2;
-
 ///
 /// ### %regex.disj
 ///
 /// Match any of the sub expressions: `[0123456789]`
 ///
 .ax %regex.disj: Π[n: .Nat][«n; RE»] -> RE, normalize_disj, 2;
-
 ///
 /// ## Values
 ///
@@ -48,7 +47,7 @@
 /// Wraps a range of literals.
 /// Use: `%regex.range ('a', 'z')` to match all lower case letters.
 ///
-.ax %regex.range: Π <<2; %core.I8>> -> RE, normalize_range, 1;
+.ax %regex.range: «2; Char» -> RE, normalize_range, 1;
 ///
 /// ### %regex.lit
 ///
@@ -60,8 +59,7 @@
 ///
 /// Do not match the parameter.
 ///
-.ax %regex.not_: Π RE -> RE, normalize_not, 1;
-
+.ax %regex.not_: RE -> RE, normalize_not, 1;
 ///
 /// ### %regex.cls.*
 ///
@@ -91,7 +89,7 @@
 ///
 /// ### %regex.quant.*
 ///
-.ax %regex.quant(optional,star,plus): Π RE -> RE, normalize_quant, 1;
+.ax %regex.quant(optional,star,plus): RE -> RE, normalize_quant, 1;
 ///
 /// ## Implementation
 ///
@@ -144,7 +142,6 @@
     .con match_plus_ret0!(mem: %mem.M, matched: .Bool, new_pos: .Idx n) =
         .con match_plus_iter0!(mem: %mem.M, matched: .Bool, new_pos: .Idx n) = sub ((mem, string, new_pos), match_plus_ret);
         (return, match_plus_iter0)#matched (mem, matched, new_pos);
-
     sub ((mem, string, pos), match_plus_ret0);
 ///
 /// ## Passes and Phases


### PR DESCRIPTION
This massages the regex code a bit.
* `regex.thorin`
    * use %core.idx instead of casts
    * use %core.mode.nuw for %core.wrap.add and %core.idx
      I actually experienced some serious performance issues some time ago, if this was missing, but I checked with the benchmark: doesn't do anything in our case
    * use more type aliases/functions
    * make use of ptrn groups
    * removed superfluous braces: `{`, `}`
    * use escaped chars (`\t` etc) instead of magic numbers
    * `1:.Bool` -> `.tt`
* C++ files
    * use `world.call` instead of `world.annex` + `world.app`
    * removed now superfluous `any_impl` & co