### PR TITLE
Refactor/blockexpr

### DIFF
--- a/include/thorin/ast/ast.h
+++ b/include/thorin/ast/ast.h
@@ -248,7 +248,7 @@ private:
 /// `dbg::(ptrn_0, ..., ptrn_n-1)` or `dbg::[ptrn_0, ..., ptrn_n-1]`
 class TuplePtrn : public Ptrn {
 public:
-    TuplePtrn(Loc loc, bool rebind, Dbg dbg, Tok::Tag delim_l, Ptrs<Ptrn>&& ptrns)
+    TuplePtrn(Loc loc, Tok::Tag delim_l, Ptrs<Ptrn>&& ptrns, bool rebind, Dbg dbg)
         : Ptrn(loc, rebind, dbg)
         , delim_l_(delim_l)
         , ptrns_(std::move(ptrns)) {}

--- a/include/thorin/ast/ast.h
+++ b/include/thorin/ast/ast.h
@@ -192,6 +192,16 @@ private:
     bool rebind_;
 };
 
+class ErrorPtrn : public Ptrn {
+public:
+    ErrorPtrn(Loc loc)
+        : Ptrn(loc, false, Dbg()) {}
+
+    void bind(Scopes&, bool quiet = false) const override;
+    Ref emit_type(Emitter&) const override;
+    std::ostream& stream(Tab&, std::ostream&) const override;
+};
+
 /// `dbg: type`
 class IdPtrn : public Ptrn {
 public:
@@ -353,25 +363,6 @@ private:
 
     Tok tok_;
     Ptr<Expr> type_;
-};
-
-/// `{ e }`
-/// @deprecated will be removed; use `( e )` instead.
-class BlockExpr : public Expr {
-public:
-    BlockExpr(Loc loc, Ptr<Expr>&& expr)
-        : Expr(loc)
-        , expr_(std::move(expr)) {}
-
-    const Expr* expr() const { return expr_.get(); }
-
-    void bind(Scopes&) const override;
-    std::ostream& stream(Tab&, std::ostream&) const override;
-
-private:
-    Ref emit_(Emitter&) const override;
-
-    Ptr<Expr> expr_;
 };
 
 /// `decls e` or `e .where decls` if @p where is `true`.

--- a/include/thorin/ast/parser.h
+++ b/include/thorin/ast/parser.h
@@ -99,7 +99,7 @@ private:
 
     /// Depending on @p tag, this parses a `()`-style (Tok::Tag::D_paren_l) or `[]`-style (Tok::Tag::D_brckt_l) Ptrn.
     Ptr<Ptrn> parse_ptrn(Tok::Tag tag, std::string_view ctxt, Prec = Prec::Bot, bool allow_annex = false);
-    Ptr<TuplePtrn> parse_tuple_ptrn(bool rebind, Dbg);
+    Ptr<TuplePtrn> parse_tuple_ptrn();
     ///@}
 
     /// @name parse decls

--- a/include/thorin/ast/parser.h
+++ b/include/thorin/ast/parser.h
@@ -82,7 +82,6 @@ private:
     /// @name parse primary exprs
     ///@{
     template<bool> Ptr<Expr> parse_arr_or_pack_expr();
-    Ptr<Expr> parse_block_expr();
     Ptr<Expr> parse_decl_expr();
     Ptr<Expr> parse_lit_expr();
     Ptr<Expr> parse_extremum_expr();

--- a/lit/affine/dynamic_for.thorin
+++ b/lit/affine/dynamic_for.thorin
@@ -9,35 +9,28 @@
 
 .ccon atoi [%mem.M, %mem.Ptr («⊤:.Nat; .I8», 0), .Cn [%mem.M, .I32]];
 
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), return : .Cn [%mem.M, .I32]] = {
-    .con for_body [i : .I32, [acc_a : .I32, acc_b : .I32], continue : .Cn [.I32, .I32]] = {
+.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), return : .Cn [%mem.M, .I32]] =
+    .con for_body [i : .I32, [acc_a : .I32, acc_b : .I32], continue : .Cn [.I32, .I32]] =
         .let a : .I32 = %core.wrap.add 0 (i, acc_a);
         .let b : .I32 = %core.wrap.sub 0 (i, acc_b);
-        continue (a, b)
-    };
+        continue (a, b);
 
-    .con atoi_cont_begin [mem : %mem.M, start : .I32] = {
+    .con atoi_cont_begin [mem : %mem.M, start : .I32] =
         .let _19234: %mem.Ptr (%mem.Ptr («⊤:.Nat; .I8», 0), 0) = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 2I32);
         .let _19247: [%mem.M, %mem.Ptr («⊤:.Nat; .I8», 0)] = %mem.load (mem, _19234);
 
-        .con atoi_cont_end [mem : %mem.M, stop : .I32] = {
+        .con atoi_cont_end [mem : %mem.M, stop : .I32] =
             .let _19318: %mem.Ptr (%mem.Ptr («⊤:.Nat; .I8», 0), 0) = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 3I32);
             .let _19331: [%mem.M, %mem.Ptr («⊤:.Nat; .I8», 0)] = %mem.load (mem, _19318);
-            .con atoi_cont_step [mem : %mem.M, step : .I32] = {
-                .con for_exit [acc : [.I32, .I32]] = {
-                    return (mem, acc#.ff)
-                };
+            .con atoi_cont_step [mem : %mem.M, step : .I32] =
+                .con for_exit [acc : [.I32, .I32]] = return (mem, acc#.ff);
 
-                %affine.For (.i32, 2, (.I32, .I32)) (start, stop, step, (0I32, 5I32), for_body, for_exit)
-            };
-            atoi (_19331#.ff, _19331#.tt, atoi_cont_step)
-        };
-        atoi (_19247#.ff, _19247#.tt, atoi_cont_end)
-    };
+                %affine.For (.i32, 2, (.I32, .I32)) (start, stop, step, (0I32, 5I32), for_body, for_exit);
+            atoi (_19331#.ff, _19331#.tt, atoi_cont_step);
+        atoi (_19247#.ff, _19247#.tt, atoi_cont_end);
 
     .let _19093: %mem.Ptr (%mem.Ptr («⊤:.Nat; .I8», 0), 0) = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 1I32);
     .let _19163: [%mem.M, %mem.Ptr («⊤:.Nat; .I8», 0)] = %mem.load (mem, _19093);
-    atoi (_19163#.ff, _19163#.tt, atoi_cont_begin)
-};
+    atoi (_19163#.ff, _19163#.tt, atoi_cont_begin);
 
 // CHECK-NOT: affine.for

--- a/lit/affine/for_2acc.thorin
+++ b/lit/affine/for_2acc.thorin
@@ -7,17 +7,14 @@
 .plugin core;
 .plugin affine;
 
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I32, 0), 0), return : .Cn [%mem.M, .I32]] = {
-    .con for_exit [acc : [.I32, .I32]] = {
-        return (mem, acc#.ff)
-    };
-
-    .con for_body [i : .I32, acc : [.I32, .I32], continue : .Cn [[.I32, .I32]]] = {
-        .let a : .I32 = %core.wrap.add 0 (i, acc#.ff);
-        .let b : .I32 = %core.wrap.sub 0 (i, acc#.tt);
-        continue (a, b)
-    };
+.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I32, 0), 0), return : .Cn [%mem.M, .I32]] =
     %affine.For (.i32, 2, (.I32, .I32)) (0I32, argc, 1I32, (0I32, 0I32), for_body, for_exit)
-};
+    .where
+        .con for_body [i : .I32, acc : [.I32, .I32], continue : .Cn [[.I32, .I32]]] =
+            .let a : .I32 = %core.wrap.add 0 (i, acc#.ff);
+            .let b : .I32 = %core.wrap.sub 0 (i, acc#.tt);
+            continue (a, b);
+        .con for_exit [acc : [.I32, .I32]] = return (mem, acc#.ff);
+    .end;
 
 // CHECK-NOT: affine.for

--- a/lit/affine/for_2acc_2types.thorin
+++ b/lit/affine/for_2acc_2types.thorin
@@ -7,17 +7,14 @@
 .plugin core;
 .plugin affine;
 
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I32, 0), 0), return : .Cn [%mem.M, .Idx 0]] = {
-    .con for_exit [acc : [.I32, .Idx 0]] = {
-        return (mem, acc#.tt)
-    };
-
-    .con for_body [i : .I32, acc : [.I32, .Idx 0], continue : .Cn [[.I32, .Idx 0]]] = {
-        .let a : .I32 = %core.wrap.add 0 (i, acc#.ff);
-        .let b : .Idx 0 = %core.wrap.add 0 (%core.conv.u 0 i, acc#.tt);
-        continue (a, b)
-    };
+.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I32, 0), 0), return : .Cn [%mem.M, .Idx 0]] =
     %affine.For (.i32, 2, (.I32, .Idx 0)) (0I32, argc, 1I32, (0I32, 0:(.Idx 0)), for_body, for_exit)
-};
+    .where
+        .con for_body [i : .I32, acc : [.I32, .Idx 0], continue : .Cn [[.I32, .Idx 0]]] =
+            .let a : .I32 = %core.wrap.add 0 (i, acc#.ff);
+            .let b : .Idx 0 = %core.wrap.add 0 (%core.conv.u 0 i, acc#.tt);
+            continue (a, b);
+        .con for_exit [acc : [.I32, .Idx 0]] = return (mem, acc#.tt);
+    .end;
 
 // CHECK-NOT: affine.for

--- a/lit/affine/for_2acc_real.thorin
+++ b/lit/affine/for_2acc_real.thorin
@@ -8,18 +8,15 @@
 .plugin math;
 .plugin affine;
 
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I32, 0), 0), return : .Cn [%mem.M, .Idx 0]] = {
-    .con for_exit [acc : [.I32, %math.F64]] = {
-        return (mem, %math.conv.f2u 0 acc#.tt)
-    };
-
-    .con for_body [i : .I32, [acc_a : .I32, acc_b : %math.F64], continue : .Cn [[.I32, %math.F64]]] = {
-        .let a : .I32 = %core.wrap.add 0 (i, acc_a);
-        .let b : %math.F64 = %math.conv.u2f %math.f64 (%core.wrap.add 0 (%core.conv.u 0 i, %math.conv.f2u 0 acc_b));
-        continue (a, b)
-    };
+.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I32, 0), 0), return : .Cn [%mem.M, .Idx 0]] =
     %affine.For (.i32, 2, (.I32, %math.F64)) (0I32, argc, 1I32, (0I32, 0:%math.F64), for_body, for_exit)
-};
+    .where
+        .con for_body [i : .I32, [acc_a : .I32, acc_b : %math.F64], continue : .Cn [[.I32, %math.F64]]] =
+            .let a = %core.wrap.add 0 (i, acc_a);
+            .let b = %math.conv.u2f %math.f64 (%core.wrap.add 0 (%core.conv.u 0 i, %math.conv.f2u 0 acc_b));
+            continue (a, b);
+        .con for_exit [acc : [.I32, %math.F64]] = return (mem, %math.conv.f2u 0 acc#.tt);
+    .end;
 
 // CHECK-NOT: affine.for
 // CHECK: %math.conv.f2u

--- a/lit/affine/for_over_mem.thorin
+++ b/lit/affine/for_over_mem.thorin
@@ -10,20 +10,20 @@
 .let arr_size = ⊤:.Nat;
 // .let arr_size = 16;
 
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I32, 0), 0), return : .Cn [%mem.M, .I32]] =
+.con .extern main [mem: %mem.M, argc: .I32, argv: %mem.Ptr (%mem.Ptr (.I32, 0), 0), return: .Cn [%mem.M, .I32]] =
     .let (`mem, ptr) = %mem.alloc (<<%core.bitcast .Nat argc; .I32>>, 0) (mem);
     %affine.For (.i32, 3, (%mem.M, .I32, .I32)) (0I32, argc, 1I32, (mem, 0I32, 0I32), for_body, for_exit)
     .where
-        .con for_body [i : .I32, [mem : %mem.M, acc_a : .I32, acc_b : .I32], continue : .Cn [%mem.M, .I32, .I32]] =
+        .con for_body [i: .I32, [mem: %mem.M, acc_a: .I32, acc_b: .I32], continue: .Cn [%mem.M, .I32, .I32]] =
             .let a    = %core.wrap.add 0 (i, acc_a);
             .let b    = %core.wrap.sub 0 (i, acc_b);
             .let lea  = %mem.lea (arr_size, <arr_size; .I32>, 0) (ptr, %core.conv.u arr_size i);
             .let `mem = %mem.store (mem, lea, a);
             continue (mem, a, b);
 
-        .con for_exit acc :: [mem : %mem.M, .I32, .I32] =
+        .con for_exit [mem: %mem.M, .I32, .I32]::acc =
             .let lea = %mem.lea (arr_size, <arr_size; .I32>, 0) (ptr, %core.conv.u arr_size (%core.wrap.sub 0 (argc, 4I32)));
-            .let ld::(`mem, val) = %mem.load (mem, lea);
+            .let (`mem, val)::ld = %mem.load (mem, lea);
             return ld;
     .end;
 

--- a/lit/affine/for_over_mem.thorin
+++ b/lit/affine/for_over_mem.thorin
@@ -7,23 +7,25 @@
 .plugin core;
 .plugin affine;
 
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I32, 0), 0), return : .Cn [%mem.M, .I32]] = {
-    // .let arr_size = 16;
-    .let arr_size = ⊤:.Nat;
-    .let (alloc_mem, ptr) = %mem.alloc (<<%core.bitcast .Nat argc; .I32>>, 0) (mem);
-    .con for_exit acc :: [mem : %mem.M, .I32, .I32] = {
-        .let lea = %mem.lea (arr_size, <arr_size; .I32>, 0) (ptr, %core.conv.u arr_size (%core.wrap.sub 0 (argc, 4I32)));
-        .let (load_mem, val) = %mem.load (mem, lea);
-        return (load_mem, val)
-    };
-    .con for_body [i : .I32, [mem : %mem.M, acc_a : .I32, acc_b : .I32], continue : .Cn [%mem.M, .I32, .I32]] = {
-        .let a : .I32 = %core.wrap.add 0 (i, acc_a);
-        .let b : .I32 = %core.wrap.sub 0 (i, acc_b);
-        .let lea = %mem.lea (arr_size, <arr_size; .I32>, 0) (ptr, %core.conv.u arr_size i);
-        .let store_mem = %mem.store (mem, lea, a);
-        continue (store_mem, a, b)
-    };
-    %affine.For (.i32, 3, (%mem.M, .I32, .I32)) (0I32, argc, 1I32, (alloc_mem, 0I32, 0I32), for_body, for_exit)
-};
+.let arr_size = ⊤:.Nat;
+// .let arr_size = 16;
+
+.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I32, 0), 0), return : .Cn [%mem.M, .I32]] =
+    .let (`mem, ptr) = %mem.alloc (<<%core.bitcast .Nat argc; .I32>>, 0) (mem);
+    %affine.For (.i32, 3, (%mem.M, .I32, .I32)) (0I32, argc, 1I32, (mem, 0I32, 0I32), for_body, for_exit)
+    .where
+        .con for_body [i : .I32, [mem : %mem.M, acc_a : .I32, acc_b : .I32], continue : .Cn [%mem.M, .I32, .I32]] =
+            .let a    = %core.wrap.add 0 (i, acc_a);
+            .let b    = %core.wrap.sub 0 (i, acc_b);
+            .let lea  = %mem.lea (arr_size, <arr_size; .I32>, 0) (ptr, %core.conv.u arr_size i);
+            .let `mem = %mem.store (mem, lea, a);
+            continue (mem, a, b);
+
+        .con for_exit acc :: [mem : %mem.M, .I32, .I32] =
+            .let lea = %mem.lea (arr_size, <arr_size; .I32>, 0) (ptr, %core.conv.u arr_size (%core.wrap.sub 0 (argc, 4I32)));
+            .let ld::(`mem, val) = %mem.load (mem, lea);
+            return ld;
+    .end;
+
 
 // CHECK-NOT: affine.For

--- a/lit/autodiff/autodiff_mult_in_call.thorin
+++ b/lit/autodiff/autodiff_mult_in_call.thorin
@@ -5,35 +5,28 @@
 .plugin autodiff;
 
 
-.con swap [[a:.I32, b:.I32], ret: .Cn [.I32,.I32]] = {
-    ret (b,a)
-};
+.con swap [[a:.I32, b:.I32], ret: .Cn [.I32,.I32]] = ret (b,a);
 
-.con f [[a:.I32, b:.I32], ret: .Cn [.I32]] = {
-    .con f_cont [x:.I32,y:.I32] = {
-        ret x
-    };
-    swap((a,b),f_cont)
-};
+.con f [[a:.I32, b:.I32], ret: .Cn [.I32]] =
+    .con f_cont [x:.I32,y:.I32] = ret x;
+    swap((a,b),f_cont);
 
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] = {
-
-    .con ret_cont [r:.I32,pb:.Cn[.I32,.Cn[.I32,.I32]]] = {
-        .con pb_ret_cont [pr_a:.I32,pr_b:.I32] = {
-            .let sr = %core.wrap.mul 0 (10000I32, r);
-            .let sa = %core.wrap.mul 0 (100I32, pr_a);
-            .let sb = pr_b;
-            .let sp = %core.wrap.add 0 (sa, sb);
-            .let o  = %core.wrap.add 0 (sr, sp);
-            return (mem, o)
-        };
-        pb(1I32,pb_ret_cont)
-    };
-
+.con .extern main [mem: %mem.M, argc: .I32, argv: %mem.Ptr (%mem.Ptr (.I8, 0), 0), return: .Cn [%mem.M, .I32]] =
     .let f_diff = %autodiff.ad f;
-
-    .let c = (42I32,43I32);
+    .let c      = (42I32, 43I32);
     f_diff (c,ret_cont)
-};
+    .where
+        .con ret_cont [r:.I32,pb:.Cn[.I32,.Cn[.I32,.I32]]] =
+            pb(1I32,pb_ret_cont)
+            .where
+                .con pb_ret_cont [pr_a:.I32,pr_b:.I32] =
+                    .let sr = %core.wrap.mul 0 (10000I32, r);
+                    .let sa = %core.wrap.mul 0 (100I32, pr_a);
+                    .let sb = pr_b;
+                    .let sp = %core.wrap.add 0 (sa, sb);
+                    .let o  = %core.wrap.add 0 (sr, sp);
+                    return (mem, o);
+            .end;
+    .end;
 
 // CHECK-DAG: return{{.*}}430001

--- a/lit/autodiff/autodiff_mult_in_call2.thorin
+++ b/lit/autodiff/autodiff_mult_in_call2.thorin
@@ -5,32 +5,25 @@
 .plugin autodiff;
 
 
-.con snd [[a:.I32, b:.I32], ret: .Cn [.I32]] = {
-    ret (b)
-};
+.con snd [[a:.I32, b:.I32], ret: .Cn [.I32]] = ret (b);
+.con f [[a:.I32, b:.I32], ret: .Cn [.I32]] = snd((a,b),ret);
 
-.con f [[a:.I32, b:.I32], ret: .Cn [.I32]] = {
-    snd((a,b),ret)
-};
-
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] = {
-
-    .con ret_cont [r:.I32,pb:.Cn[.I32,.Cn[.I32,.I32]]] = {
-        .con pb_ret_cont [pr_a:.I32,pr_b:.I32] = {
-            .let sr = %core.wrap.mul 0 (10000I32, r);
-            .let sa = %core.wrap.mul 0 (100I32, pr_a);
-            .let sb = pr_b;
-            .let sp = %core.wrap.add 0 (sa, sb);
-            .let o  = %core.wrap.add 0 (sr, sp);
-            return (mem, o)
-        };
-        pb(1I32,pb_ret_cont)
-    };
-
+.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] =
     .let f_diff = %autodiff.ad f;
-
-    .let c = (42I32,43I32);
+    .let c      = (42I32,43I32);
     f_diff (c,ret_cont)
-};
+    .where
+        .con ret_cont [r:.I32,pb:.Cn[.I32,.Cn[.I32,.I32]]] =
+            pb(1I32,pb_ret_cont)
+            .where
+                .con pb_ret_cont [pr_a:.I32,pr_b:.I32] =
+                    .let sr = %core.wrap.mul 0 (10000I32, r);
+                    .let sa = %core.wrap.mul 0 (100I32, pr_a);
+                    .let sb = pr_b;
+                    .let sp = %core.wrap.add 0 (sa, sb);
+                    .let o  = %core.wrap.add 0 (sr, sp);
+                    return (mem, o)
+            .end;
+    .end;
 
 // CHECK-DAG: return{{.*}}430001

--- a/lit/autodiff/autodiff_mult_in_call2_2.thorin
+++ b/lit/autodiff/autodiff_mult_in_call2_2.thorin
@@ -3,33 +3,25 @@
 
 .plugin autodiff;
 
+.fun fst(a b:.I32): .I32 = return a;
+.fun f(a b: .I32): .I32 = fst ((a, b), return);
 
-.con fst [[a:.I32, b:.I32], ret: .Cn [.I32]] = {
-    ret (a)
-};
-
-.con f [[a:.I32, b:.I32], ret: .Cn [.I32]] = {
-    fst((a,b),ret)
-};
-
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] = {
-
-    .con ret_cont [r:.I32,pb:.Cn[.I32,.Cn[.I32,.I32]]] = {
-        .con pb_ret_cont [pr_a:.I32,pr_b:.I32] = {
-            .let sr = %core.wrap.mul 0 (10000I32, r);
-            .let sa = %core.wrap.mul 0 (100I32, pr_a);
-            .let sb = pr_b;
-            .let sp = %core.wrap.add 0 (sa, sb);
-            .let o  = %core.wrap.add 0 (sr, sp);
-            return (mem, o)
-        };
-        pb(1I32,pb_ret_cont)
-    };
-
+.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] =
     .let f_diff = %autodiff.ad f;
-
-    .let c = (42I32,43I32);
+    .let c      = (42I32, 43I32);
     f_diff (c,ret_cont)
-};
+    .where
+        .con ret_cont [r:.I32,pb:.Cn[.I32,.Cn[.I32,.I32]]] =
+            pb(1I32,pb_ret_cont)
+            .where
+                .con pb_ret_cont [pr_a:.I32,pr_b:.I32] =
+                    .let sr = %core.wrap.mul 0 (10000I32, r);
+                    .let sa = %core.wrap.mul 0 (100I32, pr_a);
+                    .let sb = pr_b;
+                    .let sp = %core.wrap.add 0 (sa, sb);
+                    .let o  = %core.wrap.add 0 (sr, sp);
+                    return (mem, o);
+            .end;
+    .end;
 
 // CHECK-DAG: return{{.*}}420100

--- a/lit/autodiff/autodiff_mult_in_call2_3.thorin
+++ b/lit/autodiff/autodiff_mult_in_call2_3.thorin
@@ -5,32 +5,25 @@
 .plugin autodiff;
 
 
-.con snd [[a:.I32, b:.I32], ret: .Cn [.I32]] = {
-    ret (b)
-};
+.con snd [[a:.I32, b:.I32], ret: .Cn [.I32]] = ret (b);
+.con f [[a:.I32, b:.I32], ret: .Cn [.I32]] = snd((b,a),ret);
 
-.con f [[a:.I32, b:.I32], ret: .Cn [.I32]] = {
-    snd((b,a),ret)
-};
-
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] = {
-
-    .con ret_cont [r:.I32,pb:.Cn[.I32,.Cn[.I32,.I32]]] = {
-        .con pb_ret_cont [pr_a:.I32,pr_b:.I32] = {
-            .let sr = %core.wrap.mul 0 (10000I32, r);
-            .let sa = %core.wrap.mul 0 (100I32, pr_a);
-            .let sb = pr_b;
-            .let sp = %core.wrap.add 0 (sa, sb);
-            .let o  = %core.wrap.add 0 (sr, sp);
-            return (mem, o)
-        };
-        pb(1I32,pb_ret_cont)
-    };
-
+.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] =
     .let f_diff = %autodiff.ad f;
-
-    .let c = (42I32,43I32);
+    .let c      = (42I32,43I32);
     f_diff (c,ret_cont)
-};
+    .where
+        .con ret_cont [r:.I32,pb:.Cn[.I32,.Cn[.I32,.I32]]] =
+            pb(1I32,pb_ret_cont)
+            .where
+                .con pb_ret_cont [pr_a:.I32,pr_b:.I32] =
+                    .let sr = %core.wrap.mul 0 (10000I32, r);
+                    .let sa = %core.wrap.mul 0 (100I32, pr_a);
+                    .let sb = pr_b;
+                    .let sp = %core.wrap.add 0 (sa, sb);
+                    .let o  = %core.wrap.add 0 (sr, sp);
+                    return (mem, o);
+            .end;
+    .end;
 
 // CHECK-DAG: return{{.*}}420100

--- a/lit/autodiff/autodiff_mult_in_call_cont.thorin
+++ b/lit/autodiff/autodiff_mult_in_call_cont.thorin
@@ -5,31 +5,28 @@
 .plugin autodiff;
 
 
-.con f [[a:.I32, b:.I32], ret: .Cn [.I32]] = {
-    .con f_cont [x:.I32,y:.I32] = {
-        ret x
-    };
+.con f [[a:.I32, b:.I32], ret: .Cn [.I32]] =
     f_cont((b,a))
-};
+    .where
+        .con f_cont [x:.I32,y:.I32] = ret x;
+    .end;
 
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] = {
-
-    .con ret_cont [r:.I32,pb:.Cn[.I32,.Cn[.I32,.I32]]] = {
-        .con pb_ret_cont [pr_a:.I32,pr_b:.I32] = {
-            .let sr = %core.wrap.mul 0 (10000I32, r);
-            .let sa = %core.wrap.mul 0 (100I32, pr_a);
-            .let sb = pr_b;
-            .let sp = %core.wrap.add 0 (sa, sb);
-            .let o  = %core.wrap.add 0 (sr, sp);
-            return (mem, o)
-        };
-        pb(1I32,pb_ret_cont)
-    };
-
+.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] =
     .let f_diff = %autodiff.ad f;
-
-    .let c = (42I32,43I32);
+    .let c      = (42I32, 43I32);
     f_diff (c,ret_cont)
-};
+    .where
+        .con ret_cont [r:.I32,pb:.Cn[.I32,.Cn[.I32,.I32]]] =
+            pb(1I32,pb_ret_cont)
+            .where
+                .con pb_ret_cont [pr_a:.I32,pr_b:.I32] =
+                    .let sr = %core.wrap.mul 0 (10000I32, r);
+                    .let sa = %core.wrap.mul 0 (100I32, pr_a);
+                    .let sb = pr_b;
+                    .let sp = %core.wrap.add 0 (sa, sb);
+                    .let o  = %core.wrap.add 0 (sr, sp);
+                    return (mem, o);
+            .end;
+    .end;
 
 // CHECK-DAG: return{{.*}}430001

--- a/lit/autodiff/call_autodiff.thorin
+++ b/lit/autodiff/call_autodiff.thorin
@@ -5,34 +5,29 @@
 .plugin autodiff;
 
 
-.con g [b:.I32, ret: .Cn [.I32]] = {
+.fun g(b: .I32): .I32 =
     .let c = %core.wrap.mul 0 (3I32, b);
-    ret c
-};
+    return c;
 
-.con f [a:.I32, ret: .Cn [.I32]] = {
+.fun f(a: .I32): .I32 =
     .let b = %core.wrap.mul 0 (2I32, a);
-    // ret b
-    g (b, ret)
-};
+    g (b, return);
 
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] = {
-
-    .con ret_cont [r:.I32,pb:.Cn[.I32,.Cn[.I32]]] = {
-        .con pb_ret_cont [pr:.I32] = {
-            .let c = %core.wrap.mul 0 (100I32, r);
-            .let d = %core.wrap.add 0 (c, pr);
-            return (mem, d)
-        };
-        // return (mem, r)
-        pb(1I32,pb_ret_cont)
-    };
-
-    .let f_diff = %autodiff.ad f;
+.con .extern main[mem: %mem.M, argc: .I32, argv: %mem.Ptr (%mem.Ptr (.I8, 0), 0), return: .Cn [%mem.M, .I32]] =
+    .let f_diff      = %autodiff.ad f;
     .let f_diff_cast = f_diff;
-
-    .let c = 42I32;
+    .let c           = 42I32;
     f_diff_cast (c,ret_cont)
-};
+    .where
+        .con ret_cont [r:.I32,pb:.Cn[.I32,.Cn[.I32]]] =
+            pb(1I32,pb_ret_cont)
+            .where
+                .con pb_ret_cont [pr:.I32] =
+                    .let c = %core.wrap.mul 0 (100I32, r);
+                    .let d = %core.wrap.add 0 (c, pr);
+                    return (mem, d);
+            .end;
+            // return (mem, r)
+    .end;
 
 // CHECK-DAG: return{{.*}}25206

--- a/lit/autodiff/call_autodiff_cont.thorin
+++ b/lit/autodiff/call_autodiff_cont.thorin
@@ -5,38 +5,31 @@
 .plugin autodiff;
 
 
-.con g [b:.I32, ret: .Cn [.I32]] = {
+.fun g(b: .I32): .I32 =
     .let c = %core.wrap.add 0 (3I32, b);
-    ret c
-};
+    return c;
 
 // 4(3+2a)
-.con f [a:.I32, ret: .Cn [.I32]] = {
-    .con ret_cont [x:.I32] = {
-        .let b = %core.wrap.mul 0 (4I32, x);
-        ret b
-    };
+.fun f(a: .I32): .I32 =
     .let b = %core.wrap.mul 0 (2I32, a);
-    g (b, ret_cont)
-};
+    .ret x = g $ b;
+    .let c = %core.wrap.mul 0 (4I32, x);
+    return c;
 
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] = {
-
-    .con ret_cont [r:.I32,pb:.Cn[.I32,.Cn[.I32]]] = {
-        .con pb_ret_cont [pr:.I32] = {
-            .let c = %core.wrap.mul 0 (100I32, r);
-            .let d = %core.wrap.add 0 (c, pr);
-            return (mem, d)
-        };
-        // return (mem, r)
-        pb(1I32,pb_ret_cont)
-    };
-
+.con .extern main(mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]) =
     .let f_diff = %autodiff.ad f;
-
-    .let c = 42I32;
+    .let c      = 42I32;
     f_diff (c,ret_cont)
-
-};
+    .where
+        .con ret_cont [r:.I32,pb:.Cn[.I32,.Cn[.I32]]] =
+            pb(1I32,pb_ret_cont)
+            .where
+                .con pb_ret_cont [pr:.I32] =
+                    .let c = %core.wrap.mul 0 (100I32, r);
+                    .let d = %core.wrap.add 0 (c, pr);
+                    return (mem, d);
+            .end;
+            // return (mem, r)
+    .end;
 
 // CHECK-DAG: return{{.*}}34808

--- a/lit/autodiff/general/cps_inline.thorin
+++ b/lit/autodiff/general/cps_inline.thorin
@@ -4,20 +4,14 @@
 .plugin core;
 
 
-.con f [a:.I32, ret: .Cn [.I32]] = {
+.fun f(a: .I32): .I32 =
     .let b = %core.wrap.mul 0 (2I32, a);
-    ret b
-};
+    return b;
 
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] = {
-
-    .con ret_cont r::[.I32] = {
-        return (mem, r)
-    };
-
+.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] =
     .let c = 42I32;
-    f (c,ret_cont)
-};
+    .ret r = f $ c;
+    return (mem, r);
 
 
 // CHECK-DAG: return{{.*}}84

--- a/lit/autodiff/general/ds_inline.thorin
+++ b/lit/autodiff/general/ds_inline.thorin
@@ -7,8 +7,8 @@
 .lam f [a:.I32]: .I32 =
     %core.wrap.mul 0 (2I32, a);
 
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] =
-    .con ret_cont r::[.I32] = return (mem, r);
+.con .extern main [mem: %mem.M, argc: .I32, argv: %mem.Ptr (%mem.Ptr (.I8, 0), 0), return: .Cn [%mem.M, .I32]] =
+    .con ret_cont r: .I32 = return (mem, r);
     .let c = 42I32;
     .let r = f c;
     ret_cont r;

--- a/lit/autodiff/general/invoke_ds.thorin
+++ b/lit/autodiff/general/invoke_ds.thorin
@@ -5,15 +5,15 @@
 .plugin direct;
 .plugin autodiff;
 
-.con extract_pb_535733 _535735::[s_535741: %mem.M, _535737: .Cn [%mem.M, «2; .I32»]] =
+.con extract_pb_535733 [s_535741: %mem.M, _535737: .Cn [%mem.M, «2; .I32»]] =
     .con _535734 _535738: [%mem.M, «2; .I32»] = _535737 _535738;
     _535734 (s_535741, ‹2; 0I32›);
 
-.con extract_pb_535776 _535778::[s_535787: .I32, _535780: .Cn [%mem.M, «2; .I32»]] =
+.con extract_pb_535776 [s_535787: .I32, _535780: .Cn [%mem.M, «2; .I32»]] =
     .con _535777 _535781: [%mem.M, «2; .I32»] = _535780 _535781;
     _535777 (%autodiff.zero %mem.M, (0I32, s_535787));
 
-.con .extern main __535682::[mem_535757: %mem.M, .I32, %mem.Ptr (%mem.Ptr ((.I8), 0), 0), return_535686: .Cn [%mem.M, .I32]] =
+.con .extern main [mem_535757: %mem.M, .I32, %mem.Ptr (%mem.Ptr ((.I8), 0), 0), return_535686: .Cn [%mem.M, .I32]] =
     .let _535758: [%mem.M, «2; .I32»] = %direct.cps2ds (%mem.M, [%mem.M, «2; .I32»]) extract_pb_535733 mem_535757;
     .let _535793: [%mem.M, «2; .I32»] = %direct.cps2ds (.I32, [%mem.M, «2; .I32»]) extract_pb_535776 1I32;
     .let _535797: %mem.M = %autodiff.add (_535758#.ff, _535793#0_2);

--- a/lit/autodiff/general/invoke_ds.thorin
+++ b/lit/autodiff/general/invoke_ds.thorin
@@ -5,22 +5,15 @@
 .plugin direct;
 .plugin autodiff;
 
-.con extract_pb_535733 _535735::[s_535741: %mem.M, _535737: .Cn [%mem.M, «2; .I32»]] = {
-    .con _535734 _535738: [%mem.M, «2; .I32»] = {
-        _535737 _535738
-    };
-    _535734 (s_535741, ‹2; 0I32›)
-};
-.con extract_pb_535776 _535778::[s_535787: .I32, _535780: .Cn [%mem.M, «2; .I32»]] = {
-    .con _535777 _535781: [%mem.M, «2; .I32»] = {
-        _535780 _535781
-    };
-    _535777 (%autodiff.zero %mem.M, (0I32, s_535787))
-};
-.con .extern main __535682::[mem_535757: %mem.M, .I32, %mem.Ptr (%mem.Ptr ((.I8), 0), 0), return_535686: .Cn [%mem.M, .I32]] = {
-    .con return_535681 _535687: [%mem.M, .I32] = {
-        return_535686 _535687
-    };
+.con extract_pb_535733 _535735::[s_535741: %mem.M, _535737: .Cn [%mem.M, «2; .I32»]] =
+    .con _535734 _535738: [%mem.M, «2; .I32»] = _535737 _535738;
+    _535734 (s_535741, ‹2; 0I32›);
+
+.con extract_pb_535776 _535778::[s_535787: .I32, _535780: .Cn [%mem.M, «2; .I32»]] =
+    .con _535777 _535781: [%mem.M, «2; .I32»] = _535780 _535781;
+    _535777 (%autodiff.zero %mem.M, (0I32, s_535787));
+
+.con .extern main __535682::[mem_535757: %mem.M, .I32, %mem.Ptr (%mem.Ptr ((.I8), 0), 0), return_535686: .Cn [%mem.M, .I32]] =
     .let _535758: [%mem.M, «2; .I32»] = %direct.cps2ds (%mem.M, [%mem.M, «2; .I32»]) extract_pb_535733 mem_535757;
     .let _535793: [%mem.M, «2; .I32»] = %direct.cps2ds (.I32, [%mem.M, «2; .I32»]) extract_pb_535776 1I32;
     .let _535797: %mem.M = %autodiff.add (_535758#.ff, _535793#0_2);
@@ -29,6 +22,8 @@
     .let _535884: .I32 = %core.wrap.add 0 (_535843#1_2, _535879);
     .let _535895: .I32 = %core.wrap.add 0 (430000I32, _535884);
     return_535681 (_535797, _535895)
-};
+    .where
+        .con return_535681 _535687: [%mem.M, .I32] = return_535686 _535687;
+    .end;
 
 // CHECK-DAG: return{{.*}}430001

--- a/lit/autodiff/general/tangent_type_cast.thorin
+++ b/lit/autodiff/general/tangent_type_cast.thorin
@@ -10,11 +10,11 @@
     ret b;
 
 .con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] =
-    .con ret_cont r::[%autodiff.Tangent .I32] =
+    .con ret_cont r: %autodiff.Tangent .I32 =
         .let r2=%core.bitcast .I32 r;
         return (mem, r2);
 
-    .con ret_wrap r::[.I32] =
+    .con ret_wrap r: .I32 =
         .let r2=%core.bitcast (%autodiff.Tangent .I32) r;
         ret_cont r2;
 

--- a/lit/autodiff/general/zero_tuple.thorin
+++ b/lit/autodiff/general/zero_tuple.thorin
@@ -5,13 +5,8 @@
 .plugin direct;
 .plugin autodiff;
 
-
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] = {
-
-    .let t = %autodiff.zero [.I32,.I32];
-    .let c = t#(.ff);
-    return (mem,c)
-};
-
+.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] =
+    .let (c, _) = %autodiff.zero [.I32,.I32];
+    return (mem, c);
 
 // CHECK-DAG: return{{.*}}0

--- a/lit/autodiff/id_autodiff.thorin
+++ b/lit/autodiff/id_autodiff.thorin
@@ -3,28 +3,21 @@
 
 .plugin autodiff;
 
-
-.con f [a:.I32, ret: .Cn [.I32]] = {
+.fun f(a: .I32): .I32 =
     .let b = a;
-    ret b
-};
+    return b;
 
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] = {
-
-    .con pb_ret_cont [pr:.I32] = {
-        return (mem, pr)
-    };
-
-    .con ret_cont [r:.I32,pb:.Cn[.I32,.Cn[.I32]]] = {
-        // return (mem, r)
-        pb(1I32,pb_ret_cont)
-    };
-
-    .let f_diff = %autodiff.ad f;
+.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] =
+    .let f_diff      = %autodiff.ad f;
     .let f_diff_cast = f_diff;
-
-    .let c = 43I32;
+    .let c           = 43I32;
     f_diff_cast (c,ret_cont)
-};
+    .where
+        .con ret_cont [r:.I32,pb:.Cn[.I32,.Cn[.I32]]] =
+        pb (1I32, pb_ret_cont)
+        .where
+            .con pb_ret_cont [pr:.I32] = return (mem, pr);
+        .end;
+    .end;
 
 // CHECK-DAG: return{{.*}}1

--- a/lit/autodiff/id_autodiff_info_out.thorin
+++ b/lit/autodiff/id_autodiff_info_out.thorin
@@ -5,27 +5,25 @@
 .plugin autodiff;
 
 
-.con f [a:.I32, ret: .Cn [.I32]] = {
+.fun f(a: .I32): .I32 =
     .let b = a;
-    ret b
-};
+    return b;
 
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] = {
-
-    .con ret_cont [r:.I32,pb:.Cn[.I32,.Cn[.I32]]] = {
-        .con pb_ret_cont [pr:.I32] = {
-            .let c = %core.wrap.mul 0 (100I32, r);
-            .let d = %core.wrap.add 0 (c, pr);
-            return (mem, d)
-        };
-        pb(1I32,pb_ret_cont)
-    };
-
+.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] =
     .let f_diff = %autodiff.ad f;
     .let f_diff_cast = f_diff;
 
     .let c = 43I32;
     f_diff_cast (c,ret_cont)
-};
+    .where
+        .con ret_cont [r:.I32,pb:.Cn[.I32,.Cn[.I32]]] =
+            pb(1I32,pb_ret_cont)
+            .where
+                .con pb_ret_cont [pr:.I32] =
+                    .let c = %core.wrap.mul 0 (100I32, r);
+                    .let d = %core.wrap.add 0 (c, pr);
+                    return (mem, d);
+            .end;
+    .end;
 
 // CHECK-DAG: return{{.*}}4301

--- a/lit/autodiff/id_autodiff_mult_in.thorin
+++ b/lit/autodiff/id_autodiff_mult_in.thorin
@@ -4,30 +4,26 @@
 .plugin core;
 .plugin autodiff;
 
-
-.con f [[a:.I32, b:.I32], ret: .Cn [.I32]] = {
+.fun f(a b: .I32): .I32 =
     .let x = b;
-    ret x
-};
+    return x;
 
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] = {
-
-    .con ret_cont [r:.I32,pb:.Cn[.I32,.Cn[.I32,.I32]]] = {
-        .con pb_ret_cont [pr_a:.I32,pr_b:.I32] = {
-            .let sr = %core.wrap.mul 0 (10000I32, r);
-            .let sa = %core.wrap.mul 0 (100I32, pr_a);
-            .let sb = pr_b;
-            .let sp = %core.wrap.add 0 (sa, sb);
-            .let o  = %core.wrap.add 0 (sr, sp);
-            return (mem, o)
-        };
-        pb(1I32,pb_ret_cont)
-    };
-
+.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] =
     .let f_diff = %autodiff.ad f;
-
-    .let c = (42I32,43I32);
-    f_diff (c,ret_cont)
-};
+    .let c      = (42I32, 43I32);
+    f_diff (c, ret_cont)
+    .where
+        .con ret_cont(r:.I32, pb: .Cn[.I32,.Cn[.I32,.I32]]) =
+            pb(1I32,pb_ret_cont)
+            .where
+                .con pb_ret_cont [pr_a:.I32,pr_b:.I32] =
+                    .let sr = %core.wrap.mul 0 (10000I32, r);
+                    .let sa = %core.wrap.mul 0 (100I32, pr_a);
+                    .let sb = pr_b;
+                    .let sp = %core.wrap.add 0 (sa, sb);
+                    .let o  = %core.wrap.add 0 (sr, sp);
+                    return (mem, o)
+            .end;
+    .end;
 
 // CHECK-DAG: return{{.*}}430001

--- a/lit/autodiff/id_autodiff_mult_in_mem.thorin
+++ b/lit/autodiff/id_autodiff_mult_in_mem.thorin
@@ -5,29 +5,26 @@
 .plugin autodiff;
 
 
-.con f [[mem:%mem.M,[a:.I32, b:.I32]], ret: .Cn [%mem.M,.I32]] = {
+.fun f(mem: %mem.M, (a b:.I32)): [%mem.M, .I32] =
     .let x = b;
-    ret (mem,x)
-};
+    return (mem,x);
 
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] = {
-
-    .con ret_cont [[rmem:%mem.M,r:.I32],pb:.Cn[[%mem.M,.I32],.Cn[%mem.M,[.I32,.I32]]]] = {
-        .con pb_ret_cont [pb_mem:%mem.M,[pr_a:.I32,pr_b:.I32]] = {
-            .let sr = %core.wrap.mul 0 (10000I32, r);
-            .let sa = %core.wrap.mul 0 (100I32, pr_a);
-            .let sb = pr_b;
-            .let sp = %core.wrap.add 0 (sa, sb);
-            .let o  = %core.wrap.add 0 (sr, sp);
-            return (pb_mem, o)
-        };
-        pb ((rmem, 1I32), pb_ret_cont)
-    };
-
+.con .extern main [mem: %mem.M, argc: .I32, argv: %mem.Ptr (%mem.Ptr (.I8, 0), 0), return: .Cn [%mem.M, .I32]] =
     .let f_diff = %autodiff.ad f;
-
-    .let c = (42I32, 43I32);
+    .let c      = (42I32, 43I32);
     f_diff ((mem,c),ret_cont)
-};
+    .where
+        .con ret_cont [[rmem: %mem.M,r:.I32], pb: .Cn[[%mem.M,.I32],.Cn[%mem.M,[.I32,.I32]]]] =
+            pb ((rmem, 1I32), pb_ret_cont)
+            .where
+                .con pb_ret_cont [pb_mem:%mem.M,[pr_a:.I32,pr_b:.I32]] =
+                    .let sr = %core.wrap.mul 0 (10000I32, r);
+                    .let sa = %core.wrap.mul 0 (100I32, pr_a);
+                    .let sb = pr_b;
+                    .let sp = %core.wrap.add 0 (sa, sb);
+                    .let o  = %core.wrap.add 0 (sr, sp);
+                    return (pb_mem, o);
+            .end;
+    .end;
 
 // CHECK-DAG: return{{.*}}430001

--- a/lit/autodiff/id_autodiff_mult_in_mult.thorin
+++ b/lit/autodiff/id_autodiff_mult_in_mult.thorin
@@ -5,29 +5,26 @@
 .plugin autodiff;
 
 
-.con f [[a:.I32, b:.I32], ret: .Cn [.I32]] = {
+.fun f(a b:.I32): .I32 =
     .let x = %core.wrap.mul 0 (b, a);
-    ret x
-};
+    return x;
 
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] = {
-
-    .con ret_cont [r:.I32,pb:.Cn[.I32,.Cn[.I32,.I32]]] = {
-        .con pb_ret_cont [pr_a:.I32,pr_b:.I32] = {
-            .let sr = %core.wrap.mul 0 (10000I32, r);
-            .let sa = %core.wrap.mul 0 (100I32, pr_a);
-            .let sb = pr_b;
-            .let sp = %core.wrap.add 0 (sa, sb);
-            .let o  = %core.wrap.add 0 (sr, sp);
-            return (mem, o)
-        };
-        pb(1I32,pb_ret_cont)
-    };
-
+.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] =
     .let f_diff = %autodiff.ad f;
-
-    .let c = (42I32,43I32);
+    .let c      = (42I32, 43I32);
     f_diff (c,ret_cont)
-};
+    .where
+        .con ret_cont[r: .I32,pb: .Cn[.I32,.Cn[.I32,.I32]]] =
+            pb(1I32,pb_ret_cont)
+            .where
+                .con pb_ret_cont [pr_a: .I32,pr_b: .I32] =
+                    .let sr = %core.wrap.mul 0 (10000I32, r);
+                    .let sa = %core.wrap.mul 0 (100I32, pr_a);
+                    .let sb = pr_b;
+                    .let sp = %core.wrap.add 0 (sa, sb);
+                    .let o  = %core.wrap.add 0 (sr, sp);
+                    return (mem, o);
+            .end;
+    .end;
 
 // CHECK-DAG: return{{.*}}18064342

--- a/lit/autodiff/id_autodiff_mult_in_mult2.thorin
+++ b/lit/autodiff/id_autodiff_mult_in_mult2.thorin
@@ -4,30 +4,26 @@
 .plugin core;
 .plugin autodiff;
 
-
-.con f [[a:.I32, b:.I32], ret: .Cn [.I32]] = {
+.fun f(a b:.I32): .I32 =
     .let x = %core.wrap.mul 0 (a, b);
-    ret x
-};
+    return x;
 
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] = {
-
-    .con ret_cont [r:.I32,pb:.Cn[.I32,.Cn[.I32,.I32]]] = {
-        .con pb_ret_cont [pr_a:.I32,pr_b:.I32] = {
-            .let sr = %core.wrap.mul 0 (10000I32, r);
-            .let sa = %core.wrap.mul 0 (100I32, pr_a);
-            .let sb = pr_b;
-            .let sp = %core.wrap.add 0 (sa, sb);
-            .let o  = %core.wrap.add 0 (sr, sp);
-            return (mem, o)
-        };
-        pb(1I32,pb_ret_cont)
-    };
-
+.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] =
     .let f_diff = %autodiff.ad f;
-
-    .let c = (42I32,43I32);
+    .let c      = (42I32, 43I32);
     f_diff (c,ret_cont)
-};
+    .where
+        .con ret_cont [r:.I32,pb:.Cn[.I32,.Cn[.I32,.I32]]] =
+            pb(1I32,pb_ret_cont)
+            .where
+                .con pb_ret_cont [pr_a:.I32,pr_b:.I32] =
+                    .let sr = %core.wrap.mul 0 (10000I32, r);
+                    .let sa = %core.wrap.mul 0 (100I32, pr_a);
+                    .let sb = pr_b;
+                    .let sp = %core.wrap.add 0 (sa, sb);
+                    .let o  = %core.wrap.add 0 (sr, sp);
+                    return (mem, o);
+            .end;
+    .end;
 
 // CHECK-DAG: return{{.*}}18064342

--- a/lit/autodiff/multiply2_autodiff.thorin
+++ b/lit/autodiff/multiply2_autodiff.thorin
@@ -4,31 +4,27 @@
 .plugin core;
 .plugin autodiff;
 
-
-.con f [a:.I32, ret: .Cn [.I32]] = {
+.fun f(a: .I32): .I32 =
     .let b = %core.wrap.add 0 (3I32, a);
     .let c = %core.wrap.mul 0 (a, b);
     // (3+a)a => 3 + 2a
-    ret c
-};
+    return c;
 
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] = {
-
-    .con ret_cont [r:.I32,pb:.Cn[.I32,.Cn[.I32]]] = {
-        .con pb_ret_cont [pr:.I32] = {
-            .let c = %core.wrap.mul 0 (100I32, r);
-            .let d = %core.wrap.add 0 (c, pr);
-            return (mem, d)
-        };
-        // return (mem, r)
-        pb(1I32,pb_ret_cont)
-    };
-
-    .let f_diff = %autodiff.ad f;
+.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] =
+    .let f_diff      = %autodiff.ad f;
     .let f_diff_cast = f_diff;
-
-    .let c = 42I32;
+    .let c           = 42I32;
     f_diff_cast (c,ret_cont)
-};
+    .where
+        .con ret_cont [r: .I32, pb: .Fn .I32 -> .I32] =
+            // return (mem, r)
+            pb(1I32,pb_ret_cont)
+            .where
+                .con pb_ret_cont [pr:.I32] =
+                    .let c = %core.wrap.mul 0 (100I32, r);
+                    .let d = %core.wrap.add 0 (c, pr);
+                    return (mem, d);
+            .end;
+    .end;
 
 // CHECK-DAG: return{{.*}}189087

--- a/lit/autodiff/multiply_autodiff.thorin
+++ b/lit/autodiff/multiply_autodiff.thorin
@@ -5,28 +5,25 @@
 .plugin autodiff;
 
 
-.con f [a:.I32, ret: .Cn [.I32]] = {
+.fun f(a: .I32): .I32 =
     .let b = %core.wrap.mul 0 (2I32, a);
-    ret b
-};
+    return b;
 
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] = {
-
-    .con ret_cont [r:.I32,pb:.Cn[.I32,.Cn[.I32]]] = {
-        .con pb_ret_cont [pr:.I32] = {
-            .let c = %core.wrap.mul 0 (100I32, r);
-            .let d = %core.wrap.add 0 (c, pr);
-            return (mem, d)
-        };
-        // return (mem, r)
-        pb(1I32,pb_ret_cont)
-    };
-
-    .let f_diff = %autodiff.ad f;
+.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] =
+    .let f_diff      = %autodiff.ad f;
     .let f_diff_cast = f_diff;
-
-    .let c = 42I32;
+    .let c           = 42I32;
     f_diff_cast (c,ret_cont)
-};
+    .where
+        .con ret_cont [r: .I32, pb: .Fn .I32 -> .I32] =
+            pb(1I32,pb_ret_cont)
+            .where
+                .con pb_ret_cont [pr:.I32] =
+                    .let c = %core.wrap.mul 0 (100I32, r);
+                    .let d = %core.wrap.add 0 (c, pr);
+                    return (mem, d);
+                // return (mem, r)
+            .end;
+    .end;
 
 // CHECK-DAG: return{{.*}}8402

--- a/lit/autodiff/multiply_autodiff_cond.thorin
+++ b/lit/autodiff/multiply_autodiff_cond.thorin
@@ -5,36 +5,33 @@
 .plugin autodiff;
 
 
-.con f [a:.I32, ret: .Cn [.I32]] = {
-    .con twice [] = {
-        .let b = %core.wrap.mul 0 (2I32, a);
-        ret b
-    };
-    .con thrice [] = {
-        .let b = %core.wrap.mul 0 (3I32, a);
-        ret b
-    };
+.fun f(a: .I32): .I32 =
     .let cmp = %core.icmp.sle (a,5I32);
-    ((twice,thrice)#cmp) ()
-};
+    (twice,thrice)#cmp ()
+    .where
+        .con twice [] =
+            .let b = %core.wrap.mul 0 (2I32, a);
+            return b;
+        .con thrice [] =
+            .let b = %core.wrap.mul 0 (3I32, a);
+            return b;
+    .end;
 
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] = {
-
-    .con ret_cont [r:.I32,pb:.Cn[.I32,.Cn[.I32]]] = {
-        .con pb_ret_cont [pr:.I32] = {
-            .let c = %core.wrap.mul 0 (100I32, r);
-            .let d = %core.wrap.add 0 (c, pr);
-            return (mem, d)
-        };
-        // return (mem, r)
-        pb (1I32, pb_ret_cont)
-    };
-
-    .let f_diff = %autodiff.ad f;
+.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] =
+    .let f_diff      = %autodiff.ad f;
     .let f_diff_cast = f_diff;
-
-    .let c = 4I32; // 42
+    .let c           = 4I32; // 42
     f_diff_cast (c,ret_cont)
-};
+    .where
+        .con ret_cont [r: .I32, pb: .Fn .I32 -> .I32] =
+            // return (mem, r)
+            pb (1I32, pb_ret_cont)
+            .where
+                .con pb_ret_cont [pr:.I32] =
+                    .let c = %core.wrap.mul 0 (100I32, r);
+                    .let d = %core.wrap.add 0 (c, pr);
+                    return (mem, d);
+            .end;
+    .end;
 
 // CHECK-DAG: return{{.*}}1203

--- a/lit/autodiff/multiply_autodiff_cond2.thorin
+++ b/lit/autodiff/multiply_autodiff_cond2.thorin
@@ -5,36 +5,33 @@
 .plugin autodiff;
 
 
-.con f [a:.I32, ret: .Cn [.I32]] = {
-    .con twice [] = {
-        .let b = %core.wrap.mul 0 (2I32, a);
-        ret b
-    };
-    .con thrice [] = {
-        .let b = %core.wrap.mul 0 (3I32, a);
-        ret b
-    };
+.fun f(a: .I32): .I32 =
     .let cmp = %core.icmp.sle (a,5I32);
-    ((twice,thrice)#cmp) ()
-};
+    (twice,thrice)#cmp ()
+    .where
+        .con twice [] =
+            .let b = %core.wrap.mul 0 (2I32, a);
+            return b;
+        .con thrice [] =
+            .let b = %core.wrap.mul 0 (3I32, a);
+            return b;
+    .end;
 
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] = {
-
-    .con ret_cont [r:.I32,pb:.Cn[.I32,.Cn[.I32]]] = {
-        .con pb_ret_cont [pr:.I32] = {
-            .let c = %core.wrap.mul 0 (100I32, r);
-            .let d = %core.wrap.add 0 (c, pr);
-            return (mem, d)
-        };
-        // return (mem, r)
-        pb(1I32,pb_ret_cont)
-    };
-
-    .let f_diff = %autodiff.ad f;
+.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] =
+    .let f_diff      = %autodiff.ad f;
     .let f_diff_cast = f_diff;
-
-    .let c = 7I32; // 42
+    .let c           = 7I32; // 42
     f_diff_cast (c,ret_cont)
-};
+    .where
+        .con ret_cont [r: .I32, pb: .Fn .I32 -> .I32] =
+            // return (mem, r)
+            pb(1I32,pb_ret_cont)
+            .where
+                .con pb_ret_cont [pr:.I32] =
+                    .let c = %core.wrap.mul 0 (100I32, r);
+                    .let d = %core.wrap.add 0 (c, pr);
+                    return (mem, d);
+            .end;
+    .end;
 
 // CHECK-DAG: return{{.*}}1402

--- a/lit/autodiff/second/snd_order_man.thorin
+++ b/lit/autodiff/second/snd_order_man.thorin
@@ -5,44 +5,32 @@
 .plugin autodiff;
 
 
-.con g_diff [a:.I32, ret: .Cn [.I32,.Cn[.I32,.Cn[.I32]]]] = {
-    .con pb [s:.I32, pb_ret: .Cn[.I32]] = {
-        .let b = %core.wrap.mul 0 (2I32, a);
-        .let c = %core.wrap.add 0 (3I32, b);
-        pb_ret c
-    };
+.fun g_diff(a:.I32): [.I32, .Fn .I32 -> .I32] =
     .let b = %core.wrap.add 0 (3I32, a);
     .let c = %core.wrap.mul 0 (a, b);
-    ret (c,pb)
-};
+    return (c, .fn (s:.I32): .I32 =
+        .let b = %core.wrap.mul 0 (2I32, a);
+        .let c = %core.wrap.add 0 (3I32, b);
+        return c);
 
-.con f [a:.I32, ret: .Cn [.I32]] = {
-    .con ret_cont [r:.I32,pb:.Cn[.I32,.Cn[.I32]]] = {
-        .con pb_ret_cont [pr:.I32] = {
-            ret pr
-        };
-        pb(1I32,pb_ret_cont)
-    };
-    g_diff (a,ret_cont)
-};
+.fun f(a:.I32): .I32 =
+    .con ret_cont [r:.I32, pb: .Fn .I32 -> .I32] =
+        .con pb_ret_cont [pr:.I32] = return pr;
+        pb(1I32,pb_ret_cont);
+    g_diff (a, ret_cont);
 
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] = {
-
-    .con ret_cont [r:.I32,pb:.Cn[.I32,.Cn[.I32]]] = {
-        .con pb_ret_cont [pr:.I32] = {
+.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] =
+    .con ret_cont [r: .I32, pb: .Fn .I32 -> .I32] =
+        .con pb_ret_cont [pr:.I32] =
             .let c = %core.wrap.mul 0 (100I32, r);
             .let d = %core.wrap.add 0 (c, pr);
-            return (mem, d)
-        };
+            return (mem, d);
         // return (mem, r)
-        pb(1I32,pb_ret_cont)
-    };
+        pb(1I32,pb_ret_cont);
 
-    .let f_diff = %autodiff.ad f;
+    .let f_diff      = %autodiff.ad f;
     .let f_diff_cast = f_diff;
-
-    .let c = 42I32;
-    f_diff_cast (c,ret_cont)
-};
+    .let c           = 42I32;
+    f_diff_cast (c,ret_cont);
 
 // CHECK-DAG: return{{.*}}8702

--- a/lit/autodiff/simple_autodiff.thorin
+++ b/lit/autodiff/simple_autodiff.thorin
@@ -4,28 +4,21 @@
 .plugin core;
 .plugin autodiff;
 
-
-.con f [a:.I32, ret: .Cn [.I32]] = {
+.fun f(a: .I32): .I32 =
     .let b = %core.wrap.mul 0 (2I32, a);
-    ret b
-};
+    return b;
 
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] = {
-
-
-    .con pb_ret_cont [pr:.I32] = {
-        return (mem, pr)
-    };
-
-    .con ret_cont [r:.I32,pb:.Cn[.I32,.Cn[.I32]]] = {
-        pb(1I32,pb_ret_cont)
-    };
-
-    .let f_diff = %autodiff.ad f;
+.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] =
+    .let f_diff      = %autodiff.ad f;
     .let f_diff_cast = f_diff;
-
-    .let c = 43I32;
+    .let c           = 43I32;
     f_diff_cast (c,ret_cont)
-};
+    .where
+        .con ret_cont [r: .I32, pb: .Fn .I32 -> .I32] =
+            pb(1I32,pb_ret_cont)
+            .where
+                .con pb_ret_cont [pr:.I32] = return (mem, pr);
+            .end;
+    .end;
 
 // CHECK-DAG: return{{.*}}2

--- a/lit/autodiff/square.thorin
+++ b/lit/autodiff/square.thorin
@@ -5,28 +5,25 @@
 .plugin autodiff;
 
 
-.con f [a:.I32, ret: .Cn [.I32]] = {
+.fun f(a: .I32): .I32 =
     .let b = %core.wrap.mul 0 (a, a);
-    ret b
-};
+    return b;
 
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] = {
-
-    .con ret_cont [r:.I32,pb:.Cn[.I32,.Cn[.I32]]] = {
-        .con pb_ret_cont [pr:.I32] = {
-            .let c = %core.wrap.mul 0 (1000I32, r);
-            .let d = %core.wrap.add 0 (c, pr);
-            return (mem, d)
-        };
-        // return (mem, r)
-        pb(1I32,pb_ret_cont)
-    };
-
-    .let f_diff = %autodiff.ad f;
+.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] =
+    .let f_diff      = %autodiff.ad f;
     .let f_diff_cast = f_diff;
-
-    .let c = 42I32;
+    .let c           = 42I32;
     f_diff_cast (c,ret_cont)
-};
+    .where
+        .con ret_cont [r: .I32, pb: .Fn .I32 -> .I32] =
+            // return (mem, r)
+            pb(1I32,pb_ret_cont)
+            .where
+                .con pb_ret_cont [pr:.I32] =
+                    .let c = %core.wrap.mul 0 (1000I32, r);
+                    .let d = %core.wrap.add 0 (c, pr);
+                    return (mem, d);
+            .end;
+    .end;
 
 // CHECK-DAG: return{{.*}}1764084

--- a/lit/autodiff/square_autodiff.thorin
+++ b/lit/autodiff/square_autodiff.thorin
@@ -4,30 +4,25 @@
 .plugin core;
 .plugin autodiff;
 
-
-.con f [a:.I32, ret: .Cn [.I32]] = {
+.fun f(a: .I32): .I32 =
     .let b = %core.wrap.mul 0 (a, a);
-    ret b
-};
+    return b;
 
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] = {
-
-    .con ret_cont [r:.I32,pb:.Cn[.I32,.Cn[.I32]]] = {
-        .con pb_ret_cont [pr:.I32] = {
-            .let c = %core.wrap.mul 0 (100I32, r);
-            .let d = %core.wrap.add 0 (c, pr);
-            return (mem, d)
-        };
-        // return (mem, r)
-        pb(1I32,pb_ret_cont)
-    };
-
-    .let f_diff = %autodiff.ad f;
-    .let f_diff_cast =
-        f_diff;
-
-    .let c = 42I32;
-    f_diff_cast (c,ret_cont)
-};
+.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] =
+    .let f_diff      = %autodiff.ad f;
+    .let f_diff_cast = f_diff;
+    .let c           = 42I32;
+    f_diff_cast (c, ret_cont)
+    .where
+        .con ret_cont [r:.I32,pb:.Cn[.I32,.Cn[.I32]]] =
+            // return (mem, r)
+            pb(1I32,pb_ret_cont)
+            .where
+                .con pb_ret_cont [pr:.I32] =
+                    .let c = %core.wrap.mul 0 (100I32, r);
+                    .let d = %core.wrap.add 0 (c, pr);
+                    return (mem, d);
+            .end;
+    .end;
 
 // CHECK-DAG: return{{.*}}176484

--- a/lit/beta_equiv.thorin
+++ b/lit/beta_equiv.thorin
@@ -4,7 +4,7 @@
 .plugin mem;
 
 .rec Num = [T: *, add: [T, T] -> T];
-.lam my_add.(pe: «2; .Nat»)(a b: %math.F pe): %math.F pe = %math.arith.add 0 (a, b);
+.lam my_add {pe: «2; .Nat»} (a b: %math.F pe): %math.F pe = %math.arith.add 0 (a, b);
 
 .let F64 = (%math.F64, my_add @%math.f64);
 .ax %bug.Arr: Num -> *;
@@ -15,8 +15,8 @@
     .ret _ = test F64 $ A;
     return mem;
 
-.lam pow(a b: .Nat): .Nat =
+.lam pow (a b: .Nat): .Nat =
     (%core.nat.mul (a, pow (a, %core.nat.sub (b, 1))), 1)#(%core.ncmp.e (b, 0));
 
-.lam foo(a: «8; .Nat»): .Bool = .tt;
+.lam foo (a: «8; .Nat»): .Bool = .tt;
 .let _ = foo(‹pow (2, 3); 42›);

--- a/lit/beta_equiv.thorin
+++ b/lit/beta_equiv.thorin
@@ -4,7 +4,7 @@
 .plugin mem;
 
 .rec Num = [T: *, add: [T, T] -> T];
-.lam my_add {pe: «2; .Nat»} (a b: %math.F pe): %math.F pe = %math.arith.add 0 (a, b);
+.lam my_add .(pe: «2; .Nat») (a b: %math.F pe): %math.F pe = %math.arith.add 0 (a, b);
 
 .let F64 = (%math.F64, my_add @%math.f64);
 .ax %bug.Arr: Num -> *;

--- a/lit/clos/array.thorin
+++ b/lit/clos/array.thorin
@@ -12,47 +12,30 @@
     return (mem, 1I32);
 
 
-.con .extern main [mem: %mem.M, argc: .I32, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), return : .Cn [%mem.M, .I32]] = {
-
-    .con h [mem: %mem.M, x : .I32, return : .Cn [%mem.M, .I32]] = {
-        return (mem, %core.wrap.add 0 (x, argc))
-    };
+.con .extern main [mem: %mem.M, argc: .I32, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), return : .Cn [%mem.M, .I32]] =
+    .con h [mem: %mem.M, x : .I32, return : .Cn [%mem.M, .I32]] = return (mem, %core.wrap.add 0 (x, argc));
 
     .let pb_type = .Cn [%mem.M, .I32, .Cn [%mem.M, .I32]];
     .let Tas = (pb_type, 0);
-
     .let real_arr_type = (.I32, 0);
-
     .let arr_size = ⊤:.Nat;
 
-    .let (alloc_pb_mem, pb_arr) = %mem.alloc (<<%core.bitcast .Nat 4I32; pb_type>>, 0) (mem);
-    .let (alloc_mem, a_arr) = %mem.alloc (<<%core.bitcast .Nat 4I32; .I32>>, 0) (alloc_pb_mem);
+    .let (`mem, pb_arr) = %mem.alloc (<<%core.bitcast .Nat 4I32; pb_type>>, 0) mem;
+    .let (`mem, a_arr)  = %mem.alloc (<<%core.bitcast .Nat 4I32; .I32>>, 0) mem;
 
     .let lea_0 = %mem.lea (arr_size, <arr_size; pb_type>, 0) (pb_arr, 0I32);
-    .let mem2 = %mem.store (alloc_mem, lea_0, f);
+    .let `mem  = %mem.store (mem, lea_0, f);
     .let lea_1 = %mem.lea (arr_size, <arr_size; pb_type>, 0) (pb_arr, 1I32);
-    .let mem3 = %mem.store (mem2, lea_1, g);
+    .let `mem  = %mem.store (mem, lea_1, g);
     .let lea_2 = %mem.lea (arr_size, <arr_size; pb_type>, 0) (pb_arr, 2I32);
-    .let mem4 = %mem.store (mem3, lea_2, h);
+    .let `mem  = %mem.store (mem, lea_2, h);
+    .let lea   = %mem.lea (arr_size, <arr_size; .I32>, 0) (a_arr, 0I32);
+    .let `mem  = %mem.store (mem, lea, 10I32);
 
-    .let lea = %mem.lea (arr_size, <arr_size; .I32>, 0) (a_arr, 0I32);
-
-    .let mem5 = %mem.store (mem4, lea, 10I32);
-
-    .let fn_lea = %mem.lea (arr_size, <arr_size; pb_type>, 0) (pb_arr, 2I32);
-    .let load = %mem.load (mem5, fn_lea);
-
-    .let load_mem = load#.ff;
-    .let load2 = %mem.load (load_mem, lea);
-
-    .let func = load#.tt;
-
-    .let load2_mem = load2#.ff;
-    .let load2_val = load2#.tt;
-
-    .con callback [mem: %mem.M, x : .I32] = {
-        return (mem, x)
-    };
-
-    func(load2_mem, 1I32, callback)
-};
+    .let fn_lea       = %mem.lea (arr_size, <arr_size; pb_type>, 0) (pb_arr, 2I32);
+    .let (`mem, func) = %mem.load (mem, fn_lea);
+    .let (`mem, _)    = %mem.load (mem, lea);
+    func(mem, 1I32, callback)
+    .where
+        .con callback [mem: %mem.M, x : .I32] = return (mem, x);
+    .end;

--- a/lit/clos/bind.thorin
+++ b/lit/clos/bind.thorin
@@ -7,49 +7,42 @@
 .plugin core;
 
 .let pb_type = .Cn [%mem.M, .Cn [%mem.M]];
+.let size    = 100;
 
 .ccon println_i32 [mem: %mem.M, val: .I32, return : .Cn [%mem.M]];
 
-.let size = 100;
-
-.con recursive [mem: %mem.M, i : .I32, last_pullback: pb_type, return: .Cn [%mem.M]] = {
-    .con exit [mem: %mem.M] = {
-        last_pullback ( mem, return )
-    };
-
-    .con loop_body [mem: %mem.M] = {
-        .con pb [mem: %mem.M, return: .Cn [%mem.M]] = {
-            .con next [mem: %mem.M] = {
-                last_pullback (mem, return)
-            };
-
-            println_i32( mem, i , next )
-        };
-
-        .con next [mem: %mem.M] = {
-            recursive( mem, %core.wrap.add 0 (i, 1I32), pb, return )
-        };
-
-        println_i32( mem, i , next )
-    };
-
+.con recursive [mem: %mem.M, i : .I32, last_pullback: pb_type, return: .Cn [%mem.M]] =
     .let condition = %core.icmp.ul (i, %core.bitcast .I32 size);
-    .let target = (exit, loop_body)#condition;
-    target ( mem )
-};
+    (exit, loop_body)#condition mem
+    .where
+        .con loop_body [mem: %mem.M] =
+            println_i32( mem, i , next )
+            .where
+                .con next [mem: %mem.M] =
+                    recursive( mem, %core.wrap.add 0 (i, 1I32), pb, return )
+                    .where
+                        .con pb [mem: %mem.M, return: .Cn [%mem.M]] =
+                            println_i32( mem, i , next )
+                            .where
+                                .con next [mem: %mem.M] = last_pullback (mem, return);
+                            .end;
+                    .end;
+            .end;
 
-.con outer [mem: %mem.M, x : .I32, return : .Cn [%mem.M]] = {
-    .con end [mem: %mem.M, return : .Cn [%mem.M]] = {
-        return (mem)
-    };
+        .con exit [mem: %mem.M] = last_pullback ( mem, return );
+    .end;
 
+.con outer [mem: %mem.M, x : .I32, return : .Cn [%mem.M]] =
     recursive ( mem, 0I32, end, return )
-};
+    .where
+        .con end [mem: %mem.M, return : .Cn [%mem.M]] = return mem;
+    .end;
 
-.con .extern main [mem: %mem.M, argc: .I32, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), return : .Cn [%mem.M, .I32]] = {
-    .con callback (mem: %mem.M) = return (mem, 0I32);
+.con .extern main [mem: %mem.M, argc: .I32, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), return : .Cn [%mem.M, .I32]] =
     outer(mem, 1I32, callback)
-};
+    .where
+        .con callback (mem: %mem.M) = return (mem, 0I32);
+    .end;
 
 // CHECK: 99
 // CHECK-COUNT-98: {{[0-9]+}}

--- a/lit/clos/loopDiff.thorin
+++ b/lit/clos/loopDiff.thorin
@@ -10,97 +10,63 @@
 .ccon time [mem: %mem.M, return : .Cn [%mem.M, void_ptr]];
 .ccon print_time_diff [mem: %mem.M, t1: void_ptr, t2: void_ptr, return : .Cn [%mem.M]];
 
+.let arr_size = ⊤:.Nat;
 .let size = 100;
 
-.con printArr [mem: %mem.M, arr : %mem.Ptr (<<size; .I32>>, 0), return : .Cn [%mem.M]] = {
-    .let arr_size = ⊤:.Nat;
-
-    .con loop_body [mem: %mem.M, i : .I32, continue : .Cn %mem.M] = {
-        .let lea = %mem.lea (arr_size, <arr_size; .I32>, 0) (arr, i);
-        .let (load_mem, val) = %mem.load (mem, lea);
-        printInteger(load_mem, val, continue)
-    };
-
-    .con loop_head [mem: %mem.M, i : .I32] = {
-        .con yield [mem: %mem.M] = {
-            loop_head( mem, %core.wrap.add 0 (i, 1I32))
-        };
-
-        .con enter [mem: %mem.M] = {
-            loop_body ( mem, i, yield )
-        };
-
-        .con exit [mem: %mem.M] = {
-            printNL (mem, return)
-        };
-
-        .let condition = %core.icmp.ul (i, %core.bitcast .I32 size);
-        .let target = (exit, enter)#condition;
-        target ( mem )
-    };
-
+.con printArr [mem: %mem.M, arr : %mem.Ptr (<<size; .I32>>, 0), return : .Cn [%mem.M]] =
     loop_head ( mem, 0I32 )
-};
+    .where
+        .con loop_head [mem: %mem.M, i : .I32] =
+            .let condition = %core.icmp.ul (i, %core.bitcast .I32 size);
+            (exit, enter)#condition mem
+            .where
+                .con enter [mem: %mem.M] =
+                    loop_body ( mem, i, yield )
+                    .where
+                        .con loop_body [mem: %mem.M, i : .I32, continue : .Cn %mem.M] =
+                            .let lea = %mem.lea (arr_size, <arr_size; .I32>, 0) (arr, i);
+                            .let (load_mem, val) = %mem.load (mem, lea);
+                            printInteger(load_mem, val, continue);
+                        .con yield [mem: %mem.M] = loop_head( mem, %core.wrap.add 0 (i, 1I32));
+                    .end;
+                .con exit[mem: %mem.M] = printNL (mem, return);
+            .end;
+    .end;
 
-.con init [mem: %mem.M, arr : %mem.Ptr (<<size; .I32>>, 0), offset : .I32, return : .Cn [%mem.M]] = {
-    .let arr_size = ⊤:.Nat;
-
-    .con loop_body [mem: %mem.M, i : .I32, continue : .Cn %mem.M] = {
-        .let lea = %mem.lea (arr_size, <arr_size; .I32>, 0) (arr, i);
-        .let add = %core.wrap.add 0 (offset, i);
-        .let store_mem = %mem.store (mem, lea, add);
-        continue(store_mem)
-    };
-
-    .con loop_head [mem: %mem.M, i : .I32] = {
-        .con yield [mem: %mem.M] = {
-            loop_head( mem, %core.wrap.add 0 (i, 1I32))
-        };
-
-        .con enter [mem: %mem.M] = {
-            loop_body ( mem, i, yield )
-        };
-
-        .let condition = %core.icmp.ul (i, %core.bitcast .I32 size);
-        .let target = (return, enter)#condition;
-        target ( mem )
-    };
-
+.con init [mem: %mem.M, arr : %mem.Ptr (<<size; .I32>>, 0), offset : .I32, return : .Cn [%mem.M]] =
     loop_head ( mem, 0I32 )
-};
+    .where
+        .con loop_head [mem: %mem.M, i : .I32] =
+            .con yield [mem: %mem.M] = loop_head( mem, %core.wrap.add 0 (i, 1I32));
+            .con enter [mem: %mem.M] = loop_body ( mem, i, yield );
 
+            .let condition = %core.icmp.ul (i, %core.bitcast .I32 size);
+            .let target = (return, enter)#condition;
+            target mem;
+        .con loop_body [mem: %mem.M, i : .I32, continue : .Cn %mem.M] =
+            .let lea = %mem.lea (arr_size, <arr_size; .I32>, 0) (arr, i);
+            .let add = %core.wrap.add 0 (offset, i);
+            .let store_mem = %mem.store (mem, lea, add);
+            continue(store_mem);
+    .end;
 
-.con const [mem: %mem.M, arr : %mem.Ptr (<<size; .I32>>, 0), constValue : .I32, return : .Cn [%mem.M]] = {
-    .let arr_size = ⊤:.Nat;
-
-    .con loop_body [mem: %mem.M, i : .I32, continue : .Cn %mem.M] = {
+.con const [mem: %mem.M, arr : %mem.Ptr (<<size; .I32>>, 0), constValue : .I32, return : .Cn [%mem.M]] =
+    .con loop_body [mem: %mem.M, i : .I32, continue : .Cn %mem.M] =
         .let lea = %mem.lea (arr_size, <arr_size; .I32>, 0) (arr, i);
-
         .let store_mem = %mem.store (mem, lea, constValue);
-        continue(store_mem)
-    };
+        continue(store_mem);
 
-    .con loop_head [mem: %mem.M, i : .I32] = {
-        .con yield [mem: %mem.M] = {
-            loop_head( mem, %core.wrap.add 0 (i, 1I32))
-        };
-
-        .con enter [mem: %mem.M] = {
-            loop_body ( mem, i, yield )
-        };
+    .con loop_head [mem: %mem.M, i : .I32] =
+        .con yield [mem: %mem.M] = loop_head( mem, %core.wrap.add 0 (i, 1I32));
+        .con enter [mem: %mem.M] = loop_body ( mem, i, yield );
 
         .let condition = %core.icmp.ul (i, %core.bitcast .I32 size);
         .let target = (return, enter)#condition;
-        target ( mem )
-    };
+        target ( mem );
 
-    loop_head ( mem, 0I32 )
-};
+    loop_head ( mem, 0I32 );
 
-
-.con outer [mem: %mem.M, x : .I32, return : .Cn [%mem.M]] = {
-    .let arr_size = ⊤:.Nat;
-
+.con outer [mem: %mem.M, x : .I32, return : .Cn [%mem.M]] =
     .let (alloc_mem_a, a_arr) = %mem.alloc (<<size; .I32>>, 0) (mem);
     .let (alloc_mem_b, b_arr) = %mem.alloc (<<size; .I32>>, 0) (alloc_mem_a);
     .let (alloc_mem_c, c_arr) = %mem.alloc (<<size; .I32>>, 0) (alloc_mem_b);
@@ -109,9 +75,7 @@
     .let (alloc_mem_bd, bd_arr) = %mem.alloc (<<size; .I32>>, 0) (alloc_mem_ad);
     .let (alloc_mem_cd, cd_arr) = %mem.alloc (<<size; .I32>>, 0) (alloc_mem_bd);
 
-    .con end [mem: %mem.M, return : .Cn [%mem.M]] = {
-        return (mem)
-    };
+    .con end [mem: %mem.M, return : .Cn [%mem.M]] = return (mem);
 
     .let pb_type = .Cn [%mem.M, .Cn [%mem.M]];
     .let (alloc_pb_mem, pb_ptr) = %mem.malloc (pb_type, 0) (alloc_mem_cd, 32); // besser slot
@@ -121,7 +85,7 @@
 
     .let finish_mem = mem_assign_pb_anchor;
 
-    .con loop_body [mem: %mem.M, i : .I32, return : .Cn %mem.M] = {
+    .con loop_body [mem: %mem.M, i : .I32, return : .Cn %mem.M] =
         .let a_lea = %mem.lea (arr_size, <arr_size; .I32>, 0) (a_arr, i);
         .let b_lea = %mem.lea (arr_size, <arr_size; .I32>, 0) (b_arr, i);
         .let c_lea = %mem.lea (arr_size, <arr_size; .I32>, 0) (c_arr, i);
@@ -135,7 +99,7 @@
 
         .let (load_pb_mem, last_pb) = %mem.load (c_store_mem, lea_pb);
 
-        .con pb [mem: %mem.M, end: .Cn [%mem.M]] = {
+        .con pb [mem: %mem.M, end: .Cn [%mem.M]] =
             .let ad_lea = %mem.lea (arr_size, <arr_size; .I32>, 0) (ad_arr, i);
             .let bd_lea = %mem.lea (arr_size, <arr_size; .I32>, 0) (bd_arr, i);
             .let cd_lea = %mem.lea (arr_size, <arr_size; .I32>, 0) (cd_arr, i);
@@ -153,100 +117,54 @@
             .let bd_a_add = %core.wrap.add 0 (bd_val, cd_a_mul);
             .let bd_store_mem = %mem.store (bd_load_mem, bd_lea, bd_a_add);
 
-            last_pb (bd_store_mem, end)
-        };
+            last_pb (bd_store_mem, end);
 
         .let store_pb_mem = %mem.store (load_pb_mem, lea_pb, pb);
+        return(store_pb_mem);
 
-        return(store_pb_mem)
-    };
+    .con print_c [mem: %mem.M] = printArr(mem, c_arr, return);
+    .con print_b [mem: %mem.M] = printArr(mem, b_arr, print_c);
+    .con print_a [mem: %mem.M] = printArr(mem, a_arr, print_b);
+    .con print_cd[mem: %mem.M] = printArr(mem, cd_arr, print_a);
+    .con print_bd[mem: %mem.M] = printArr(mem, bd_arr, print_cd);
+    .con print_ad[mem: %mem.M] = printArr(mem, ad_arr, print_bd);
 
-
-    .con print_c [mem: %mem.M] = {
-        printArr(mem, c_arr, return)
-    };
-
-    .con print_b [mem: %mem.M] = {
-        printArr(mem, b_arr, print_c)
-    };
-
-    .con print_a [mem: %mem.M] = {
-        printArr(mem, a_arr, print_b)
-    };
-
-    .con print_cd [mem: %mem.M] = {
-        printArr(mem, cd_arr, print_a)
-    };
-
-     .con print_bd [mem: %mem.M] = {
-        printArr(mem, bd_arr, print_cd)
-    };
-
-    .con print_ad [mem: %mem.M] = {
-        printArr(mem, ad_arr, print_bd)
-    };
-
-
-    .con time_start_cont [mem:%mem.M, start_time:void_ptr] = {
-        .con timer [mem:%mem.M] = {
-            .con time_end_cont [mem:%mem.M, end_time:void_ptr] = {
-                print_time_diff (mem, start_time, end_time, print_ad)
-            };
-            time (mem, time_end_cont)
+    .con time_start_cont [mem:%mem.M, start_time:void_ptr] =
+        .con timer [mem:%mem.M] =
+            .con time_end_cont [mem:%mem.M, end_time:void_ptr] = print_time_diff (mem, start_time, end_time, print_ad);
+            time (mem, time_end_cont);
             // print_ad(mem)
-        };
 
-        .con loop_head [mem: %mem.M, i : .I32] = {
-            .con exit [mem: %mem.M] = {
+        .con loop_head [mem: %mem.M, i : .I32] =
+            .con exit [mem: %mem.M] =
                 .let (backward_pass_mem, backward_pass) = %mem.load (mem, lea_pb);
-                backward_pass (backward_pass_mem, timer)
-            };
+                backward_pass (backward_pass_mem, timer);
 
-            .con yield [mem: %mem.M] = {
+            .con yield [mem: %mem.M] =
                 // loop_head( mem, %core.wrap.add (0, .i32) (i, 1I32))
-                loop_head( mem, %core.wrap.add 0 (i, 1I32))
-            };
+                loop_head( mem, %core.wrap.add 0 (i, 1I32));
 
-            .con enter [mem: %mem.M] = {
-                loop_body ( mem, i, yield )
-            };
+            .con enter [mem: %mem.M] = loop_body ( mem, i, yield );
 
             .let condition = %core.icmp.ul (i, %core.bitcast .I32 size);
             .let target = (exit, enter)#condition;
-            target ( mem )
-        };
+            target ( mem );
+        loop_head ( mem, 0I32 );
 
-        loop_head ( mem, 0I32 )
-    };
+    .con init_a [mem: %mem.M] =
+        .con init_b [mem: %mem.M] =
+            .con init_c [mem: %mem.M] =
+                .con init_ad [mem: %mem.M] =
+                    .con init_bd [mem: %mem.M] =
+                        .con init_cd [mem: %mem.M] =
+                            time (mem, time_start_cont);
+                        const(mem, cd_arr, 1I32, init_cd);
+                    const(mem, bd_arr,  0I32, init_bd);
+                const(mem, ad_arr,  0I32, init_ad);
+            const(mem, c_arr, 0I32, init_c);
+        init(mem, b_arr, 1I32, init_b);
+    init(finish_mem, a_arr, 0I32, init_a);
 
-    .con init_a [mem: %mem.M] = {
-        .con init_b [mem: %mem.M] = {
-            .con init_c [mem: %mem.M] = {
-                .con init_ad [mem: %mem.M] = {
-                    .con init_bd [mem: %mem.M] = {
-                        .con init_cd [mem: %mem.M] = {
-                            time (mem, time_start_cont)
-                        };
-
-                        const(mem, cd_arr, 1I32, init_cd)
-                    };
-
-                    const(mem, bd_arr,  0I32, init_bd)
-                };
-
-                const(mem, ad_arr,  0I32, init_ad)
-            };
-
-            const(mem, c_arr, 0I32, init_c)
-        };
-
-        init(mem, b_arr, 1I32, init_b)
-    };
-
-    init(finish_mem, a_arr, 0I32, init_a)
-};
-
-.con .extern main [mem: %mem.M, argc: .I32, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), return : .Cn [%mem.M, .I32]] = {
+.con .extern main [mem: %mem.M, argc: .I32, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), return : .Cn [%mem.M, .I32]] =
     .con callback (mem: %mem.M) = return (mem, 1I32);
-    outer(mem, 1I32, callback)
-};
+    outer(mem, 1I32, callback);

--- a/lit/clos/loopDiff2.thorin
+++ b/lit/clos/loopDiff2.thorin
@@ -10,98 +10,60 @@
 .ccon time [mem: %mem.M, return : .Cn [%mem.M, void_ptr]];
 .ccon print_time_diff [mem: %mem.M, t1: void_ptr, t2: void_ptr, return : .Cn [%mem.M]];
 
+.let arr_size = ⊤:.Nat;
 .let size = 100000;
 
-.con printArr [mem: %mem.M, arr : %mem.Ptr (<<size; .I32>>, 0), return : .Cn [%mem.M]] = {
-    .let arr_size = ⊤:.Nat;
-
-    .con loop_body [mem: %mem.M, i : .I32, continue : .Cn %mem.M] = {
+.con printArr [mem: %mem.M, arr : %mem.Ptr (<<size; .I32>>, 0), return : .Cn [%mem.M]] =
+    .con loop_body [mem: %mem.M, i : .I32, continue : .Cn %mem.M] =
         .let lea = %mem.lea (arr_size, <arr_size; .I32>, 0) (arr, i);
         .let (load_mem, val) = %mem.load (mem, lea);
-        printInteger(load_mem, val, continue)
-    };
+        printInteger(load_mem, val, continue);
 
-    .con loop_head [mem: %mem.M, i : .I32] = {
-        .con yield [mem: %mem.M] = {
-            loop_head( mem, %core.wrap.add 0 (i, 1I32))
-        };
-
-        .con enter [mem: %mem.M] = {
-            loop_body ( mem, i, yield )
-        };
-
-        .con exit [mem: %mem.M] = {
-            printNL (mem, return)
-        };
+    .con loop_head [mem: %mem.M, i : .I32] =
+        .con yield [mem: %mem.M] = loop_head( mem, %core.wrap.add 0 (i, 1I32));
+        .con enter [mem: %mem.M] = loop_body ( mem, i, yield );
+        .con exit [mem: %mem.M] = printNL (mem, return);
 
         .let condition = %core.icmp.ul (i, %core.bitcast .I32 size);
         .let target = (exit, enter)#condition;
-        target ( mem )
-    };
+        target ( mem );
 
-    loop_head ( mem, 0I32 )
-};
+    loop_head ( mem, 0I32 );
 
-.con init [mem: %mem.M, arr : %mem.Ptr (<<size; .I32>>, 0), offset : .I32, return : .Cn [%mem.M]] = {
-    .let arr_size = ⊤:.Nat;
-
-    .con loop_body [mem: %mem.M, i : .I32, continue : .Cn %mem.M] = {
+.con init [mem: %mem.M, arr : %mem.Ptr (<<size; .I32>>, 0), offset : .I32, return : .Cn [%mem.M]] =
+    .con loop_body [mem: %mem.M, i : .I32, continue : .Cn %mem.M] =
         .let lea = %mem.lea (arr_size, <arr_size; .I32>, 0) (arr, i);
         .let add = %core.wrap.add 0 (offset, i);
         .let store_mem = %mem.store (mem, lea, add);
-        continue(store_mem)
-    };
+        continue(store_mem);
 
-    .con loop_head [mem: %mem.M, i : .I32] = {
-        .con yield [mem: %mem.M] = {
-            loop_head( mem, %core.wrap.add 0 (i, 1I32))
-        };
-
-        .con enter [mem: %mem.M] = {
-            loop_body ( mem, i, yield )
-        };
+    .con loop_head [mem: %mem.M, i : .I32] =
+        .con yield [mem: %mem.M] = loop_head( mem, %core.wrap.add 0 (i, 1I32));
+        .con enter [mem: %mem.M] = loop_body ( mem, i, yield );
 
         .let condition = %core.icmp.ul (i, %core.bitcast .I32 size);
         .let target = (return, enter)#condition;
-        target ( mem )
-    };
+        target ( mem );
 
-    loop_head ( mem, 0I32 )
-};
+    loop_head ( mem, 0I32 );
 
-
-.con const [mem: %mem.M, arr : %mem.Ptr (<<size; .I32>>, 0), constValue : .I32, return : .Cn [%mem.M]] = {
-    .let arr_size = ⊤:.Nat;
-
-    .con loop_body [mem: %mem.M, i : .I32, continue : .Cn %mem.M] = {
+.con const [mem: %mem.M, arr : %mem.Ptr (<<size; .I32>>, 0), constValue : .I32, return : .Cn [%mem.M]] =
+    .con loop_body [mem: %mem.M, i : .I32, continue : .Cn %mem.M] =
         .let lea = %mem.lea (arr_size, <arr_size; .I32>, 0) (arr, i);
-
         .let store_mem = %mem.store (mem, lea, constValue);
-        continue(store_mem)
-    };
+        continue(store_mem);
 
-    .con loop_head [mem: %mem.M, i : .I32] = {
-        .con yield [mem: %mem.M] = {
-            loop_head( mem, %core.wrap.add 0 (i, 1I32))
-        };
-
-        .con enter [mem: %mem.M] = {
-            loop_body ( mem, i, yield )
-        };
+    .con loop_head [mem: %mem.M, i : .I32] =
+        .con yield [mem: %mem.M] = loop_head( mem, %core.wrap.add 0 (i, 1I32));
+        .con enter [mem: %mem.M] = loop_body ( mem, i, yield );
 
         .let condition = %core.icmp.ul (i, %core.bitcast .I32 size);
         .let target = (return, enter)#condition;
-        target ( mem )
-    };
+        target ( mem );
 
-    loop_head ( mem, 0I32 )
-};
+    loop_head ( mem, 0I32 );
 
-
-.con outer [mem: %mem.M, x : .I32, return : .Cn [%mem.M]] = {
-
-    .let arr_size = ⊤:.Nat;
-
+.con outer [mem: %mem.M, x : .I32, return : .Cn [%mem.M]] =
     .let (alloc_mem_a, a_arr) = %mem.alloc (<<size; .I32>>, 0) (mem);
     .let (alloc_mem_b, b_arr) = %mem.alloc (<<size; .I32>>, 0) (alloc_mem_a);
     .let (alloc_mem_c, c_arr) = %mem.alloc (<<size; .I32>>, 0) (alloc_mem_b);
@@ -115,7 +77,7 @@
     .let pb_arr = %core.bitcast (%mem.Ptr («⊤:.Nat; pb_type», 0)) pb_ptr;
     .let finish_mem = alloc_pb_mem;
 
-    .con loop_body [mem: %mem.M, i : .I32, return : .Cn %mem.M] = {
+    .con loop_body [mem: %mem.M, i : .I32, return : .Cn %mem.M] =
         .let a_lea = %mem.lea (arr_size, <arr_size; .I32>, 0) (a_arr, i);
         .let b_lea = %mem.lea (arr_size, <arr_size; .I32>, 0) (b_arr, i);
         .let c_lea = %mem.lea (arr_size, <arr_size; .I32>, 0) (c_arr, i);
@@ -127,131 +89,84 @@
 
         .let c_store_mem = %mem.store (b_load_mem, c_lea, prod);
 
-        .con left_pb [mem: %mem.M, s : .I32, return: .Cn [%mem.M]] = {
+        .con left_pb [mem: %mem.M, s : .I32, return: .Cn [%mem.M]] =
             .let ad_lea = %mem.lea (arr_size, <arr_size; .I32>, 0) (ad_arr, i);
             .let (load_mem, val) = %mem.load (mem, ad_lea);
             .let new_val = %core.wrap.add 0 (val, s);
             .let store_mem = %mem.store (load_mem, ad_lea, new_val);
-            return store_mem
-        };
+            return store_mem;
 
-        .con right_pb [mem: %mem.M, s : .I32, return: .Cn [%mem.M]] = {
+        .con right_pb [mem: %mem.M, s : .I32, return: .Cn [%mem.M]] =
             .let bd_lea = %mem.lea (arr_size, <arr_size; .I32>, 0) (bd_arr, i);
             .let (load_mem, val) = %mem.load (mem, bd_lea);
             .let new_val = %core.wrap.add 0 (val, s);
             .let store_mem = %mem.store (load_mem, bd_lea, new_val);
-            return store_mem
-        };
+            return store_mem;
 
-        .con mul_pb [mem: %mem.M, s : .I32, return: .Cn [%mem.M]] = {
+        .con mul_pb [mem: %mem.M, s : .I32, return: .Cn [%mem.M]] =
             .let sa_mul = %core.wrap.mul 0 (s, b_val);
 
-            .con next [mem: %mem.M] = {
+            .con next [mem: %mem.M] =
                 .let sb_mul = %core.wrap.mul 0 (s, a_val);
-                right_pb(mem, sb_mul, return)
-            };
+                right_pb(mem, sb_mul, return);
 
-            left_pb( mem, sa_mul,  next)
-        };
+            left_pb( mem, sa_mul,  next);
 
         .let lea_pb = %mem.lea (⊤:.Nat, <⊤:.Nat; pb_type>, 0) (pb_arr, i);
         .let store_pb_mem = %mem.store (c_store_mem, lea_pb, mul_pb);
 
-        return(store_pb_mem)
-    };
+        return(store_pb_mem);
 
+    .con print_c [mem: %mem.M] = printArr(mem, c_arr, return);
+    .con print_b [mem: %mem.M] = printArr(mem, b_arr, print_c);
+    .con print_a [mem: %mem.M] = printArr(mem, a_arr, print_b);
+    .con print_cd[mem: %mem.M] = printArr(mem, cd_arr, print_a);
+    .con print_bd[mem: %mem.M] = printArr(mem, bd_arr, print_cd);
+    .con print_ad[mem: %mem.M] = printArr(mem, ad_arr, print_bd);
 
-    .con print_c [mem: %mem.M] = {
-        printArr(mem, c_arr, return)
-    };
-
-    .con print_b [mem: %mem.M] = {
-        printArr(mem, b_arr, print_c)
-    };
-
-    .con print_a [mem: %mem.M] = {
-        printArr(mem, a_arr, print_b)
-    };
-
-    .con print_cd [mem: %mem.M] = {
-        printArr(mem, cd_arr, print_a)
-    };
-
-     .con print_bd [mem: %mem.M] = {
-        printArr(mem, bd_arr, print_cd)
-    };
-
-    .con print_ad [mem: %mem.M] = {
-        printArr(mem, ad_arr, print_bd)
-    };
-
-
-
-    .con time_start_cont [mem:%mem.M, start_time:void_ptr] = {
-
-        .con timer [mem:%mem.M] = {
-            .con time_end_cont [mem:%mem.M, end_time:void_ptr] = {
-                print_time_diff (mem, start_time, end_time, print_ad)
-            };
-            time (mem, time_end_cont)
+    .con time_start_cont [mem:%mem.M, start_time:void_ptr] =
+        .con timer [mem:%mem.M] =
+            .con time_end_cont [mem:%mem.M, end_time:void_ptr] =
+                print_time_diff (mem, start_time, end_time, print_ad);
+            time (mem, time_end_cont);
             // print_ad(mem)
-        };
 
-        .con backward_loop_head [mem: %mem.M, i : .I32] = {
-            .con yield [mem: %mem.M] =
-                backward_loop_head( mem, %core.wrap.add 0 (i, 1I32 ) );
+        .con backward_loop_head [mem: %mem.M, i : .I32] =
+            .con yield [mem: %mem.M] = backward_loop_head( mem, %core.wrap.add 0 (i, 1I32 ) );
 
-            .con enter [mem: %mem.M] = {
+            .con enter [mem: %mem.M] =
                 .let lea_pb = %mem.lea (⊤:.Nat, <⊤:.Nat; pb_type>, 0) (pb_arr, i);
                 .let (backward_pass_mem, backward_pass) = %mem.load (mem, lea_pb);
-                backward_pass ( backward_pass_mem, 1I32, yield )
-            };
+                backward_pass ( backward_pass_mem, 1I32, yield );
 
             .let condition = %core.icmp.ul (i, %core.bitcast .I32 size);
             .let target = (timer, enter)#condition;
-            target ( mem )
-        };
+            target ( mem );
 
-
-        .con loop_head [mem: %mem.M, i : .I32] = {
+        .con loop_head [mem: %mem.M, i : .I32] =
             .con exit [mem: %mem.M] = backward_loop_head(mem, 0I32);
             .con yield [mem: %mem.M] = loop_head( mem, %core.wrap.add 0 (i, 1I32));
             .con enter [mem: %mem.M] = loop_body ( mem, i, yield );
 
             .let condition = %core.icmp.ul (i, %core.bitcast .I32 size);
             .let target = (exit, enter)#condition;
-            target ( mem )
-        };
-        loop_head ( mem, 0I32 )
-    };
+            target ( mem );
+        loop_head ( mem, 0I32 );
 
-    .con init_a [mem: %mem.M] = {
-        .con init_b [mem: %mem.M] = {
-            .con init_c [mem: %mem.M] = {
-                .con init_ad [mem: %mem.M] = {
-                    .con init_bd [mem: %mem.M] = {
-                        .con init_cd [mem: %mem.M] = {
-                            time (mem, time_start_cont)
+    .con init_a [mem: %mem.M] =
+        .con init_b [mem: %mem.M] =
+            .con init_c [mem: %mem.M] =
+                .con init_ad [mem: %mem.M] =
+                    .con init_bd [mem: %mem.M] =
+                        .con init_cd [mem: %mem.M] =
+                            time (mem, time_start_cont);
                             // loop_head ( mem, 0I32 )
-                        };
-
-                        const(mem, cd_arr, 1I32, init_cd)
-                    };
-
-                    const(mem, bd_arr,  0I32, init_bd)
-                };
-
-                const(mem, ad_arr,  0I32, init_ad)
-            };
-
-            const(mem, c_arr, 0I32, init_c)
-        };
-
-        init(mem, b_arr, 1I32, init_b)
-    };
-
-    init(finish_mem, a_arr, 0I32, init_a)
-};
+                        const(mem, cd_arr, 1I32, init_cd);
+                    const(mem, bd_arr,  0I32, init_bd);
+                const(mem, ad_arr,  0I32, init_ad);
+            const(mem, c_arr, 0I32, init_c);
+        init(mem, b_arr, 1I32, init_b);
+    init(finish_mem, a_arr, 0I32, init_a);
 
 .con .extern main [mem: %mem.M, argc: .I32, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), return : .Cn [%mem.M, .I32]] =
     .con callback (mem: %mem.M) = return (mem, 1I32);

--- a/lit/clos/loopDiffSave.thorin
+++ b/lit/clos/loopDiffSave.thorin
@@ -5,39 +5,25 @@
 
 .ccon printInteger [mem: %mem.M, val: .I32, return : .Cn [%mem.M]];
 
+.let arr_size = ⊤:.Nat;
 
-.con init [mem: %mem.M, arr : %mem.Ptr (<<4; .I32>>, 0), return : .Cn [%mem.M]] = {
-    .let arr_size = ⊤:.Nat;
-
-    .con loop_body [mem: %mem.M, i : .I32, continue : .Cn %mem.M] = {
+.con init [mem: %mem.M, arr : %mem.Ptr (<<4; .I32>>, 0), return : .Cn [%mem.M]] =
+    .con loop_body [mem: %mem.M, i : .I32, continue : .Cn %mem.M] =
         .let lea = %mem.lea (arr_size, <arr_size; .I32>, 0) (arr, i);
-
         .let store_mem = %mem.store (mem, lea, i);
-        continue(store_mem)
-    };
+        continue(store_mem);
 
-    .con loop_head [mem: %mem.M, i : .I32] = {
-        .con yield [mem: %mem.M] = {
-            loop_head( mem, %core.wrap.add 0 (i, 1I32))
-        };
-
-        .con enter [mem: %mem.M] = {
-            loop_body ( mem, i, yield )
-        };
+    .con loop_head [mem: %mem.M, i : .I32] =
+        .con yield [mem: %mem.M] = loop_head( mem, %core.wrap.add 0 (i, 1I32));
+        .con enter [mem: %mem.M] = loop_body ( mem, i, yield );
 
         .let condition = %core.icmp.ul (i, 19I32);
         .let target = (return, enter)#condition;
-        target ( mem )
-    };
+        target ( mem );
 
-    loop_head ( mem, 0I32 )
-};
+    loop_head ( mem, 0I32 );
 
-
-.con outer [mem: %mem.M, x : .I32, return : .Cn [%mem.M, .I32]] = {
-
-    .let arr_size = ⊤:.Nat;
-
+.con outer [mem: %mem.M, x : .I32, return : .Cn [%mem.M, .I32]] =
     .let (alloc_mem_a, a_arr) = %mem.alloc (<<4; .I32>>, 0) (mem);
     .let (alloc_mem_b, b_arr) = %mem.alloc (<<4; .I32>>, 0) (alloc_mem_a);
     .let (alloc_mem_c, c_arr) = %mem.alloc (<<4; .I32>>, 0) (alloc_mem_b);
@@ -46,10 +32,8 @@
     .let (alloc_mem_bd, bd_arr) = %mem.alloc (<<4; .I32>>, 0) (alloc_mem_ad);
     .let (alloc_mem_cd, cd_arr) = %mem.alloc (<<4; .I32>>, 0) (alloc_mem_bd);
 
-    .con finish_pb_trace [mem: %mem.M, return : .Cn %mem.M] = {
-            // TODO: check if fix is correct
-        return mem
-    };
+    // TODO: check if fix is correct
+    .con finish_pb_trace [mem: %mem.M, return : .Cn %mem.M] = return mem;
 
     .let pb_type = .Cn [%mem.M, .Cn [%mem.M]];
     .let (alloc_pb_mem, pb_ptr) = %mem.malloc (pb_type, 0) (mem, 32);
@@ -58,7 +42,7 @@
     .let lea_pb = %mem.lea (⊤:.Nat, <⊤:.Nat; pb_type>, 0) (pb_arr, 0I32);
     .let mem_assign_pb_anchor = %mem.store (alloc_pb_mem, lea_pb, finish_pb_trace);
 
-    .con loop_body [mem: %mem.M, i : .I32, continue : .Cn %mem.M] = {
+    .con loop_body [mem: %mem.M, i : .I32, continue : .Cn %mem.M] =
         .let a_lea = %mem.lea (arr_size, <arr_size; .I32>, 0) (a_arr, i);
         .let b_lea = %mem.lea (arr_size, <arr_size; .I32>, 0) (b_arr, i);
         .let c_lea = %mem.lea (arr_size, <arr_size; .I32>, 0) (c_arr, i);
@@ -70,7 +54,7 @@
 
         .let c_store_mem = %mem.store (b_load_mem, c_lea, prod);
 
-        .con pb [mem: %mem.M, return : .Cn %mem.M] = {
+        .con pb [mem: %mem.M, return : .Cn %mem.M] =
             .let ad_lea = %mem.lea (arr_size, <arr_size; .I32>, 0) (ad_arr, i);
             .let bd_lea = %mem.lea (arr_size, <arr_size; .I32>, 0) (bd_arr, i);
             .let cd_lea = %mem.lea (arr_size, <arr_size; .I32>, 0) (cd_arr, i);
@@ -85,52 +69,30 @@
             .let (bd_load_mem, bd_val) = %mem.load (ad_store_mem, bd_lea);
             .let bd_a_add = %core.wrap.add 0 (bd_val, a_val);
             .let bd_store_mem = %mem.store (bd_load_mem, bd_lea, bd_a_add);
-            return (bd_store_mem)
-        };
+            return (bd_store_mem);
 
-        printInteger(c_store_mem, prod, continue)
+        printInteger(c_store_mem, prod, continue);
         //continue(c_store_mem)
-    };
 
-
-    .con loop_head [mem: %mem.M, i : .I32] = {
-        .con exit [mem: %mem.M] = {
-            // TODO: check if fix is correct
-            return (mem,i)
-        };
-
-        .con yield [mem: %mem.M] = {
-            loop_head( mem, %core.wrap.add 0 (i, 1I32))
-        };
-
-        .con enter [mem: %mem.M] = {
-            loop_body ( mem, i, yield )
-        };
+    .con loop_head [mem: %mem.M, i : .I32] =
+        // TODO: check if fix is correct
+        .con exit [mem: %mem.M] = return (mem,i);
+        .con yield[mem: %mem.M] = loop_head( mem, %core.wrap.add 0 (i, 1I32));
+        .con enter[mem: %mem.M] = loop_body ( mem, i, yield );
 
         .let condition = %core.icmp.ul (i, 19I32);
         .let target = (exit, enter)#condition;
-        target ( mem )
-    };
+        target ( mem );
 
-    .con init_a [mem: %mem.M] = {
-        .con init_b [mem: %mem.M] = {
-            .con init_c [mem: %mem.M] = {
-                loop_head ( mem, 0I32 )
-            };
+    .con init_a [mem: %mem.M] =
+        .con init_b [mem: %mem.M] =
+            .con init_c [mem: %mem.M] =
+                loop_head ( mem, 0I32 );
+            init(mem, c_arr, init_c);
+        init(mem, b_arr, init_b);
 
-            init(mem, c_arr, init_c)
-        };
+    init(mem_assign_pb_anchor, a_arr, init_a);
 
-        init(mem, b_arr, init_b)
-    };
-
-    init(mem_assign_pb_anchor, a_arr, init_a)
-};
-
-.con .extern main [mem: %mem.M, argc: .I32, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), return : .Cn [%mem.M, .I32]] = {
-    .con callback (mem: %mem.M, x : .I32) = {
-        return (mem, x)
-    };
-
-    outer(mem, 1I32, callback)
-};
+.con .extern main [mem: %mem.M, argc: .I32, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), return : .Cn [%mem.M, .I32]] =
+    .con callback (mem: %mem.M, x : .I32) = return (mem, x);
+    outer(mem, 1I32, callback);

--- a/lit/clos/loopError.thorin
+++ b/lit/clos/loopError.thorin
@@ -5,33 +5,20 @@
 
 .ccon printInteger [mem: %mem.M, val: .I32, return : .Cn [%mem.M]];
 
-.con init [mem: %mem.M, return : .Cn [%mem.M]] = {
-    .let arr_size = ⊤:.Nat;
+.let arr_size = ⊤:.Nat;
 
-    .con loop_head [mem: %mem.M, i : .I32] = {
-        .con yield [mem: %mem.M] =
-            loop_head( mem, %core.wrap.add 0 (i, 1I32) );
-
-        .con print [mem: %mem.M] = {
-            printInteger( mem, i, yield )
-        };
+.con init [mem: %mem.M, return : .Cn [%mem.M]] =
+    .con loop_head [mem: %mem.M, i : .I32] =
+        .con yield [mem: %mem.M] = loop_head( mem, %core.wrap.add 0 (i, 1I32) );;
+        .con print [mem: %mem.M] = printInteger( mem, i, yield );
 
         .let condition = %core.icmp.ul (i, 42I32);
         .let target = (return, print)#condition;
-        target ( mem )
-    };
+        target ( mem );
+    loop_head ( mem, 0I32 );
 
-    loop_head ( mem, 0I32 )
-};
+.con .extern main [mem: %mem.M, argc: .I32, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), return : .Cn [%mem.M, .I32]] =
+    .con init_b [mem: %mem.M] = return ( mem, 0I32 );
+    .con init_a [mem: %mem.M] = init(mem, init_b);
 
-.con .extern main [mem: %mem.M, argc: .I32, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), return : .Cn [%mem.M, .I32]] = {
-    .con init_b [mem: %mem.M] = {
-        return ( mem, 0I32 )
-    };
-
-    .con init_a [mem: %mem.M] = {
-        init(mem, init_b)
-    };
-
-    init(mem, init_a)
-};
+    init(mem, init_a);

--- a/lit/clos/malloc.thorin
+++ b/lit/clos/malloc.thorin
@@ -7,7 +7,7 @@
 .con f [mem: %mem.M, x: .I32, return: .Cn [%mem.M, .I32]] = return (mem, %core.wrap.add 0 (x, 42I32));
 .con g [mem: %mem.M, x: .I32, return: .Cn [%mem.M, .I32]] = return (mem, 1I32);
 
-.fun .extern main(mem: %mem.M, argc: .I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0)): [%mem.M, .I32] = {
+.fun .extern main(mem: %mem.M, argc: .I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0)): [%mem.M, .I32] =
     .con h(mem: %mem.M, x: .I32, return: .Cn [%mem.M, .I32]) = return (mem, %core.wrap.add 0 (x, argc));
 
     .let pb_type  = .Cn [%mem.M, .I32, .Cn [%mem.M, .I32]];
@@ -30,5 +30,4 @@
     .let (`mem, func) = %mem.load (mem, lea);
     .let (`mem,  val) = %mem.load (mem, lea);
 
-    func(mem, 1I32, .cn (mem: %mem.M, x: .I32) = return (mem, x))
-};
+    func(mem, 1I32, .cn (mem: %mem.M, x: .I32) = return (mem, x));

--- a/lit/clos/no_mem_lazy.thorin
+++ b/lit/clos/no_mem_lazy.thorin
@@ -3,13 +3,11 @@
 
 .plugin core;
 
-.con f [a: .I32, ret: .Cn .I32] =
+.fun f(a: .I32): .I32 =
     .let b = %core.wrap.mul 0 (a, a);
-    ret b;
+    return b;
 
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] = {
-    .con ret_cont [r: .I32] =
-        .con ret_cont2 [r: .I32] = return (mem, r);
-        f (r, ret_cont2);
-    f (42I32,ret_cont)
-};
+.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] =
+    .ret r1 = f $ 42I32;
+    .ret r2 = f $ r1;
+    return (mem, r2);

--- a/lit/clos/pass_through_return.thorin
+++ b/lit/clos/pass_through_return.thorin
@@ -6,13 +6,11 @@
 
 .let pb_type = .Cn [%mem.M, .Cn [%mem.M]];
 
-.con end [mem: %mem.M, return : .Cn [%mem.M]] = {
-    return (mem)
-};
+.fun end(mem: %mem.M): %mem.M = return mem;
 
 .ccon printInteger [mem: %mem.M, val: .I32, return : .Cn [%mem.M]];
 
-.con .extern main [mem: %mem.M, argc: .I32, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), return : .Cn [%mem.M, .I32]] = {
+.con .extern main [mem: %mem.M, argc: .I32, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), return : .Cn [%mem.M, .I32]] =
     .con callback (mem: %mem.M) = return (mem, 1I32);
 
     .let (alloc_pb_mem, pb_ptr) = %mem.malloc (pb_type, 0) (mem, 100);
@@ -20,36 +18,26 @@
     .let lea_pb = %mem.lea (⊤:.Nat, <⊤:.Nat; pb_type>, 0) (pb_arr, 0I32);
     .let store_pb = %mem.store (alloc_pb_mem, lea_pb, end);
 
-    .con loop_head [mem: %mem.M, i : .I32] = {
-        .con exit [mem: %mem.M] = {
+    .con loop_head [mem: %mem.M, i : .I32] =
+        .con exit [mem: %mem.M] =
             .let (backward_pass_mem, backward_pass) = %mem.load (mem, lea_pb); // <- begin backward pass
-            backward_pass (backward_pass_mem, callback)
-        };
+            backward_pass (backward_pass_mem, callback);
 
-        .con yield [mem: %mem.M] = {
-            loop_head( mem, %core.wrap.add 0 (i, 1I32) )
-        };
+        .con yield [mem: %mem.M] = loop_head( mem, %core.wrap.add 0 (i, 1I32) );
 
-        .con body [mem: %mem.M] = {
+        .con body [mem: %mem.M] =
             .let (load_pb_mem, last_pb) = %mem.load (mem, lea_pb);
-            .con pb [mem: %mem.M, end: .Cn [%mem.M]] = {
-                .con inner_yield [mem: %mem.M] = {
-                    last_pb( mem, end )
-                };
-
-                printInteger(mem, i, inner_yield)
+            .con pb [mem: %mem.M, end: .Cn [%mem.M]] =
+                .con inner_yield [mem: %mem.M] = last_pb( mem, end );
+                printInteger(mem, i, inner_yield);
                 //last_pb (mem, end)  // << call previous backward pass block
-            };
 
             .let store_pb_mem = %mem.store (load_pb_mem, lea_pb, pb); // << stack backward pass block
 
-            printInteger(store_pb_mem, i, yield)
-        };
+            printInteger(store_pb_mem, i, yield);
 
         .let condition = %core.icmp.ul (i, 19I32);
         .let target = (exit, body)#condition;
-        target ( mem )
-    };
+        target ( mem );
 
-    loop_head ( store_pb, 0I32 ) // <-- start forward pass
-};
+    loop_head ( store_pb, 0I32 ); // <-- start forward pass

--- a/lit/clos/recursiveLoop.thorin
+++ b/lit/clos/recursiveLoop.thorin
@@ -13,46 +13,33 @@
 
 .let size = 10;
 
-.con recursive [mem: %mem.M, i : .I32, last_pullback: pb_type, return: .Cn [%mem.M]] = {
-    .con exit [mem: %mem.M] = {
-        last_pullback ( mem, return )
-    };
-
-    .con loop_body [mem: %mem.M] = {
-        .con pb [mem: %mem.M, return: .Cn [%mem.M]] = {
-            .con next [mem: %mem.M] = {
-                last_pullback (mem, return)
-            };
-
-            printIntegerNL( mem, i , next )
-        };
-
-        .con next [mem: %mem.M] = {
-            recursive( mem, %core.wrap.add 0 (i, 1I32), pb, return )
-        };
-
-        printIntegerNL( mem, i , next )
-    };
-
+.con recursive [mem: %mem.M, i : .I32, last_pullback: pb_type, return: .Cn [%mem.M]] =
     .let condition = %core.icmp.ul (i, %core.bitcast .I32 size);
-    .let target = (exit, loop_body)#condition;
-    target ( mem )
-};
+    (exit, loop_body)#condition mem
+    .where
+        .con loop_body [mem: %mem.M] =
+            .con pb [mem: %mem.M, return: .Cn [%mem.M]] =
+                printIntegerNL( mem, i , next )
+                .where
+                    .con next [mem: %mem.M] = last_pullback (mem, return);
+                .end;
 
-.con end [mem: %mem.M, return : .Cn [%mem.M]] = {
-    return (mem)
-};
+            printIntegerNL (mem, i , next)
+            .where
+                .con next [mem: %mem.M] = recursive( mem, %core.wrap.add 0 (i, 1I32), pb, return );
+            .end;
+        .con exit [mem: %mem.M] = last_pullback (mem, return);
+    .end;
 
-.con outer [mem: %mem.M, x : .I32, return : .Cn [%mem.M]] = {
-    recursive ( mem, 0I32, end, return )
-};
+.con end  [mem: %mem.M, return : .Cn [%mem.M]] = return (mem);
+.con outer[mem: %mem.M, x : .I32, return : .Cn [%mem.M]] = recursive ( mem, 0I32, end, return );
 
-.con .extern main [mem: %mem.M, argc: .I32, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), return : .Cn [%mem.M, .I32]] = {
-    .con callback (mem: %mem.M) = {
-
-        .con callback2 (mem: %mem.M) = return (mem, 1I32);
-        recursive (mem, 3I32, end, callback2)
-    };
-
+.con .extern main [mem: %mem.M, argc: .I32, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), return : .Cn [%mem.M, .I32]] =
     outer(mem, 1I32, callback)
-};
+    .where
+        .con callback (mem: %mem.M) =
+            recursive (mem, 3I32, end, callback2)
+            .where
+                .con callback2 (mem: %mem.M) = return (mem, 1I32);
+            .end;
+    .end;

--- a/lit/clos/return_cont_in_closure.thorin
+++ b/lit/clos/return_cont_in_closure.thorin
@@ -6,8 +6,7 @@
 
 .let pb_type = .Cn [%mem.M];
 
-.con .extern main [mem: %mem.M, argc: .I32, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), return : .Cn [%mem.M, .I32]] = {
-
+.con .extern main [mem: %mem.M, argc: .I32, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), return : .Cn [%mem.M, .I32]] =
     .con end [mem: %mem.M] = return (mem, 1I32); // <-- end backward pass
 
     .let (alloc_pb_mem, pb_ptr) = %mem.malloc (pb_type, 0) (mem, 100);
@@ -15,28 +14,22 @@
     .let lea_pb = %mem.lea (⊤:.Nat, <⊤:.Nat; pb_type>, 0) (pb_arr, 0I32);
     .let store_pb = %mem.store (alloc_pb_mem, lea_pb, end);
 
-    .con loop_head [mem: %mem.M, i : .I32] = {
-        .con exit [mem: %mem.M] = {
+    .con loop_head [mem: %mem.M, i : .I32] =
+        .con exit [mem: %mem.M] =
             .let (backward_pass_mem, backward_pass) = %mem.load (mem, lea_pb); // <- begin backward pass
-            backward_pass (backward_pass_mem)
-        };
+            backward_pass (backward_pass_mem);
 
         .con yield [mem: %mem.M] = loop_head( mem, %core.wrap.add 0 (i, 1I32) );
 
-        .con body [mem: %mem.M] = {
+        .con body [mem: %mem.M] =
             .let (load_pb_mem, last_pb) = %mem.load (mem, lea_pb);
-            .con pb [mem: %mem.M] = {
-                last_pb (mem) // << call previous backward pass block
-            };
+            .con pb [mem: %mem.M] = last_pb (mem); // << call previous backward pass block
 
             .let store_pb_mem = %mem.store (load_pb_mem, lea_pb, pb);  // << stack backward pass block
-            yield(store_pb_mem)
-        };
+            yield(store_pb_mem);
 
         .let condition = %core.icmp.ul (i, 19I32);
         .let target = (exit, body)#condition;
-        target ( mem )
-    };
+        target ( mem );
 
-    loop_head ( store_pb, 0I32 ) // <-- start forward pass
-};
+    loop_head ( store_pb, 0I32 ); // <-- start forward pass

--- a/lit/clos/using_c_function.thorin
+++ b/lit/clos/using_c_function.thorin
@@ -15,44 +15,35 @@
 
 .ccon printInteger [mem: %mem.M, val: .I32, return : .Cn [%mem.M]];
 
-.con .extern main [mem: %mem.M, argc: .I32, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), return : .Cn [%mem.M, .I32]] = {
+.con .extern main [mem: %mem.M, argc: .I32, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), return : .Cn [%mem.M, .I32]] =
     .con end [mem: %mem.M] = return (mem, 99I32);
 
-    .con init22 [mem: %mem.M] = {
+    .con init22 [mem: %mem.M] =
         .let (alloc_pb_mem, pb_ptr) = %mem.malloc (pb_type, 0) (mem, 100);
         .let pb_arr = %core.bitcast (%mem.Ptr («⊤:.Nat; pb_type», 0)) pb_ptr;
         .let lea_pb = %mem.lea (⊤:.Nat, <⊤:.Nat; pb_type>, 0) (pb_arr, 0I32);
         .let store_pb = %mem.store (alloc_pb_mem, lea_pb, end);
 
-        .con loop_head [mem: %mem.M, i : .I32] = {
-            .con exit [mem: %mem.M] = {
+        .con loop_head [mem: %mem.M, i : .I32] =
+            .con exit [mem: %mem.M] =
                 .let (backward_pass_mem, backward_pass) = %mem.load (mem, lea_pb);  // <- begin backward pass
-                backward_pass (backward_pass_mem)
-            };
+                backward_pass (backward_pass_mem);
 
             .con yield [mem: %mem.M] = loop_head( mem, %core.wrap.add 0 (i, 1I32) );
 
-            .con body [mem: %mem.M] = {
+            .con body [mem: %mem.M] =
                 .let (load_pb_mem, last_pb) = %mem.load (mem, lea_pb);
-                .con pb [mem: %mem.M] = {
+                .con pb [mem: %mem.M] =
                     //last_pb (mem)  // << call previous backward pass block
-
-                    printInteger(mem, i, last_pb)
-                };
+                    printInteger(mem, i, last_pb);
 
                 .let store_pb_mem = %mem.store (load_pb_mem, lea_pb, pb);  // << stack backward pass block
-
-                printInteger(store_pb_mem, i, yield)
-            };
+                printInteger(store_pb_mem, i, yield);
 
             .let condition = %core.icmp.ul (i, 19I32);
             .let target = (exit, body)#condition;
-            target ( mem )
-        };
+            target ( mem );
 
+        loop_head ( store_pb, 0I32 ); // <-- start forward pass
 
-        loop_head ( store_pb, 0I32 ) // <-- start forward pass
-    };
-
-    printInteger(mem, 42I32, init22)
-};
+    printInteger(mem, 42I32, init22);

--- a/lit/core/normalize_and_ff_tt.thorin
+++ b/lit/core/normalize_and_ff_tt.thorin
@@ -1,11 +1,10 @@
 // RUN: rm -f %t.ll
 // RUN: %thorin %s -o - | FileCheck %s
 
-.plugin core;
+//.plugin core;
 
-.con .extern and_lit_ff_tt [return : .Cn .Bool] = {
-    return (%core.bit2.and_ 0 (.ff, .tt))
-};
+.con .extern and_lit_ff_tt [return : .Cn .Bool] =
+    return (%core.bit2.and_ 0 (.ff, .tt));
 
 // CHECK-DAG: and_lit_ff_tt return_[[retId_ff_tt:[0-9_]+]]: .Cn .Bool
 // CHECK-DAG: _[[etaId_ff_tt:[0-9_]+]] .ff

--- a/lit/core/normalize_and_icmps.thorin
+++ b/lit/core/normalize_and_icmps.thorin
@@ -3,9 +3,8 @@
 
 .plugin core;
 
-.con .extern and (a b: .Bool, return : .Cn .Bool) = {
-    return (%core.bit2.and_ 0 (%core.icmp.uge (a, b), %core.icmp.ug (a, b)))
-};
+.con .extern and (a b: .Bool, return : .Cn .Bool) =
+    return (%core.bit2.and_ 0 (%core.icmp.uge (a, b), %core.icmp.ug (a, b)));
 
 // CHECK-DAG: .con .extern and _{{[0-9_]+}}::[a_[[aId:[0-9_]+]]: .Bool, b_[[bId:[0-9_]+]]: .Bool, return_[[retId:[0-9_]+]]: .Cn .Bool]
 // CHECK-DAG: .let _[[cmpId:[0-9_]+]]: .Bool = %core.icmp.xYGle 2 (a_[[aId]], b_[[bId]]);

--- a/lit/core/normalize_and_tree.thorin
+++ b/lit/core/normalize_and_tree.thorin
@@ -3,7 +3,7 @@
 
 .plugin core;
 
-.con .extern and_lit [return : .Cn .Bool] = {
+.con .extern and_lit [return : .Cn .Bool] =
     return
     (%core.bit2.and_ 0
         (%core.bit2.and_ 0
@@ -11,8 +11,7 @@
              %core.bit2.and_ 0 (.ff, .ff)),
          %core.bit2.and_ 0
             (%core.bit2.and_ 0 (.ff, .tt),
-             %core.bit2.and_ 0 (.tt, .ff))))
-};
+             %core.bit2.and_ 0 (.tt, .ff))));
 
 // CHECK-DAG: .con .extern and_lit return_[[retId:[0-9_]+]]: .Cn .Bool{{(@.*)?}}= {
 // CHECK-DAG: _[[etaId:[0-9_]+]] .ff

--- a/lit/core/normalize_and_tt.thorin
+++ b/lit/core/normalize_and_tt.thorin
@@ -3,9 +3,8 @@
 
 .plugin core;
 
-.con .extern and_tt [i :.Bool, return : .Cn .Bool] = {
-    return (%core.bit2.and_ 0 (i, .tt))
-};
+.con .extern and_tt [i :.Bool, return : .Cn .Bool] =
+    return (%core.bit2.and_ 0 (i, .tt));
 
 // CHECK-DAG: and_tt _{{[0-9_]+}}::[i_[[valId_tt:[0-9_]+]]: .Bool, return_[[retId_tt:[0-9_]+]]: .Cn .Bool]{{(@.*)?}}= {
 // CHECK-DAG: return_[[etaId_tt:[0-9_]+]] i_[[valId_tt]]

--- a/lit/core/normalize_and_tt_tt.thorin
+++ b/lit/core/normalize_and_tt_tt.thorin
@@ -3,9 +3,8 @@
 
 .plugin core;
 
-.con .extern and_lit_tt_tt [return : .Cn .Bool] = {
-    return (%core.bit2.and_ 0 (.tt, .tt))
-};
+.con .extern and_lit_tt_tt [return : .Cn .Bool] =
+    return (%core.bit2.and_ 0 (.tt, .tt));
 
 // CHECK-DAG: .con .extern and_lit_tt_tt return_[[retId:[0-9_]+]]: .Cn .Bool{{(@.*)?}}= {
 // CHECK-DAG: _[[etaId:[0-9_]+]] .tt

--- a/lit/core/normalize_bitcast.thorin
+++ b/lit/core/normalize_bitcast.thorin
@@ -4,9 +4,8 @@
 
 .plugin core;
 
-.con .extern bitcast_bitcast(i : %mem.Ptr (.I8, 0), return: .Cn .I32) = {
-    return (%core.bitcast (.I32) (%core.bitcast .Nat i))
-};
+.con .extern bitcast_bitcast(i : %mem.Ptr (.I8, 0), return: .Cn .I32) =
+    return (%core.bitcast (.I32) (%core.bitcast .Nat i));
 
 // TODO parenthesis in output broken for bitcast
 // CHECK-DAG: bitcast_bitcast _{{[0-9_]+}}::[i_[[valId:[0-9_]+]]: %mem.Ptr (.I8, 0), return_[[retId:[0-9_]+]]: .Cn .I32]{{(@.*)?}}= {

--- a/lit/core/normalize_icmp.thorin
+++ b/lit/core/normalize_icmp.thorin
@@ -3,9 +3,8 @@
 
 .plugin core;
 
-.con .extern icmp_lit [return : .Cn .Bool] = {
-    return (%core.icmp.e (%core.icmp.uge (.tt, .ff), %core.icmp.ug (.tt, .ff)))
-};
+.con .extern icmp_lit [return : .Cn .Bool] =
+    return (%core.icmp.e (%core.icmp.uge (.tt, .ff), %core.icmp.ug (.tt, .ff)));
 
 // CHECK-DAG: icmp_lit return_[[retId:[0-9_]+]]: .Cn .Bool{{(@.*)?}}= {
 // CHECK-DAG: _[[etaId:[0-9_]+]] .tt

--- a/lit/core/ret_add.thorin
+++ b/lit/core/ret_add.thorin
@@ -8,17 +8,17 @@
 
 .ccon atoi[%mem.M, %mem.Ptr («⊤:.Nat; .I8», 0), .Cn [%mem.M, .I32]];
 
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), return : .Cn [%mem.M, .I32]] =
+.con .extern main(mem: %mem.M, argc: .I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), return: .Cn [%mem.M, .I32]) =
     .let argv_ptr_a  = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 1I32);
     .let (`mem, val) = %mem.load (mem, argv_ptr_a);
     atoi (mem, val, atoi_cont_a)
     .where
-        .con atoi_cont_a [mem : %mem.M, a : .I32] =
+        .con atoi_cont_a [mem: %mem.M, a: .I32] =
             .let argv_ptr_b  = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 2I32);
             .let (`mem, val) = %mem.load (mem, argv_ptr_b);
             atoi (mem, val, atoi_cont_b)
             .where
-                .con atoi_cont_b [mem : %mem.M, b : .I32] =
+                .con atoi_cont_b [mem: %mem.M, b: .I32] =
                     return (mem, %core.wrap.add 0 (a, b));
             .end
     .end

--- a/lit/core/ret_and.thorin
+++ b/lit/core/ret_and.thorin
@@ -6,23 +6,23 @@
 
 .plugin core;
 
-.ccon atoi [%mem.M, %mem.Ptr («⊤:.Nat; .I8», 0), .Cn [%mem.M, .I32]];
+.ccon atoi[%mem.M, %mem.Ptr («⊤:.Nat; .I8», 0), .Cn [%mem.M, .I32]];
 
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), return : .Cn [%mem.M, .I32]] = {
-    .con atoi_cont_a [mem : %mem.M, a : .I32] = {
-        .con atoi_cont_b [mem : %mem.M, b : .I32] = {
-                return (mem, %core.bit2.and_ 0 (a, b))
-        };
+.con .extern main(mem: %mem.M, argc: .I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), return: .Cn [%mem.M, .I32]) =
+    .let argv_ptr_a  = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 1I32);
+    .let (`mem, val) = %mem.load (mem, argv_ptr_a);
+    atoi (mem, val, atoi_cont_a)
+    .where
+        .con atoi_cont_a(mem: %mem.M, a: .I32) =
+            .let argv_ptr_b  = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 2I32);
+            .let (`mem, val) = %mem.load (mem, argv_ptr_b);
+            atoi (mem, val, atoi_cont_b)
+            .where
+                .con atoi_cont_b(mem: %mem.M, b: .I32) =
+                    return (mem, %core.bit2.and_ 0 (a, b));
+            .end
+    .end
 
-        .let argv_ptr_b = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 2I32);
-        .let argv_load_b = %mem.load (mem, argv_ptr_b);
-        atoi (argv_load_b#.ff, argv_load_b#.tt, atoi_cont_b)
-    };
-
-    .let argv_ptr_a = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 1I32);
-    .let argv_load_a = %mem.load (mem, argv_ptr_a);
-    atoi (argv_load_a#.ff, argv_load_a#.tt, atoi_cont_a)
-};
 
 // CHECK-DAG: main _{{[0-9_]+}}::[mem_[[memId:[0-9_]+]]: %mem.M, .I32, argv_{{[0-9]+}}: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), return_[[returnId:[0-9_]+]]: .Cn [%mem.M, .I32]]{{(@.*)?}}= {
 

--- a/lit/core/ret_lshr.thorin
+++ b/lit/core/ret_lshr.thorin
@@ -6,23 +6,22 @@
 
 .plugin core;
 
-.ccon atoi [%mem.M, %mem.Ptr («⊤:.Nat; .I8», 0), .Cn [%mem.M, .I32]];
+.ccon atoi[%mem.M, %mem.Ptr («⊤:.Nat; .I8», 0), .Cn [%mem.M, .I32]];
 
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), return : .Cn [%mem.M, .I32]] = {
-    .con atoi_cont_a [mem : %mem.M, a : .I32] = {
-        .con atoi_cont_b [mem : %mem.M, b : .I32] = {
-                return (mem, %core.shr.l (a, b))
-        };
-
-        .let argv_ptr_b = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 2I32);
-        .let argv_load_b = %mem.load (mem, argv_ptr_b);
-        atoi (argv_load_b#.ff, argv_load_b#.tt, atoi_cont_b)
-    };
-
-    .let argv_ptr_a = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 1I32);
-    .let argv_load_a = %mem.load (mem, argv_ptr_a);
-    atoi (argv_load_a#.ff, argv_load_a#.tt, atoi_cont_a)
-};
+.con .extern main(mem: %mem.M, argc: .I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), return: .Cn [%mem.M, .I32]) =
+    .let argv_ptr_a  = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 1I32);
+    .let (`mem, val) = %mem.load (mem, argv_ptr_a);
+    atoi (mem, val, atoi_cont_a)
+    .where
+        .con atoi_cont_a(mem: %mem.M, a: .I32) =
+            .let argv_ptr_b  = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 2I32);
+            .let (`mem, val) = %mem.load (mem, argv_ptr_b);
+            atoi (mem, val, atoi_cont_b)
+            .where
+                .con atoi_cont_b(mem: %mem.M, b: .I32) =
+                    return (mem, %core.shr.l (a, b))
+            .end
+    .end
 
 // CHECK-DAG: main _{{[0-9_]+}}::[mem_[[memId:[0-9_]+]]: %mem.M, .I32, argv_{{[0-9]+}}: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), return_[[returnId:[0-9_]+]]: .Cn [%mem.M, .I32]]{{(@.*)?}}= {
 

--- a/lit/core/ret_nand.thorin
+++ b/lit/core/ret_nand.thorin
@@ -7,18 +7,16 @@
 
 .ccon atoi [%mem.M, %mem.Ptr («⊤:.Nat; .I8», 0), .Cn [%mem.M, .I32]];
 
-.con .extern main [mem: %mem.M, argc: .I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), return: .Cn [%mem.M, .I32]] = {
-    .con atoi_cont_a [mem: %mem.M, a: .I32] = {
-        .con atoi_cont_b [mem: %mem.M, b: .I32] = {
-            return (mem, %core.bit2.and_ 0 (0b00000000000000000000000000001111I32, %core.bit2.nand 0 (a, b)))
-        };
-
-        .let argv_ptr_b = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 2I32);
-        .let argv_load_b = %mem.load (mem, argv_ptr_b);
-        atoi (argv_load_b#0_2, argv_load_b#1_2, atoi_cont_b)
-    };
-
+.con .extern main [mem: %mem.M, argc: .I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), return: .Cn [%mem.M, .I32]] =
     .let argv_ptr_a = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 1I32);
     .let (`mem, val) = %mem.load (mem, argv_ptr_a);
     atoi (mem, val, atoi_cont_a)
-};
+    .where
+        .con atoi_cont_a [mem: %mem.M, a: .I32] =
+            .let argv_ptr_b = %mem.lea (⊤:.Nat, ‹⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 2I32);
+            .let argv_load_b = %mem.load (mem, argv_ptr_b);
+            atoi (argv_load_b#0_2, argv_load_b#1_2, atoi_cont_b)
+            .where
+                .con atoi_cont_b [mem: %mem.M, b: .I32] = return (mem, %core.bit2.and_ 0 (0b00000000000000000000000000001111I32, %core.bit2.nand 0 (a, b)));
+            .end;
+    .end;

--- a/lit/demo/const.thorin
+++ b/lit/demo/const.thorin
@@ -4,11 +4,10 @@
 .plugin core;
 .plugin demo;
 
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] = {
+.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] =
     .con ret_cont r: .I32 = return (mem, r);
     .let c = %demo.const_idx .i32;
-    ret_cont c
-};
+    ret_cont c;
 
 // CHECK-DAG: .con .extern main _{{[0-9_]+}}::[mem_[[memId:[_0-9]*]]: %mem.M, .I32, %mem.Ptr (%mem.Ptr (.I8, 0), 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, .I32]]{{(@.*)?}}= {
 // CHECK-DAG: return_[[returnEtaId:[_0-9]*]] (mem_[[memId]], 42I32)

--- a/lit/direct/ds2cps_ax_cps2ds.thorin
+++ b/lit/direct/ds2cps_ax_cps2ds.thorin
@@ -4,15 +4,13 @@
 .plugin core;
 .plugin direct;
 
-.con f [a:.I32, return: .Cn .I32] = {
+.fun f(a: .I32): .I32 =
     .let b = %core.wrap.add 0 (2I32, a);
-    return b
-};
+    return b;
 
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] = {
+.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] =
     .let g = %direct.cps2ds (.I32,.I32) f;
     .let c = g 40I32;
-    return (mem, c)
-};
+    return (mem, c);
 
 // CHECK-DAG: return{{.*}}42

--- a/lit/direct/ds2cps_ax_cps2ds_twice_diff.thorin
+++ b/lit/direct/ds2cps_ax_cps2ds_twice_diff.thorin
@@ -4,22 +4,19 @@
 .plugin core;
 .plugin direct;
 
-.con f [a:.I32, return: .Cn .I32] = {
+.fun f(a: .I32): .I32 =
     .let b = %core.wrap.add 0 (2I32, a);
-    return b
-};
+    return b;
 
-.con f2 [a:.I32, return: .Cn .I32] = {
+.fun f2(a:.I32): .I32 =
     .let b = %core.wrap.add 0 (30I32, a);
-    return b
-};
+    return b;
 
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] = {
+.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] =
     .let g = %direct.cps2ds (.I32,.I32) f;
     .let c1 = g 10I32;
     .let h = %direct.cps2ds (.I32,.I32) f2;
     .let c2 = h (c1);
-    return (mem, c2)
-};
+    return (mem, c2);
 
 // CHECK-DAG: return{{.*}}42

--- a/lit/direct/ds2cps_mixed2.thorin
+++ b/lit/direct/ds2cps_mixed2.thorin
@@ -9,18 +9,15 @@
 
 .lam f [a:.I32]: .I32 = %core.wrap.add 0 (2I32, a);
 
-.con h [mem : %mem.M, a : .I32, return : .Cn [%mem.M, .I32]] = {
+.con h [mem : %mem.M, a : .I32, return : .Cn [%mem.M, .I32]] =
     .let c = f a;
-    return (mem, c)
-};
+    return (mem, c);
 
-.con g [mem : %mem.M, a : .I32, return : .Cn [%mem.M, .I32]] = {
+.con g [mem : %mem.M, a : .I32, return : .Cn [%mem.M, .I32]] =
     .let b = %core.wrap.add 0 (3I32, a);
-    h (mem, b, return)
-};
+    h (mem, b, return);
 
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] = {
-    g (mem, 40I32, return)
-};
+.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] =
+    g (mem, 40I32, return);
 
 // CHECK-DAG: return{{.*}}45

--- a/lit/direct/mut_dom_bug.thorin
+++ b/lit/direct/mut_dom_bug.thorin
@@ -3,23 +3,17 @@
 
 .lam ForBody [n: .Nat] = [%mem.M, .Idx n] -> %mem.M;
 
-.lam For .[n: .Nat] [start: .Idx n, end: .Idx n] [mem: %mem.M] [it: ForBody n]: %mem.M = {
-    .lam loop [mem: %mem.M, i: .Idx n] @(%core.pe.known i) : [%mem.M, .Idx n] = {
+.lam For .[n: .Nat] [start: .Idx n, end: .Idx n] [mem: %mem.M] [it: ForBody n]: %mem.M =
+    .lam loop [mem: %mem.M, i: .Idx n] @(%core.pe.known i) : [%mem.M, .Idx n] =
         .let `mem = it (mem, i);
 
         .let j   = %core.wrap.add 0 (i, %core.idx n 0 1);
         .let cmp = %core.icmp.ul    (i, end);
-        ((mem, j), loop (mem, j))#cmp
-    };
+        ((mem, j), loop (mem, j))#cmp;
 
     .let (`mem, _) = loop (mem, start);
-    mem
-};
+    mem;
 
-.con .extern main [mem: %mem.M, ret: .Cn [%mem.M, .I32]] = {
-    .let `mem = For (0_123, 122_123) mem (.lm [mem: %mem.M, i: .Idx 123]: %mem.M = {
-        // do stuff
-        mem
-    });
-    ret (mem, 0I32)
-};
+.con .extern main [mem: %mem.M, ret: .Cn [%mem.M, .I32]] =
+    .let `mem = For (0_123, 122_123) mem (.lm [mem: %mem.M, i: .Idx 123]: %mem.M = mem);
+    ret (mem, 0I32);

--- a/lit/group.thorin
+++ b/lit/group.thorin
@@ -1,4 +1,4 @@
 // RUN: %thorin %s -o -
 .lam f(a b: .Nat, x: «a; .Nat»): .Bool = .ff;
 .ax %foo.F: [p e: .Nat] -> *;
-.ax %foo.bar: Π.pe::[p e: .Nat][.Nat][a b: %foo.F pe] -> %foo.F (p, e);
+.ax %foo.bar: Π .[p e: .Nat]::pe [.Nat] [a b: %foo.F pe] -> %foo.F (p, e);

--- a/lit/math/exp.thorin
+++ b/lit/math/exp.thorin
@@ -6,11 +6,10 @@
 .plugin math;
 .plugin core;
 
-.con .extern main [mem: %mem.M, argc: .I32, argv: %mem.Ptr (%mem.Ptr (.I8, 0), 0), return: .Cn [%mem.M, .I32]] = {
+.con .extern main [mem: %mem.M, argc: .I32, argv: %mem.Ptr (%mem.Ptr (.I8, 0), 0), return: .Cn [%mem.M, .I32]] =
     .let s = %math.conv.u2f %math.f32 argc;
     .let x = %math.exp.log2 0 (%math.exp.exp 0 s);
     .let y = %math.exp.log 0 (%math.exp.exp2 0 s);
     .let z = %math.arith.add 0 (x, y);
     .let r = %math.conv.f2u .i32 (%math.arith.mul 0 (%math.conv.f2f %math.f64 z, 10.0:%math.F64));
-    return (mem, r)
-};
+    return (mem, r);

--- a/lit/math/tri.thorin
+++ b/lit/math/tri.thorin
@@ -7,12 +7,11 @@
 .plugin mem;
 .plugin core;
 
-.con .extern main [mem: %mem.M, argc: .I32, argv: %mem.Ptr (%mem.Ptr (.I8, 0), 0), return: .Cn [%mem.M, .I32]] = {
+.con .extern main [mem: %mem.M, argc: .I32, argv: %mem.Ptr (%mem.Ptr (.I8, 0), 0), return: .Cn [%mem.M, .I32]] =
     .let s   = %math.conv.u2f %math.f32 argc;
     .let d   = %math.conv.u2f %math.f64 argc;
     .let x   = %math.conv.f2f %math.f64 (%math.tri.sin 0 s);
     .let y   = %math.tri.atanh 0 (%math.arith.div 0 (d, 10.0:%math.F64));
     .let z   = %math.pow 0 (x, y);
     .let res = %math.arith.mul 0 (z, 100.0:%math.F64);
-    return (mem, %math.conv.f2u .i32 res)
-};
+    return (mem, %math.conv.f2u .i32 res);

--- a/lit/matrix/get_shape.thorin
+++ b/lit/matrix/get_shape.thorin
@@ -4,13 +4,12 @@
 .plugin core;
 .plugin matrix;
 
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] = {
+.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] =
     .let MT = (2, (3, 5), .I32);
     .let c = 5I32;
     .let (`mem, m) = %matrix.constMat MT (mem,c);
     .let d = %matrix.shape MT (m, 0_2);
     .let e = %core.bitcast .I32 d;
-    return (mem, e)
-};
+    return (mem, e);
 
 // CHECK-DAG: return{{.*}}3{{.*}}

--- a/lit/matrix/map_reduce_mult.thorin
+++ b/lit/matrix/map_reduce_mult.thorin
@@ -6,23 +6,18 @@
 
 // .let MT = (2, (2,4), I32);
 
-.con inner_fun [[mem:%mem.M, acc:.I32, [a:.I32, b:.I32]], ret:.Cn[%mem.M,.I32]] = {
-    .let v = %core.wrap.mul 0 (a,b);
+.con inner_fun [[mem:%mem.M, acc:.I32, [a:.I32, b:.I32]], ret:.Cn[%mem.M,.I32]] =
+    .let v       = %core.wrap.mul 0 (a,b);
+    .let new_acc = %core.wrap.add 0 (acc,v); // reduce op = addition
+    ret (mem, new_acc);
 
-    // reduce op = addition
-    .let new_acc = %core.wrap.add 0 (acc,v);
-
-    ret (mem, new_acc)
-};
-
-.con .extern f [mem : %mem.M,
-    [k:.Nat, l:.Nat, m:.Nat],
-    M:%matrix.Mat (2,(k,m),.I32),
-    N:%matrix.Mat (2,(m,l),.I32),
-    return: .Cn[%mem.M, %matrix.Mat (2,(k,l),.I32)]] = {
-
-    // .let (mem2, MN) = %matrix.constMat (2,(k,l),.I32) (mem, 0I32;
-    .let (mem2,MN) = %matrix.map_reduce
+.con .extern f[mem: %mem.M,
+              [k l m:.Nat],
+              M:%matrix.Mat (2, (k, m), .I32),
+              N:%matrix.Mat (2, (m, l), .I32),
+              return: .Cn[%mem.M, %matrix.Mat (2, (k, l), .I32)]] =
+    // .let (`mem, MN) = %matrix.constMat (2,(k,l),.I32) (mem, 0I32;
+    .let (`mem, MN) = %matrix.map_reduce
         (
             2, (k,l), .I32,
             2,
@@ -38,11 +33,7 @@
                 ((0,2),M),
                 ((2,1),N)
             )
-        )
-        ;
-
-
-    return (mem2, MN)
-};
+        );
+    return (mem, MN);
 
 // CHECK-NOT: %matrix.

--- a/lit/matrix/map_reduce_mult_init.thorin
+++ b/lit/matrix/map_reduce_mult_init.thorin
@@ -6,27 +6,20 @@
 
 // .let MT = (2, (2,4), I32);
 
-.con fun [[mem:%mem.M, acc:.I32, [a:.I32, b:.I32]], ret:.Cn[%mem.M,.I32]] = {
-    .let v = %core.wrap.mul 0 (a,b);
-
-    // reduce op = addition
-    .let new_acc = %core.wrap.add 0 (acc,v);
-
-    ret (mem, new_acc)
-};
+.con fun [[mem:%mem.M, acc:.I32, [a:.I32, b:.I32]], ret:.Cn[%mem.M,.I32]] =
+    .let v       = %core.wrap.mul 0 (a,b);
+    .let new_acc = %core.wrap.add 0 (acc,v); // reduce op = addition
+    ret (mem, new_acc);
 
 .con .extern f [mem : %mem.M,
-    [k:.Nat, l:.Nat, m:.Nat],
+    [k l m:.Nat],
     // M:%matrix.Mat (2,(k,m),.I32),
     // N:%matrix.Mat (2,(m,l),.I32),
     // return: .Cn[%mem.M, %matrix.Mat (2,(k,l),.I32)]] = {
-    return: .Cn[%mem.M]] = {
-
-    .let (mem2, M) = %matrix.constMat (2,(k,m),.I32) (mem, 42I32);
-    .let (mem3, N) = %matrix.constMat (2,(m,l),.I32) (mem2, 44I32);
-
-    // .let mem4 = mem3;
-    .let (mem4,MN) = %matrix.map_reduce
+    return: .Cn[%mem.M]] =
+    .let (`mem, M)  = %matrix.constMat (2,(k,m),.I32) (mem, 42I32);
+    .let (`mem, N)  = %matrix.constMat (2,(m,l),.I32) (mem, 44I32);
+    .let (`mem, MN) = %matrix.map_reduce
         (
             2, (k,l), .I32,
             2,
@@ -35,19 +28,14 @@
             ((k,m),(m,l))
         )
         (
-            mem3,
+            mem,
             0I32,
             fun,
             (
                 ((0,2),M),
                 ((2,1),N)
             )
-        )
-        ;
-
-
-    // return (mem3)
-    return (mem4)
-};
+        );
+    return mem;
 
 // CHECK-NOT: %matrix.

--- a/lit/matrix/map_reduce_mult_init_ret.thorin
+++ b/lit/matrix/map_reduce_mult_init_ret.thorin
@@ -6,27 +6,20 @@
 
 // .let MT = (2, (2,4),  .I32);
 
-.con fun [[mem:%mem.M, acc:.I32, [a:.I32, b:.I32]], ret:.Cn[%mem.M,.I32]] = {
-    .let v = %core.wrap.mul 0 (a,b);
-
-    // reduce op = addition
-    .let new_acc = %core.wrap.add 0 (acc,v);
-
-    ret (mem, new_acc)
-};
+.con fun [[mem:%mem.M, acc:.I32, [a:.I32, b:.I32]], ret:.Cn[%mem.M,.I32]] =
+    .let v       = %core.wrap.mul 0 (a,b);
+    .let new_acc = %core.wrap.add 0 (acc,v); // reduce op = addition
+    ret (mem, new_acc);
 
 .con .extern f [mem : %mem.M,
-    [k:.Nat, l:.Nat, m:.Nat],
+    [k l m:.Nat],
     // M:%matrix.Mat (2,(k,m), .I32),
     // N:%matrix.Mat (2,(m,l), .I32),
-    return: .Cn[%mem.M, %matrix.Mat (2,(k,l), .I32)]] = {
-    // return: .Cn[%mem.M]] = {
+    return: .Cn[%mem.M, %matrix.Mat (2,(k,l), .I32)]] =
+    .let (`mem, M) = %matrix.constMat (2,(k,m), .I32) (mem, 42I32);
+    .let (`mem, N) = %matrix.constMat (2,(m,l), .I32) (mem, 44I32);
 
-    .let (mem2, M) = %matrix.constMat (2,(k,m), .I32) (mem, 42I32);
-    .let (mem3, N) = %matrix.constMat (2,(m,l), .I32) (mem2, 44I32);
-
-    // .let mem4 = mem3;
-    .let (mem4,MN) = %matrix.map_reduce
+    .let (`mem,MN) = %matrix.map_reduce
         (
             2, (k,l),  .I32,
             2,
@@ -35,18 +28,14 @@
             ((k,m),(m,l))
         )
         (
-            mem3,
+            mem,
             0I32,
             fun,
             (
                 ((0,2),M),
                 ((2,1),N)
             )
-        )
-        ;
-
-
-    return (mem4,MN)
-};
+        );
+    return (mem,MN);
 
 // CHECK-NOT: %matrix.

--- a/lit/matrix/map_reduce_zip_add.thorin
+++ b/lit/matrix/map_reduce_zip_add.thorin
@@ -6,24 +6,18 @@
 
 // .let MT = (2, (2,4), .I32);
 
-.con .extern fun [[mem:%mem.M, acc:.I32, [a:.I32, b:.I32]], ret:.Cn[%mem.M,.I32]] = {
-    .let v = %core.wrap.add 0 (a,b);
-
-    // reduce op = addition
-    .let new_acc = %core.wrap.add 0 (acc,v);
-
-    ret (mem, new_acc)
-};
+.con .extern fun [[mem:%mem.M, acc:.I32, [a:.I32, b:.I32]], ret:.Cn[%mem.M,.I32]] =
+    .let v       = %core.wrap.add 0 (a,b);
+    .let new_acc = %core.wrap.add 0 (acc,v); // reduce op = addition
+    ret (mem, new_acc);
 
 .con .extern f [mem : %mem.M,
-    [k:.Nat, l:.Nat],
+    [k l:.Nat],
     M:%matrix.Mat (2,(k,l),.I32),
-    return: .Cn[%mem.M, %matrix.Mat (2,(k,l),.I32)]] = {
+    return: .Cn[%mem.M, %matrix.Mat (2,(k,l),.I32)]] =
     // .let v2 = %core.wrap.add (0, .i32) (v, v);
     // .let (k,l) = kl;
     // .let add = %core.wrap.add (0, .i32);
-
-
     .let MT = M;
     .let (mem2,MT2) = %matrix.map_reduce
         (
@@ -49,9 +43,6 @@
         //     identity,
         //     (((1,0),M))
         // );
-
-
-    return (mem2, MT)
-};
+    return (mem2, MT);
 
 // CHECK-NOT: %matrix.

--- a/lit/matrix/print_const.thorin
+++ b/lit/matrix/print_const.thorin
@@ -10,23 +10,19 @@
 
 .ccon print_int_matrix [mem: %mem.M, k: .Nat, l: .Nat, m: %matrix.Mat (2, (⊤:.Nat,⊤:.Nat), .I32), return : .Cn [%mem.M]];
 
-.con print_int_matrix_wrap [mem: %mem.M, k: .Nat, l: .Nat, m: %matrix.Mat (2, (k,l), .I32), return : .Cn [%mem.M]] = {
+.con print_int_matrix_wrap [mem: %mem.M, k: .Nat, l: .Nat, m: %matrix.Mat (2, (k,l), .I32), return : .Cn [%mem.M]] =
     .let m2 = %core.bitcast (%matrix.Mat (2,(⊤:.Nat,⊤:.Nat),.I32)) m;
-    print_int_matrix(mem, k, l, m2, return)
-};
+    print_int_matrix(mem, k, l, m2, return);
 
-
-
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] = {
-    .con return_cont [mem:%mem.M] = return (mem, 0I32);
-
+.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] =
     .let c = argc;
     .let (mem2,m) = %matrix.constMat MT (mem,c);
-
     // return_cont mem2
     // print_int_matrix (mem2, 2, 4, m, return_cont)
     print_int_matrix_wrap (mem2, 2, 4, m, return_cont)
-};
+    .where
+        .con return_cont [mem:%mem.M] = return (mem, 0I32);
+    .end;
 
 // CHECK: 3, 3, 3, 3,
 // CHECK: 3, 3, 3, 3,

--- a/lit/matrix/print_const_dyn_mat.thorin
+++ b/lit/matrix/print_const_dyn_mat.thorin
@@ -14,52 +14,42 @@
 .ccon atoi [%mem.M, String, .Cn [%mem.M, .I32]];
 .ccon print_int_matrix [mem: %mem.M, k: .Nat, l: .Nat, m: %matrix.Mat (2, (⊤:.Nat,⊤:.Nat), .I32), return : .Cn [%mem.M]];
 
-.con print_int_matrix_wrap [mem: %mem.M, k: .Nat, l: .Nat, m: %matrix.Mat (2, (k,l), .I32), return : .Cn [%mem.M]] = {
+.con print_int_matrix_wrap [mem: %mem.M, k: .Nat, l: .Nat, m: %matrix.Mat (2, (k,l), .I32), return : .Cn [%mem.M]] =
     .let m2 = %core.bitcast (%matrix.Mat (2,(⊤:.Nat,⊤:.Nat),.I32)) m;
-    print_int_matrix(mem, k, l, m2, return)
-};
+    print_int_matrix(mem, k, l, m2, return);
 
-.con .extern f [mem : %mem.M,
-    [k:.Nat, l:.Nat],
-    return: .Cn[%mem.M]] = {
-
-    .let (mem2, M) = %matrix.constMat (2,(k,l),.I32) (mem, 3I32);
-    // .let (mem2, N) = %matrix.constMat (2,(k,l),.I32) (mem, 5I32);
-
-    print_int_matrix_wrap (mem2, k, l, M, return)
-    // return mem2
-};
+.con .extern f [mem : %mem.M, [k l:.Nat], return: .Cn[%mem.M]] =
+    .let (`mem, M) = %matrix.constMat (2,(k,l),.I32) (mem, 3I32);
+    // .let (mem, N) = %matrix.constMat (2,(k,l),.I32) (mem, 5I32);
+    print_int_matrix_wrap (mem, k, l, M, return);
+    // return mem
 
 .con .extern main [mem1 : %mem.M,
         argc : .I32,
         argv : %mem.Ptr («⊤:.Nat; String», 0), // const char *argv[]
         return : .Cn [%mem.M, .I32]
-    ] = {
-
-    .con return_cont [mem: %mem.M] = {
-        return (mem, 0I32)
-    };
-
-    .let arg1_ptr = %mem.lea (⊤:.Nat, ‹⊤:.Nat; String›, 0) (argv, 1I32); // argv+1 : const char**
-    .let (mem2,arg1) = %mem.load (mem1, arg1_ptr); // argv[1] : const char*
-
-    .let arg2_ptr = %mem.lea (⊤:.Nat, ‹⊤:.Nat; String›, 0) (argv, 2I32); // argv+2
-    .let (mem3,arg2) = %mem.load (mem2, arg2_ptr); // argv[2]
-
-    .con atoi_cont_1 [mem : %mem.M, a : .I32] = {
-        .con atoi_cont_2 [mem : %mem.M, b : .I32] = {
-            // return (mem, 42I32
-            .let a_nat = %core.bitcast .Nat a;
-            .let b_nat = %core.bitcast .Nat b;
-            f (mem, (a_nat,b_nat), return_cont)
-        };
-        atoi (mem, arg2, atoi_cont_2)
-    };
-
-    // .let (mem2,m) = %matrix.constMat MT (mem,c);
-    // cont (mem2, m, return)
-    // return (mem3, 0I32)
-    atoi (mem3, arg1, atoi_cont_1)
-};
+    ] =
+    .let arg1_ptr    = %mem.lea (⊤:.Nat, ‹⊤:.Nat; String›, 0) (argv, 1I32); // argv+1 : const char**
+    .let (`mem, arg1) = %mem.load (mem1, arg1_ptr); // argv[1] : const char*
+    .let arg2_ptr    = %mem.lea (⊤:.Nat, ‹⊤:.Nat; String›, 0) (argv, 2I32); // argv+2
+    .let (`mem,arg2) = %mem.load (mem, arg2_ptr); // argv[2]
+    // .let (mem,m) = %matrix.constMat MT (mem,c);
+    // cont (mem, m, return)
+    // return (mem, 0I32)
+    atoi (mem, arg1, atoi_cont_1)
+    .where
+        .con atoi_cont_1 [mem : %mem.M, a : .I32] =
+            atoi (mem, arg2, atoi_cont_2)
+            .where
+                .con atoi_cont_2 [mem : %mem.M, b : .I32] =
+                    // return (mem, 42I32
+                    .let a_nat = %core.bitcast .Nat a;
+                    .let b_nat = %core.bitcast .Nat b;
+                    f (mem, (a_nat,b_nat), return_cont)
+                    .where
+                        .con return_cont [mem: %mem.M] = return (mem, 0I32);
+                    .end;
+            .end;
+    .end;
 
 // CHECK-NOT: %matrix.

--- a/lit/matrix/print_id_mat.thorin
+++ b/lit/matrix/print_id_mat.thorin
@@ -12,16 +12,13 @@
 .ccon print_int_matrix    [mem: %mem.M, k: .Nat, l: .Nat, m: %matrix.Mat (2, (⊤:.Nat,⊤:.Nat), .I32), return : .Cn [%mem.M]];
 .ccon print_double_matrix [mem: %mem.M, k: .Nat, l: .Nat, m: %matrix.Mat (2, (⊤:.Nat,⊤:.Nat), %math.F64), return : .Cn [%mem.M]];
 
-.con print_int_matrix_wrap [mem: %mem.M, k: .Nat, l: .Nat, m: %matrix.Mat (2, (k,l), .I32), return : .Cn [%mem.M]] = {
+.con print_int_matrix_wrap [mem: %mem.M, k: .Nat, l: .Nat, m: %matrix.Mat (2, (k,l), .I32), return : .Cn [%mem.M]] =
     .let m2 = %core.bitcast (%matrix.Mat (2,(⊤:.Nat,⊤:.Nat),.I32)) m;
-    print_int_matrix(mem, k, l, m2, return)
-};
+    print_int_matrix(mem, k, l, m2, return);
 
-.con print_double_matrix_wrap [mem: %mem.M, k: .Nat, l: .Nat, m: %matrix.Mat (2, (k,l), %math.F64), return : .Cn [%mem.M]] = {
+.con print_double_matrix_wrap [mem: %mem.M, k: .Nat, l: .Nat, m: %matrix.Mat (2, (k,l), %math.F64), return : .Cn [%mem.M]] =
     .let m2 = %core.bitcast (%matrix.Mat (2,(⊤:.Nat,⊤:.Nat),%math.F64)) m;
-    print_double_matrix(mem, k, l, m2, return)
-};
-
+    print_double_matrix(mem, k, l, m2, return);
 
 // .lam .extern internal_mapRed_matrix_const
 //     ![m: .Nat, l: .Nat, [p: .Nat, e:.Nat]] ->
@@ -70,17 +67,16 @@
 // };
 
 
-.con .extern main [mem : %mem.M, argc : .I64, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] = {
-    .con return_cont [mem:%mem.M] = return (mem, 0I32);
-
+.con .extern main [mem : %mem.M, argc : .I64, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] =
     .let c = 42.0:%math.F64;
-    .let (mem2,m1) = %matrix.constMat MT1 (mem,c);
-    // .let (mem3,m2) = %matrix.constMat MT2 (mem2,d);
-
+    .let (`mem, m1) = %matrix.constMat MT1 (mem,c);
+    // .let (mem3,m2) = %matrix.constMat MT2 (mem, d);
     // .let (mem4, mP) = %matrix.prod (2,4,3, %math.f64) (mem3, m1, m2);
-    print_double_matrix_wrap (mem2, 2, 4, m1, return_cont)
     // print_double_matrix_wrap (mem4, 2, 3, mP, return_cont)
-};
+    print_double_matrix_wrap (mem, 2, 4, m1, return_cont)
+    .where
+        .con return_cont [mem:%mem.M] = return (mem, 0I32);
+    .end;
 
 // CHECK: 42.00, 42.00, 42.00, 42.00,
 // CHECK: 42.00, 42.00, 42.00, 42.00,

--- a/lit/matrix/read_transpose.thorin
+++ b/lit/matrix/read_transpose.thorin
@@ -7,20 +7,18 @@
 .let MT = (2, (2,4), .I32);
 .let MT2 = (2, (4,2), .I32);
 
-.con .extern cont [mem : %mem.M, m : (%matrix.Mat MT), return : .Cn [%mem.M, .I32]] = {
-    .let (mem2,m2) = %matrix.transpose ((2,4), .I32) (mem,m);
+.con .extern cont [mem : %mem.M, m : (%matrix.Mat MT), return : .Cn [%mem.M, .I32]] =
+    .let (`mem, m2) = %matrix.transpose ((2,4), .I32) (mem, m);
     .let idx2 = (3_4, 1_2);
-    .let (mem3,d) = %matrix.read MT2 (mem2, m2, idx2);
+    .let (`mem, d) = %matrix.read MT2 (mem, m2, idx2);
 
     // .let idx = (.tt,3:(.Idx 4));
     // .let d = %matrix.read MT (m, idx);
-    return (mem3, d)
-};
-
+    return (mem, d);
 
 .con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] =
     .let c = 5I32;
-    .let (mem2,m) = %matrix.constMat MT (mem,c);
-    cont (mem2, m, return);
+    .let (`mem, m) = %matrix.constMat MT (mem, c);
+    cont (mem, m, return);
 
 // CHECK-NOT: %matrix.

--- a/lit/matrix/test_write.thorin
+++ b/lit/matrix/test_write.thorin
@@ -14,17 +14,15 @@
     .let m2 = %core.bitcast (%matrix.Mat (2,(⊤:.Nat,⊤:.Nat),.I32)) m;
     print_int_matrix(mem, k, l, m2, return);
 
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] = {
+.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] =
     .con return_cont [mem:%mem.M] = return (mem, 0I32);
-
     .let c = argc;
     .let (mem2,m) = %matrix.constMat MT (mem,c);
     .let (mem3,m2) = %matrix.insert MT (mem2,m, (.ff, 2_4), 42I32);
 
     // return_cont mem2
     // print_int_matrix (mem2, 2, 4, m, return_cont)
-    print_int_matrix_wrap (mem3, 2, 4, m2, return_cont)
-};
+    print_int_matrix_wrap (mem3, 2, 4, m2, return_cont);
 
 // CHECK: 3, 3, 42, 3,
 // CHECK: 3, 3, 3, 3,

--- a/lit/mem/add_top_mem.thorin
+++ b/lit/mem/add_top_mem.thorin
@@ -5,9 +5,8 @@
 
 .con .extern f [mem: %mem.M, a: .I32, ret: .Cn [%mem.M, .I32]] = ret (mem, a);
 
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] = {
-    f (⊤:%mem.M, argc,return)
-};
+.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] =
+    f (⊤:%mem.M, argc, return);
 
 .lam .extern _compile []: %compile.Pipeline =
     %compile.pipe

--- a/lit/mem/alloc_load_store.thorin
+++ b/lit/mem/alloc_load_store.thorin
@@ -7,13 +7,12 @@
 
 .plugin core;
 
-.con .extern main(mem: %mem.M, argc: .I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), return: .Cn [%mem.M, .I32]) = {
+.con .extern main(mem: %mem.M, argc: .I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), return: .Cn [%mem.M, .I32]) =
     .let (`mem, ptr) = %mem.alloc (.I32, 0) mem;
     .let `mem        = %mem.store (mem, ptr, argc);
     .let (`mem, val) = %mem.load (mem, ptr);
     .let `mem        = %mem.free (mem, ptr);
-    return (mem, val)
-};
+    return (mem, val);
 
 // CHECK-DAG: .con .extern main _{{[0-9_]+}}::[mem_[[mainMemId:[_0-9]*]]: %mem.M, argc_[[argcId:[0-9_]+]]: .I32, %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, .I32]]{{(@.*)?}}= {
 // CHECK-DAG: _[[appAllocId:[0-9_]+]]: [%mem.M, %mem.Ptr (.I32, 0)] = %mem.malloc (.I32, 0) (mem_[[mainMemId]], 4);

--- a/lit/mem/malloc_load_store.thorin
+++ b/lit/mem/malloc_load_store.thorin
@@ -7,13 +7,12 @@
 
 .plugin core;
 
-.con .extern main(mem: %mem.M, argc: .I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), return: .Cn [%mem.M, .I32]) = {
+.con .extern main(mem: %mem.M, argc: .I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), return: .Cn [%mem.M, .I32]) =
     .let (`mem, ptr) = %mem.malloc (.I32, 0) (mem, 4);
     .let `mem        = %mem.store (mem, ptr, argc);
     .let (`mem, val) = %mem.load (mem, ptr);
     .let `mem        = %mem.free (mem, ptr);
-    return (mem, val)
-};
+    return (mem, val);
 
 // CHECK-DAG: .con .extern main _{{[0-9_]+}}::[mem_[[mainMemId:[_0-9]*]]: %mem.M, argc_[[argcId:[0-9_]+]]: .I32, %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, .I32]]{{(@.*)?}}= {
 // CHECK-DAG: _[[appMallocId:[0-9_]+]]: [%mem.M, %mem.Ptr (.I32, 0)] = %mem.malloc (.I32, 0) (mem_[[mainMemId]], 4);

--- a/lit/mem/mem_rm.thorin
+++ b/lit/mem/mem_rm.thorin
@@ -3,5 +3,5 @@
 // RUN: clang %t.ll -S -emit-llvm -Wno-override-module -o -
 .plugin core;
 
-.fun .extern f ab::(a b: .I32): .I32 =
+.fun .extern f (a b: .I32)::ab : .I32 =
     return (%mem.rm (2, ‹2; .I32›, .I32) (%core.div.sdiv @ .i32) ab);

--- a/lit/mem/mslot_load_store.thorin
+++ b/lit/mem/mslot_load_store.thorin
@@ -11,7 +11,7 @@
     .let Tas             = (.I32, 0);
     .let (`mem, ptr)     = %mem.mslot Tas (mem, 4, 0);
     .let `mem            = %mem.store (mem, ptr, argc);
-    .let ld::(`mem, val) = %mem.load (mem, ptr);
+    .let (`mem, val)::ld = %mem.load (mem, ptr);
     return ld;
 
 // CHECK-DAG: .con .extern main _{{[0-9_]+}}::[mem_[[mainMemId:[_0-9]*]]: %mem.M, argc_[[argcId:[0-9_]+]]: .I32, %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, .I32]]{{(@.*)?}}= {

--- a/lit/mem/no_mem_lazy.thorin
+++ b/lit/mem/no_mem_lazy.thorin
@@ -3,12 +3,11 @@
 
 .plugin core;
 
-.con f [a:.I32, ret: .Cn .I32] =
+.fun f(a: .I32): .I32 =
     .let b = %core.wrap.mul 0 (a, a);
-    ret b;
+    return b;
 
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] =
-    .con ret_cont r: .I32 =
-        .con ret_cont2 r2: .I32 = return (mem, r2);
-        f (r, ret_cont2);
-    f (42I32,ret_cont);
+.con .extern main[mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] =
+    .ret r1 = f $ 42I32;
+    .ret r2 = f $ r1;
+    return (mem, r2);

--- a/lit/mem/slot_load_store.thorin
+++ b/lit/mem/slot_load_store.thorin
@@ -11,7 +11,7 @@
     .let Tas             = (.I32, 0);
     .let (`mem, ptr)     = %mem.slot Tas (mem, 0);
     .let `mem            = %mem.store (mem, ptr, argc);
-    .let ld::(`mem, val) = %mem.load (mem, ptr);
+    .let (`mem, val)::ld = %mem.load (mem, ptr);
     return ld;
 
 // CHECK-DAG: .con .extern main _{{[0-9_]+}}::[mem_[[mainMemId:[_0-9]*]]: %mem.M, argc_[[argcId:[0-9_]+]]: .I32, %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, .I32]]{{(@.*)?}}= {

--- a/lit/mem/slot_load_store.thorin
+++ b/lit/mem/slot_load_store.thorin
@@ -7,13 +7,12 @@
 
 .plugin core;
 
-.con .extern main(mem: %mem.M, argc: .I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), return: .Cn [%mem.M, .I32]) = {
+.con .extern main(mem: %mem.M, argc: .I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), return: .Cn [%mem.M, .I32]) =
     .let Tas             = (.I32, 0);
     .let (`mem, ptr)     = %mem.slot Tas (mem, 0);
     .let `mem            = %mem.store (mem, ptr, argc);
     .let ld::(`mem, val) = %mem.load (mem, ptr);
-    return ld
-};
+    return ld;
 
 // CHECK-DAG: .con .extern main _{{[0-9_]+}}::[mem_[[mainMemId:[_0-9]*]]: %mem.M, argc_[[argcId:[0-9_]+]]: .I32, %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, .I32]]{{(@.*)?}}= {
 // CHECK-DAG: return_[[returnEtaId:[0-9_]+]] (mem_[[mainMemId]], argc_[[argcId]])

--- a/lit/mem/two_fun_mem.thorin
+++ b/lit/mem/two_fun_mem.thorin
@@ -9,35 +9,28 @@
 
 .let Tas = (.I32, 0);
 
-.con f [mem: %mem.M, p: %mem.Ptr (.I32, 0), ret: .Cn [%mem.M, .I32]] = {
-    .let (mem2, v) = %mem.load (mem, p);
+.con f(mem: %mem.M, p: %mem.Ptr0 .I32, ret: .Cn [%mem.M, .I32]) =
+    .let (`mem, v) = %mem.load (mem, p);
+    g1 (mem, cont1)
+    .where
+        .con g1 [mem: %mem.M, ret: .Cn [%mem.M, .I32]] =
+            .let b = %core.wrap.add 0 (v, 1I32);
+            ret (mem, b);
+        .con cont1 [mem: %mem.M, a: .I32] =
+            g2 (mem, cont2)
+            .where
+                .con g2(mem: %mem.M, ret: .Cn [%mem.M, .I32]) =
+                    .let c = %core.wrap.add 0 (v, 2I32);
+                    ret (mem, c);
+                .con cont2 [mem: %mem.M, b: .I32] =
+                    .let c = %core.wrap.add 0 (a, b);
+                    ret (mem, c);
+            .end;
+    .end;
 
-    .con g1 [mem: %mem.M, ret: .Cn [%mem.M, .I32]] = {
-        .let b = %core.wrap.add 0 (v, 1I32);
-        ret (mem2, b)
-    };
-
-    .con g2 [mem: %mem.M, ret: .Cn [%mem.M, .I32]] = {
-        .let c = %core.wrap.add 0 (v, 2I32);
-        ret (mem2, c)
-    };
-
-    .con cont1 [mem:%mem.M, a:.I32] = {
-        .con cont2 [mem:%mem.M, b:.I32] = {
-            .let c = %core.wrap.add 0 (a, b);
-            ret (mem, c)
-        };
-        g2 (mem2, cont2)
-    };
-    g1 (mem2, cont1)
-};
-
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] = {
-
-    .let (mem2,p) = %mem.alloc Tas mem;
-    .let mem3 = %mem.store (mem2, p, argc);
-
-    f (mem3, p, return)
-};
+.con .extern main [mem: %mem.M, argc: .I32, argv: %mem.Ptr0 (%mem.Ptr0 .I8), return: .Cn [%mem.M, .I32]] =
+    .let (`mem, p) = %mem.alloc Tas mem;
+    .let `mem      = %mem.store (mem, p, argc);
+    f (mem, p, return);
 
 // TODO: check for 1+x, 2+x, a+b

--- a/lit/mem/two_fun_no_mem.thorin
+++ b/lit/mem/two_fun_no_mem.thorin
@@ -9,31 +9,28 @@
 
 .let Tas = (.I32, 0);
 
-.con f [mem: %mem.M, p: %mem.Ptr (.I32, 0), ret: .Cn [%mem.M, .I32]] = {
-    .let (mem2, v) = %mem.load (mem, p);
-
-    .con g1 [ret: .Cn .I32] = {
-        .let b = %core.wrap.add 0 (v, 1I32);
-        ret b
-    };
-
-    .con g2 [ret: .Cn .I32] = {
-        .let c = %core.wrap.add 0 (v, 2I32);
-        ret c
-    };
-
-    .con cont1 [a:.I32] = {
-        .con cont2 [b:.I32] = {
-            .let c = %core.wrap.add 0 (a, b);
-            ret (mem2, c)
-        };
-        g2 cont2
-    };
+.con f [mem: %mem.M, p: %mem.Ptr (.I32, 0), ret: .Cn [%mem.M, .I32]] =
+    .let (`mem, v) = %mem.load (mem, p);
     g1 cont1
-};
+    .where
+        .con g1 [ret: .Cn .I32] =
+            .let b = %core.wrap.add 0 (v, 1I32);
+            ret b;
 
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] =
-    .let (mem2,p) = %mem.alloc Tas mem;
-    .let mem3 = %mem.store (mem2, p, argc);
-    f (mem3, p, return);
+        .con cont1 [a:.I32] =
+            g2 cont2
+            .where
+                .con g2 [ret: .Cn .I32] =
+                    .let c = %core.wrap.add 0 (v, 2I32);
+                    ret c;
+                .con cont2 [b:.I32] =
+                    .let c = %core.wrap.add 0 (a, b);
+                    ret (mem, c);
+            .end;
+    .end;
+
+.con .extern main [mem: %mem.M, argc: .I32, argv: %mem.Ptr (%mem.Ptr (.I8, 0), 0), return: .Cn [%mem.M, .I32]] =
+    .let (`mem, p) = %mem.alloc Tas mem;
+    .let `mem      = %mem.store (mem, p, argc);
+    f (mem, p, return);
 // TODO: check for 1+x, 2+x, a+b

--- a/lit/refly/debug_perm.thorin
+++ b/lit/refly/debug_perm.thorin
@@ -4,10 +4,9 @@
 .plugin core;
 .plugin refly;
 
-.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] = {
+.con .extern main [mem : %mem.M, argc : .I32, argv : %mem.Ptr (%mem.Ptr (.I8, 0), 0), return : .Cn [%mem.M, .I32]] =
     .let c = %refly.dbg.perm (%refly.info, 42I32);
-    return (mem, c)
-};
+    return (mem, c);
 
 // CHECK-DAG: .con .extern main _{{[0-9_]+}}::[mem_[[memId:[_0-9]*]]: %mem.M, .I32, %mem.Ptr (%mem.Ptr (.I8, 0), 0), return_[[returnId:[_0-9]*]]: .Cn [%mem.M, .I32]]{{(@.*)?}}= {
 // CHECK-DAG: return_[[returnEtaId:[_0-9]*]] (mem_[[memId]], 42I32)

--- a/lit/refly/refine.thorin
+++ b/lit/refly/refine.thorin
@@ -6,12 +6,11 @@
 .plugin core;
 .plugin refly;
 
-.fun .extern main(mem: %mem.M, argc: .I32, argv: %mem.Ptr (%mem.Ptr (.I8, 0), 0)): [%mem.M, .I32] = {
+.fun .extern main(mem: %mem.M, argc: .I32, argv: %mem.Ptr (%mem.Ptr (.I8, 0), 0)): [%mem.M, .I32] =
     .let exp = %refly.reify (0, 1, 2, 3);
     .let new = %refly.refine («4; .Nat», .Nat)(exp, 1, %refly.reify 42);
     .let tup = %refly.reflect new;
     .let x   = %core.bitcast .I64 tup#1_4;
-    return (mem, %core.conv.u .i32 x)
-};
+    return (mem, %core.conv.u .i32 x);
 
 // CHECK-DAG: return{{.*}}42

--- a/lit/regex/match_1or5or9.thorin
+++ b/lit/regex/match_1or5or9.thorin
@@ -11,20 +11,14 @@
 .let Top = ⊤:.Nat;
 .let re = %regex.disj 3 (%regex.lit '0', %regex.lit '5', %regex.lit '9');
 
-.con .extern main[mem: %mem.M, argc: .I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), exit : .Cn [%mem.M, .I32]] = {
-    .con handle_match [mem: %mem.M, matched: .Bool, match: %mem.Ptr(«Top; .I8», 0)] = {
-
-        exit (mem, %core.conv.u .i32 matched)
-    };
-
-    .con match_argument[mem: %mem.M, .I32] = {
-        .let arg1 = %mem.lea (Top, ‹Top; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 1I32);;
-        .let (`mem, to_match) = %mem.load (mem, arg1);
-        .let (`mem, matched, pos) = re (mem, to_match, 0:(.Idx Top));
-        exit (mem, %core.conv.u .i32 matched)
-    };
-
+.con .extern main[mem: %mem.M, argc: .I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), exit : .Cn [%mem.M, .I32]] =
     (exit, match_argument) # (%core.icmp.ug (argc, 1I32)) (mem, 0I32)
-};
+    .where
+        .con match_argument[mem: %mem.M, .I32] =
+            .let arg1 = %mem.lea (Top, ‹Top; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 1I32);;
+            .let (`mem, to_match) = %mem.load (mem, arg1);
+            .let (`mem, matched, pos) = re (mem, to_match, 0:(.Idx Top));
+            exit (mem, %core.conv.u .i32 matched);
+    .end;
 
 // CHECK-NOT: %regex.

--- a/lit/regex/match_lit.thorin
+++ b/lit/regex/match_lit.thorin
@@ -10,23 +10,16 @@
 .plugin direct;
 
 .let Top = ⊤:.Nat;
+.let re  = %regex.lit '1';
 
-.let re = %regex.lit '1';
-
-.con .extern main[mem: %mem.M, argc: .I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), exit : .Cn [%mem.M, .I32]] = {
-    .con handle_match [mem: %mem.M, matched: .Bool, match: %mem.Ptr(«Top; .I8», 0)] = {
-
-        exit (mem, %core.conv.u .i32 matched)
-    };
-
-    .con match_argument[mem: %mem.M, .I32] = {
-        .let arg1 = %mem.lea (Top, ‹Top; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 1I32);
-        .let (`mem, to_match) = %mem.load (mem, arg1);
-        .let (`mem, matched, pos) = re (mem, to_match, 0:(.Idx Top));
-        exit (mem, %core.conv.u .i32 matched)
-    };
-
+.con .extern main[mem: %mem.M, argc: .I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), exit : .Cn [%mem.M, .I32]] =
     (exit, match_argument) # (%core.icmp.ug (argc, 1I32)) (mem, 0I32)
-};
+    .where
+        .con match_argument[mem: %mem.M, .I32] =
+            .let arg1 = %mem.lea (Top, ‹Top; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 1I32);
+            .let (`mem, to_match) = %mem.load (mem, arg1);
+            .let (`mem, matched, pos) = re (mem, to_match, 0:(.Idx Top));
+            exit (mem, %core.conv.u .i32 matched);
+    .end
 
 // CHECK-NOT: %regex.

--- a/lit/regex/match_mail.thorin
+++ b/lit/regex/match_mail.thorin
@@ -67,18 +67,18 @@
 
 .ccon strlen[%mem.M, %mem.Ptr («⊤:.Nat; .I8», 0), .Cn [%mem.M, .I32]];
 
-.con .extern main[mem: %mem.M, argc: .I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), exit : .Cn [%mem.M, .I32]] = {
-    .con match_argument[mem: %mem.M, .I32] = {
-        .let arg1 = %mem.lea (Top, ‹Top; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 1I32);;
-        .let (`mem, to_match) = %mem.load (mem, arg1);
-        .let (`mem, matched, pos) = re (mem, to_match, 0:(.Idx Top));
-        .con exit_me(mem: %mem.M, len: .I32) = {
-            exit (mem, (%core.idx .i32 0 255, %core.wrap.sub .i32 (len, %core.conv.u .i32 pos))#matched)
-        };
-        strlen(mem, to_match, exit_me)
-    };
-
+.con .extern main[mem: %mem.M, argc: .I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), exit : .Cn [%mem.M, .I32]] =
     (exit, match_argument) # (%core.icmp.ug (argc, 1I32)) (mem, 0I32)
-};
+    .where
+        .con match_argument[mem: %mem.M, .I32] =
+            .let arg1 = %mem.lea (Top, ‹Top; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 1I32);;
+            .let (`mem, to_match) = %mem.load (mem, arg1);
+            .let (`mem, matched, pos) = re (mem, to_match, 0:(.Idx Top));
+            strlen(mem, to_match, exit_me)
+            .where
+            .con exit_me(mem: %mem.M, len: .I32) =
+                exit (mem, (%core.idx .i32 0 255, %core.wrap.sub .i32 (len, %core.conv.u .i32 pos))#matched)
+            .end
+    .end;
 
 // CHECK-NOT: %regex.

--- a/lit/regex/match_not_wds.thorin
+++ b/lit/regex/match_not_wds.thorin
@@ -12,20 +12,14 @@
 .let Top = ⊤:.Nat;
 .let re  = %regex.not_ (%regex.conj 2 (%regex.cls.w, %regex.conj 2 (%regex.cls.d, %regex.cls.s)));
 
-.con .extern main[mem: %mem.M, argc: .I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), exit : .Cn [%mem.M, .I32]] = {
-    .con handle_match [mem: %mem.M, matched: .Bool, match: %mem.Ptr(«Top; .I8», 0)] = {
-
-        exit (mem, %core.conv.u .i32 matched)
-    };
-
-    .con match_argument[mem: %mem.M, .I32] = {
-        .let arg1 = %mem.lea (Top, ‹Top; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 1I32);;
-        .let (`mem, to_match) = %mem.load (mem, arg1);
-        .let (`mem, matched, pos) = re (mem, to_match, 0:(.Idx Top));
-        exit (mem, %core.conv.u .i32 matched)
-    };
-
+.con .extern main[mem: %mem.M, argc: .I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), exit : .Cn [%mem.M, .I32]] =
     (exit, match_argument) # (%core.icmp.ug (argc, 1I32)) (mem, 0I32)
-};
+    .where
+        .con match_argument[mem: %mem.M, .I32] =
+            .let arg1                 = %mem.lea (Top, ‹Top; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 1I32);;
+            .let (`mem, to_match)     = %mem.load (mem, arg1);
+            .let (`mem, matched, pos) = re (mem, to_match, 0:(.Idx Top));
+            exit (mem, %core.conv.u .i32 matched);
+    .end;
 
 // CHECK-NOT: %regex.

--- a/lit/regex/match_sample.thorin
+++ b/lit/regex/match_sample.thorin
@@ -13,20 +13,14 @@
 .let Top = ⊤:.Nat;
 .let re  = %regex.conj 2 (%regex.quant.plus  %regex.cls.w, %regex.lit '@');
 
-.con .extern main[mem: %mem.M, argc: .I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), exit : .Cn [%mem.M, .I32]] = {
-    .con handle_match [mem: %mem.M, matched: .Bool, match: %mem.Ptr(«Top; .I8», 0)] = {
-
-        exit (mem, %core.conv.u .i32 matched)
-    };
-
-    .con match_argument[mem: %mem.M, .I32] = {
-        .let arg1 = %mem.lea (Top, ‹Top; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 1I32);;
-        .let (`mem, to_match) = %mem.load (mem, arg1);
-        .let (`mem, matched, pos) = re (mem, to_match, 0:(.Idx Top));
-        exit (mem, %core.conv.u .i32 matched)
-    };
-
+.con .extern main[mem: %mem.M, argc: .I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), exit : .Cn [%mem.M, .I32]] =
     (exit, match_argument) # (%core.icmp.ug (argc, 1I32)) (mem, 0I32)
-};
+    .where
+        .con match_argument[mem: %mem.M, .I32] =
+            .let arg1 = %mem.lea (Top, ‹Top; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 1I32);;
+            .let (`mem, to_match) = %mem.load (mem, arg1);
+            .let (`mem, matched, pos) = re (mem, to_match, 0:(.Idx Top));
+            exit (mem, %core.conv.u .i32 matched);
+    .end
 
 // CHECK-NOT: %regex.

--- a/lit/regex/match_test10.thorin
+++ b/lit/regex/match_test10.thorin
@@ -12,18 +12,16 @@
 .let pattern = %regex.conj 2 (%regex.quant.plus  %regex.cls.w, %regex.lit '@');
 .let len     = 10;
 
-.con .extern main[mem: %mem.M, argc: .I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), exit : .Cn [%mem.M, .I32]] = {
-    .fun match(len: .Nat)(mem: %mem.M, str: %mem.Ptr0 <<len; Char>>): [%mem.M, .Bool] =
-        .let (`mem, matched, pos) = pattern (mem, str, 0:(.Idx len));
-        .let end = %core.idx len 0 (%core.nat.sub (len, 1));
-        return (mem, %core.bit2.and_ 0 (%core.icmp.e (pos, end), matched));
-
+.con .extern main[mem: %mem.M, argc: .I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), exit : .Cn [%mem.M, .I32]] =
     .let (`mem, string) = %mem.alloc (<<len; Char>>, 0) mem;
-    .let `mem = %mem.store (mem, string, "testasdf@\0");
-
-    .con exiting[mem: %mem.M, ret :.Bool] = exit (mem, %core.conv.u .i32 ret);
-
+    .let `mem           = %mem.store (mem, string, "testasdf@\0");
     match len ((mem, string), exiting)
-};
+    .where
+        .fun match(len: .Nat)(mem: %mem.M, str: %mem.Ptr0 <<len; Char>>): [%mem.M, .Bool] =
+            .let (`mem, matched, pos) = pattern (mem, str, 0:(.Idx len));
+            .let end = %core.idx len 0 (%core.nat.sub (len, 1));
+            return (mem, %core.bit2.and_ 0 (%core.icmp.e (pos, end), matched));
+        .con exiting[mem: %mem.M, ret :.Bool] = exit (mem, %core.conv.u .i32 ret)
+    .end
 
 // CHECK-NOT: %regex.

--- a/lit/regex/match_w.thorin
+++ b/lit/regex/match_w.thorin
@@ -14,20 +14,14 @@
 .let Top = ⊤:.Nat;
 .let re  = %regex.cls.w;
 
-.con .extern main[mem: %mem.M, argc: .I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), exit : .Cn [%mem.M, .I32]] = {
-    .con handle_match [mem: %mem.M, matched: .Bool, match: %mem.Ptr(«Top; .I8», 0)] = {
-
-        exit (mem, %core.conv.u .i32 matched)
-    };
-
-    .con match_argument[mem: %mem.M, .I32] = {
-        .let arg1 = %mem.lea (Top, ‹Top; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 1I32);;
-        .let (`mem, to_match) = %mem.load (mem, arg1);
-        .let (`mem, matched, pos) = re (mem, to_match, 0:(.Idx Top));
-        exit (mem, %core.conv.u .i32 matched)
-    };
-
+.con .extern main[mem: %mem.M, argc: .I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), exit : .Cn [%mem.M, .I32]] =
     (exit, match_argument) # (%core.icmp.ug (argc, 1I32)) (mem, 0I32)
-};
+    .where
+        .con match_argument[mem: %mem.M, .I32] =
+            .let arg1 = %mem.lea (Top, ‹Top; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 1I32);;
+            .let (`mem, to_match) = %mem.load (mem, arg1);
+            .let (`mem, matched, pos) = re (mem, to_match, 0:(.Idx Top));
+            exit (mem, %core.conv.u .i32 matched)
+    .end;
 
 // CHECK-NOT: %regex.

--- a/lit/regex/match_wds.thorin
+++ b/lit/regex/match_wds.thorin
@@ -14,13 +14,10 @@
 .con .extern main[mem: %mem.M, argc: .I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), exit : .Cn [%mem.M, .I32]] =
     (exit, match_argument) # (%core.icmp.ug (argc, 1I32)) (mem, 0I32)
     .where
-        .con handle_match [mem: %mem.M, matched: .Bool, match: %mem.Ptr(«Top; .I8», 0)] =
-            exit (mem, %core.conv.u .i32 matched);
-
         .con match_argument[mem: %mem.M, .I32] =
             .let arg1 = %mem.lea (Top, ‹Top; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 1I32);
             .let (`mem, to_match) = %mem.load (mem, arg1);
             .let (`mem, matched, pos) = re (mem, to_match, 0:(.Idx Top));
             exit (mem, %core.conv.u .i32 matched);
-    .end
+    .end;
 // CHECK-NOT: %regex.

--- a/lit/regex/match_wds_cap.thorin
+++ b/lit/regex/match_wds_cap.thorin
@@ -12,20 +12,14 @@
 .let Top = ⊤:.Nat;
 .let re  = %regex.conj 2 (%regex.cls.W, %regex.conj 2 (%regex.cls.D, %regex.cls.S));
 
-.con .extern main[mem: %mem.M, argc: .I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), exit : .Cn [%mem.M, .I32]] = {
-    .con handle_match [mem: %mem.M, matched: .Bool, match: %mem.Ptr(«Top; .I8», 0)] = {
-
-        exit (mem, %core.conv.u .i32 matched)
-    };
-
-    .con match_argument[mem: %mem.M, .I32] = {
-        .let arg1 = %mem.lea (Top, ‹Top; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 1I32);;
-        .let (`mem, to_match) = %mem.load (mem, arg1);
-        .let (`mem, matched, pos) = re (mem, to_match, 0:(.Idx Top));
-        exit (mem, %core.conv.u .i32 matched)
-    };
-
+.con .extern main[mem: %mem.M, argc: .I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), exit : .Cn [%mem.M, .I32]] =
     (exit, match_argument) # (%core.icmp.ug (argc, 1I32)) (mem, 0I32)
-};
+    .where
+        .con match_argument[mem: %mem.M, .I32] =
+            .let arg1 = %mem.lea (Top, ‹Top; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 1I32);;
+            .let (`mem, to_match) = %mem.load (mem, arg1);
+            .let (`mem, matched, pos) = re (mem, to_match, 0:(.Idx Top));
+            exit (mem, %core.conv.u .i32 matched);
+    .end;
 
 // CHECK-NOT: %regex.

--- a/lit/regex/match_woptional.thorin
+++ b/lit/regex/match_woptional.thorin
@@ -13,20 +13,14 @@
 
 .let re = %regex.quant.optional %regex.cls.w;
 
-.con .extern main[mem: %mem.M, argc: .I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), exit : .Cn [%mem.M, .I32]] = {
-    .con handle_match [mem: %mem.M, matched: .Bool, match: %mem.Ptr(«Top; .I8», 0)] = {
-
-        exit (mem, %core.conv.u .i32 matched)
-    };
-
-    .con match_argument[mem: %mem.M, .I32] = {
-        .let arg1 = %mem.lea (Top, ‹Top; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 1I32);;
-        .let (`mem, to_match) = %mem.load (mem, arg1);
-        .let (`mem, matched, pos) = re (mem, to_match, 0:(.Idx Top));
-        exit (mem, %core.conv.u .i32 matched)
-    };
-
+.con .extern main[mem: %mem.M, argc: .I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), exit : .Cn [%mem.M, .I32]] =
     (exit, match_argument) # (%core.icmp.ug (argc, 1I32)) (mem, 0I32)
-};
+    .where
+        .con match_argument[mem: %mem.M, .I32] =
+            .let arg1 = %mem.lea (Top, ‹Top; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 1I32);;
+            .let (`mem, to_match) = %mem.load (mem, arg1);
+            .let (`mem, matched, pos) = re (mem, to_match, 0:(.Idx Top));
+            exit (mem, %core.conv.u .i32 matched);
+    .end;
 
 // CHECK-NOT: %regex.

--- a/lit/regex/match_woptionals.thorin
+++ b/lit/regex/match_woptionals.thorin
@@ -13,20 +13,14 @@
 .let Top = ⊤:.Nat;
 .let re = %regex.conj 2 (%regex.quant.optional %regex.cls.w, %regex.cls.s);
 
-.con .extern main[mem: %mem.M, argc: .I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), exit : .Cn [%mem.M, .I32]] = {
-    .con handle_match [mem: %mem.M, matched: .Bool, match: %mem.Ptr(«Top; .I8», 0)] = {
-
-        exit (mem, %core.conv.u .i32 matched)
-    };
-
-    .con match_argument[mem: %mem.M, .I32] = {
-        .let arg1 = %mem.lea (Top, ‹Top; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 1I32);;
-        .let (`mem, to_match) = %mem.load (mem, arg1);
-        .let (`mem, matched, pos) = re (mem, to_match, 0:(.Idx Top));
-        exit (mem, %core.conv.u .i32 matched)
-    };
-
+.con .extern main[mem: %mem.M, argc: .I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), exit : .Cn [%mem.M, .I32]] =
     (exit, match_argument) # (%core.icmp.ug (argc, 1I32)) (mem, 0I32)
-};
+    .where
+        .con match_argument[mem: %mem.M, .I32] =
+            .let arg1 = %mem.lea (Top, ‹Top; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 1I32);;
+            .let (`mem, to_match) = %mem.load (mem, arg1);
+            .let (`mem, matched, pos) = re (mem, to_match, 0:(.Idx Top));
+            exit (mem, %core.conv.u .i32 matched)
+    .end;
 
 // CHECK-NOT: %regex.

--- a/lit/regex/match_wors.thorin
+++ b/lit/regex/match_wors.thorin
@@ -11,20 +11,14 @@
 .let Top = ⊤:.Nat;
 .let re = %regex.disj 3 (%regex.cls.w, %regex.cls.d, %regex.cls.s);
 
-.con .extern main[mem: %mem.M, argc: .I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), exit : .Cn [%mem.M, .I32]] = {
-    .con handle_match [mem: %mem.M, matched: .Bool, match: %mem.Ptr(«Top; .I8», 0)] = {
-
-        exit (mem, %core.conv.u .i32 matched)
-    };
-
-    .con match_argument[mem: %mem.M, .I32] = {
-        .let arg1 = %mem.lea (Top, ‹Top; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 1I32);;
-        .let (`mem, to_match) = %mem.load (mem, arg1);
-        .let (`mem, matched, pos) = re (mem, to_match, 0:(.Idx Top));
-        exit (mem, %core.conv.u .i32 matched)
-    };
-
+.con .extern main[mem: %mem.M, argc: .I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), exit : .Cn [%mem.M, .I32]] =
     (exit, match_argument) # (%core.icmp.ug (argc, 1I32)) (mem, 0I32)
-};
+    .where
+        .con match_argument[mem: %mem.M, .I32] =
+            .let arg1 = %mem.lea (Top, ‹Top; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 1I32);
+            .let (`mem, to_match) = %mem.load (mem, arg1);
+            .let (`mem, matched, pos) = re (mem, to_match, 0:(.Idx Top));
+            exit (mem, %core.conv.u .i32 matched);
+    .end;
 
 // CHECK-NOT: %regex.

--- a/lit/regex/match_wplus.thorin
+++ b/lit/regex/match_wplus.thorin
@@ -12,20 +12,15 @@
 .let Top = ⊤:.Nat;
 .let re  = %regex.quant.plus %regex.cls.w;
 
-.con .extern main[mem: %mem.M, argc: .I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), exit : .Cn [%mem.M, .I32]] = {
-    .con handle_match [mem: %mem.M, matched: .Bool, match: %mem.Ptr(«Top; .I8», 0)] = {
-
-        exit (mem, %core.conv.u .i32 matched)
-    };
-
-    .con match_argument[mem: %mem.M, .I32] = {
-        .let arg1 = %mem.lea (Top, ‹Top; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 1I32);;
-        .let (`mem, to_match) = %mem.load (mem, arg1);
-        .let (`mem, matched, pos) = re (mem, to_match, 0:(.Idx Top));
-        exit (mem, %core.conv.u .i32 matched)
-    };
-
+.con .extern main[mem: %mem.M, argc: .I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), exit : .Cn [%mem.M, .I32]] =
     (exit, match_argument) # (%core.icmp.ug (argc, 1I32)) (mem, 0I32)
-};
+    .where
+        .con match_argument[mem: %mem.M, .I32] =
+            .let arg1 = %mem.lea (Top, ‹Top; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 1I32);
+            .let (`mem, to_match) = %mem.load (mem, arg1);
+            .let (`mem, matched, pos) = re (mem, to_match, 0:(.Idx Top));
+            exit (mem, %core.conv.u .i32 matched);
+    .end;
+
 
 // CHECK-NOT: %regex.

--- a/lit/regex/match_wplusa.thorin
+++ b/lit/regex/match_wplusa.thorin
@@ -13,20 +13,15 @@
 .let Top = ⊤:.Nat;
 .let re  = %regex.conj 2 (%regex.quant.plus  %regex.cls.w, %regex.lit 'a');
 
-.con .extern main[mem: %mem.M, argc: .I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), exit : .Cn [%mem.M, .I32]] = {
-    .con handle_match [mem: %mem.M, matched: .Bool, match: %mem.Ptr(«Top; .I8», 0)] = {
-
-        exit (mem, %core.conv.u .i32 matched)
-    };
-
-    .con match_argument[mem: %mem.M, .I32] = {
-        .let arg1 = %mem.lea (Top, ‹Top; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 1I32);;
-        .let (`mem, to_match) = %mem.load (mem, arg1);
-        .let (`mem, matched, pos) = re (mem, to_match, 0:(.Idx Top));
-        exit (mem, %core.conv.u .i32 matched)
-    };
-
+.con .extern main[mem: %mem.M, argc: .I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), exit : .Cn [%mem.M, .I32]] =
     (exit, match_argument) # (%core.icmp.ug (argc, 1I32)) (mem, 0I32)
-};
+    .where
+        .con match_argument[mem: %mem.M, .I32] =
+            .let arg1 = %mem.lea (Top, ‹Top; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 1I32);
+            .let (`mem, to_match) = %mem.load (mem, arg1);
+            .let (`mem, matched, pos) = re (mem, to_match, 0:(.Idx Top));
+            exit (mem, %core.conv.u .i32 matched);
+    .end;
+
 
 // CHECK-NOT: %regex.

--- a/lit/regex/match_wstar.thorin
+++ b/lit/regex/match_wstar.thorin
@@ -11,20 +11,14 @@
 .let Top = ⊤:.Nat;
 .let re  = %regex.quant.star %regex.cls.w;
 
-.con .extern main[mem: %mem.M, argc: .I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), exit : .Cn [%mem.M, .I32]] = {
-    .con handle_match [mem: %mem.M, matched: .Bool, match: %mem.Ptr(«Top; .I8», 0)] = {
-
-        exit (mem, %core.conv.u .i32 matched)
-    };
-
-    .con match_argument[mem: %mem.M, .I32] = {
-        .let arg1 = %mem.lea (Top, ‹Top; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 1I32);;
-        .let (`mem, to_match) = %mem.load (mem, arg1);
-        .let (`mem, matched, pos) = re (mem, to_match, 0:(.Idx Top));
-        exit (mem, %core.conv.u .i32 matched)
-    };
-
+.con .extern main[mem: %mem.M, argc: .I32, argv: %mem.Ptr («⊤:.Nat; %mem.Ptr («⊤:.Nat; .I8», 0)», 0), exit : .Cn [%mem.M, .I32]] =
     (exit, match_argument) # (%core.icmp.ug (argc, 1I32)) (mem, 0I32)
-};
+    .where
+        .con match_argument[mem: %mem.M, .I32] =
+            .let arg1 = %mem.lea (Top, ‹Top; %mem.Ptr («⊤:.Nat; .I8», 0)›, 0) (argv, 1I32);;
+            .let (`mem, to_match) = %mem.load (mem, arg1);
+            .let (`mem, matched, pos) = re (mem, to_match, 0:(.Idx Top));
+            exit (mem, %core.conv.u .i32 matched);
+    .end
 
 // CHECK-NOT: %regex.

--- a/src/thorin/ast/bind.cpp
+++ b/src/thorin/ast/bind.cpp
@@ -91,6 +91,8 @@ void Import::bind(Scopes& s) const { module()->bind(s); }
  * Ptrn
  */
 
+void ErrorPtrn::bind(Scopes&, bool) const {}
+
 void IdPtrn::bind(Scopes& s, bool quiet) const {
     if (!quiet && type()) type()->bind(s);
     s.bind(dbg(), this, rebind(), quiet);
@@ -131,12 +133,6 @@ void DeclExpr::bind(Scopes& s) const {
     else
         for (const auto& decl : decls()) decl->bind(s);
     expr()->bind(s);
-}
-
-void BlockExpr::bind(Scopes& s) const {
-    s.push();
-    expr()->bind(s);
-    s.pop();
 }
 
 void ArrowExpr::bind(Scopes& s) const {
@@ -283,7 +279,6 @@ void RecDecl::bind_body(Scopes& s) const { body()->bind(s); }
 
 void LamDecl::Dom::bind(Scopes& s, bool quiet) const {
     PiExpr::Dom::bind(s, quiet);
-
     if (filter() && !quiet) filter()->bind(s);
 }
 

--- a/src/thorin/ast/emit.cpp
+++ b/src/thorin/ast/emit.cpp
@@ -65,6 +65,8 @@ void TuplePtrn::emit_value_(Emitter& e, Ref def) const {
  * Ptrn::emit_Type
  */
 
+Ref ErrorPtrn::emit_type(Emitter&) const { fe::unreachable(); }
+
 Ref IdPtrn::emit_type(Emitter& e) const {
     auto _ = e.world().push(loc());
     return type() ? type()->emit(e) : e.world().mut_infer_type();
@@ -175,8 +177,6 @@ Ref DeclExpr::emit_(Emitter& e) const {
         for (const auto& decl : decls()) decl->emit(e);
     return expr()->emit(e);
 }
-
-Ref BlockExpr::emit_(Emitter& e) const { return expr()->emit(e); }
 
 Ref ArrowExpr::emit_(Emitter& e) const {
     auto d = dom()->emit(e);

--- a/src/thorin/ast/stream.cpp
+++ b/src/thorin/ast/stream.cpp
@@ -50,6 +50,8 @@ std::ostream& Module::stream(Tab& tab, std::ostream& os) const {
  * Ptrn
  */
 
+std::ostream& ErrorPtrn::stream(Tab&, std::ostream& os) const { return os << "<error pattern>"; }
+
 std::ostream& IdPtrn::stream(Tab& tab, std::ostream& os) const {
     // clang-format off
     if ( dbg() &&  type()) return print(os, "{}: {}", dbg(), S(tab, type()));
@@ -71,7 +73,7 @@ std::ostream& TuplePtrn::stream(Tab& tab, std::ostream& os) const {
  */
 
 std::ostream& IdExpr::stream(Tab&, std::ostream& os) const { return print(os, "{}", dbg()); }
-std::ostream& ErrorExpr::stream(Tab&, std::ostream& os) const { return os << "<error>"; }
+std::ostream& ErrorExpr::stream(Tab&, std::ostream& os) const { return os << "<error expression>"; }
 std::ostream& InferExpr::stream(Tab&, std::ostream& os) const { return os << "<infer>"; }
 std::ostream& PrimaryExpr::stream(Tab&, std::ostream& os) const { return print(os, "{}", tag()); }
 
@@ -101,8 +103,6 @@ std::ostream& DeclExpr::stream(Tab& tab, std::ostream& os) const {
         return print(os, "{}", S(tab, expr()));
     }
 }
-
-std::ostream& BlockExpr::stream(Tab& tab, std::ostream& os) const { return print(os, "{{ {} }}", S(tab, expr())); }
 
 std::ostream& TypeExpr::stream(Tab& tab, std::ostream& os) const { return print(os, "(.Type {})", S(tab, level())); }
 

--- a/src/thorin/ast/stream.cpp
+++ b/src/thorin/ast/stream.cpp
@@ -64,8 +64,9 @@ std::ostream& IdPtrn::stream(Tab& tab, std::ostream& os) const {
 std::ostream& GrpPtrn::stream(Tab&, std::ostream& os) const { return os << dbg(); }
 
 std::ostream& TuplePtrn::stream(Tab& tab, std::ostream& os) const {
-    if (dbg()) print(os, "{}::", dbg());
-    return print(os, "{}{, }{}", delim_l(), R(tab, ptrns()), delim_r());
+    print(os, "{}{, }{}", delim_l(), R(tab, ptrns()), delim_r());
+    if (dbg()) print(os, "::{}", dbg());
+    return os;
 }
 
 /*

--- a/src/thorin/plug/autodiff/autodiff.thorin
+++ b/src/thorin/plug/autodiff/autodiff.thorin
@@ -123,5 +123,5 @@
 ///
 /// s ↦ (s*b, s*a)
 ///
-.fun .extern internal_diff_core_wrap_mul.(s: .Nat)(m: .Nat)ab::(a b: .Idx s)@.tt: [.Idx s, .Cn[.Idx s, .Cn«2; .Idx s»]] =
+.fun .extern internal_diff_core_wrap_mul.(s: .Nat)(m: .Nat) (a b: .Idx s)::ab@.tt: [.Idx s, .Cn[.Idx s, .Cn«2; .Idx s»]] =
     return (%core.wrap.mul m ab, .fn (i: .Idx s)@.tt: «2; .Idx s» = return (%core.wrap.mul m (i, b), %core.wrap.mul m (i, a)));

--- a/src/thorin/plug/matrix/matrix.thorin
+++ b/src/thorin/plug/matrix/matrix.thorin
@@ -36,12 +36,12 @@
 /// #### Normalization
 /// * resolve shape calls at construction by replacing them with the size argument
 ///
-.ax %matrix.shape: Π nST::[n: .Nat, S: «n; .Nat», T: *][%matrix.Mat nST, i: .Idx n] -> .Nat, normalize_shape;
+.ax %matrix.shape: Π [n: .Nat, S: «n; .Nat», T: *]::nST [%matrix.Mat nST, i: .Idx n] -> .Nat, normalize_shape;
 ///
 /// ### %matrix.const
 ///
 /// a constant matrix
-.ax %matrix.constMat: Π nST::[n: .Nat, S: «n; .Nat», T: *][%mem.M, T] -> [%mem.M, %matrix.Mat nST];
+.ax %matrix.constMat: Π [n: .Nat, S: «n; .Nat», T: *]::nST [%mem.M, T] -> [%mem.M, %matrix.Mat nST];
 ///
 /// ### %matrix.read
 ///
@@ -54,7 +54,7 @@
 /// * read(insert)
 /// * read(const)
 ///
-.ax %matrix.read: Π nST::[n: .Nat, S: «n; .Nat», T: *][%mem.M, %matrix.Mat nST, idx: «i: n; .Idx S#i»] -> [%mem.M, T], normalize_read;
+.ax %matrix.read: Π [n: .Nat, S: «n; .Nat», T: *]::nST [%mem.M, %matrix.Mat nST, idx: «i: n; .Idx S#i»] -> [%mem.M, T], normalize_read;
 ///
 /// ### %matrix.insert
 ///
@@ -67,7 +67,7 @@
 /// * with other inserts
 /// * with initialization
 ///
-.ax %matrix.insert: Π nST::[n: .Nat, S: «n; .Nat», T: *][%mem.M, %matrix.Mat nST, idx: «i: n; .Idx S#i», val: T] -> [%mem.M, %matrix.Mat nST], normalize_insert;
+.ax %matrix.insert: Π [n: .Nat, S: «n; .Nat», T: *]::nST [%mem.M, %matrix.Mat nST, idx: «i: n; .Idx S#i», val: T] -> [%mem.M, %matrix.Mat nST], normalize_insert;
 ///
 /// ### %matrix.init
 ///

--- a/src/thorin/plug/mem/mem.thorin
+++ b/src/thorin/plug/mem/mem.thorin
@@ -86,7 +86,7 @@
 /// @warning Use with caution since you completely remove the `%%mem.M` dependency.
 ///
 .let %mem.m = ⊤:%mem.M;
-.lam %mem.ignore {O: *} (_: %mem.M, o: O): O = o;
+.lam %mem.ignore .(O: *) (_: %mem.M, o: O): O = o;
 .lam %mem.rm (n: .Nat, Is: «n; *», O: *)
              (f: [%mem.M, «i: n; Is#i»] -> [%mem.M, O])
              (is: «i: n; Is#i»): O

--- a/src/thorin/plug/mem/mem.thorin
+++ b/src/thorin/plug/mem/mem.thorin
@@ -31,12 +31,12 @@
 /// ### %mem.load
 ///
 /// Loads from a pointer of type `%%mem.Ptr (T, as)` the pointed value of type `T`.
-.ax %mem.load:  Π.Tas::[T: *, .Nat][%mem.M, %mem.Ptr Tas] -> [%mem.M, T], normalize_load;
+.ax %mem.load:  Π .[T: *, .Nat]::Tas [%mem.M, %mem.Ptr Tas] -> [%mem.M, T], normalize_load;
 ///
 /// ### %mem.store
 ///
 /// Stores a value of type `T` to the location pointed to by a pointer of type `%%mem.Ptr (T, as)`,
-.ax %mem.store: Π.Tas::[T: *, .Nat][%mem.M, %mem.Ptr Tas, T] -> %mem.M, normalize_store;
+.ax %mem.store: Π .[T: *, .Nat]::Tas [%mem.M, %mem.Ptr Tas, T] -> %mem.M, normalize_store;
 ///
 /// ### %mem.remem
 ///
@@ -46,31 +46,31 @@
 /// ### %mem.alloc
 ///
 /// Allocates memory of type `T` in address space `as`.
-.ax %mem.alloc: Π Tas::[*, .Nat][%mem.M] -> [%mem.M, %mem.Ptr Tas];
+.ax %mem.alloc: Π [*, .Nat]::Tas [%mem.M] -> [%mem.M, %mem.Ptr Tas];
 ///
 /// ### %mem.slot
 ///
 /// Reserves a memory slot for type `T` in address space `as`.
 /// `id` has to be provided a unique id.
-.ax %mem.slot: Π Tas::[*, .Nat][%mem.M, id: .Nat] -> [%mem.M, %mem.Ptr Tas];
+.ax %mem.slot: Π [*, .Nat]::Tas [%mem.M, id: .Nat] -> [%mem.M, %mem.Ptr Tas];
 ///
 /// ### %mem.malloc
 ///
 /// Allocates memory of type `T` in address space `as`.
 /// The difference to `%%mem.alloc` is that the `size` is automatically inferred.
-.ax %mem.malloc: Π Tas::[*, .Nat][%mem.M, .Nat] -> [%mem.M, %mem.Ptr Tas];
+.ax %mem.malloc: Π [*, .Nat]::Tas [%mem.M, .Nat] -> [%mem.M, %mem.Ptr Tas];
 ///
 /// ### %mem.free
 ///
 /// Frees memory of type `T` in address space `as`.
-.ax %mem.free: Π.Tas::[*, .Nat][%mem.M, %mem.Ptr Tas] -> %mem.M;
+.ax %mem.free: Π. [*, .Nat]::Tas [%mem.M, %mem.Ptr Tas] -> %mem.M;
 ///
 /// ### %mem.mslot
 ///
 /// Reserves a memory slot for type `T` in address space `as`.
 /// The reserved slot will be `size` bytes large.
 /// `id` has to be provided an unique id.
-.ax %mem.mslot: Π Tas::[*, .Nat][%mem.M, size: .Nat, id: .Nat] -> [%mem.M, %mem.Ptr Tas];
+.ax %mem.mslot: Π [*, .Nat]::Tas [%mem.M, size: .Nat, id: .Nat] -> [%mem.M, %mem.Ptr Tas];
 ///
 /// ## Operations w/o Side Effects
 ///
@@ -86,11 +86,11 @@
 /// @warning Use with caution since you completely remove the `%%mem.M` dependency.
 ///
 .let %mem.m = ⊤:%mem.M;
-.lam %mem.ignore.(O: *)(_: %mem.M, o: O): O = o;
-.lam %mem.rm(n: .Nat, Is: «n; *», O: *)
-            (f: [%mem.M, «i: n; Is#i»] -> [%mem.M, O])
-            (is: «i: n; Is#i»): O
-                = %mem.ignore (f (%mem.m, is));
+.lam %mem.ignore {O: *} (_: %mem.M, o: O): O = o;
+.lam %mem.rm (n: .Nat, Is: «n; *», O: *)
+             (f: [%mem.M, «i: n; Is#i»] -> [%mem.M, O])
+             (is: «i: n; Is#i»): O
+    = %mem.ignore (f (%mem.m, is));
 ///
 /// ## Passes and Phases
 ///


### PR DESCRIPTION
Plz first give #273 your blessing.

* removes block expressions: `{ d* e }`.
  simply use `d* e` instead and if you really want to use delimiters use a tuple: `(d* e)`
* `abc::(a: A, b: B, c: C)` -> `(a: A, b: B, c: C)::abc`.
  This is simpler to parse and makes more sense as the identifier `abc` is only available *after* having processed the whole tuple pattern.