### PR TITLE
allow versioned clang and FileCheck

### DIFF
--- a/lit/CMakeLists.txt
+++ b/lit/CMakeLists.txt
@@ -7,6 +7,45 @@ else()
   set(LIT_VALGRIND_COMMANDLINE "")
 endif()
 
+find_program(CLANG_EXECUTABLE
+             NAMES clang
+                   clang-21
+                   clang-20
+                   clang-19
+                   clang-18
+                   clang-17
+                   clang-16
+                   clang-15
+                   clang-14
+             DOC "clang executable" REQUIRED)
+mark_as_advanced(CLANG_EXECUTABLE)
+
+find_program(CLANG_PP_EXECUTABLE
+             NAMES clang++
+                   clang++-21
+                   clang++-20
+                   clang++-19
+                   clang++-18
+                   clang++-17
+                   clang++-16
+                   clang++-15
+                   clang++-14
+             DOC "clang++ executable" REQUIRED)
+mark_as_advanced(CLANG_PP_EXECUTABLE)
+
+find_program(LLVM_FILECHECK_EXECUTABLE
+             NAMES FileCheck
+                   FileCheck-21
+                   FileCheck-20
+                   FileCheck-19
+                   FileCheck-18
+                   FileCheck-17
+                   FileCheck-16
+                   FileCheck-15
+                   FileCheck-14
+             DOC "LLVM FileCheck executable" REQUIRED)
+mark_as_advanced(LLVM_FILECHECK_EXECUTABLE)
+
 configure_file(lit.site.cfg.py.in lit.site.cfg.py @ONLY)
 add_custom_target(lit
     COMMAND ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/lit" "${CMAKE_CURRENT_BINARY_DIR}" -v --timeout=${MIM_LIT_TIMEOUT}

--- a/lit/affine/dynamic_for.mim
+++ b/lit/affine/dynamic_for.mim
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s --output-ll %t.ll -o - | FileCheck %s
-// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %mim %s --output-ll %t.ll -o - | %FileCheck %s
+// RUN: %clang %t.ll -o %t -Wno-override-module
 // RUN: %t 1 3 1; test $? -eq 3
 // RUN: %t 0 5 2 ; test $? -eq 6
 

--- a/lit/affine/for_2acc.mim
+++ b/lit/affine/for_2acc.mim
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s --output-ll %t.ll -o - | FileCheck %s
-// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %mim %s --output-ll %t.ll -o - | %FileCheck %s
+// RUN: %clang %t.ll -o %t -Wno-override-module
 // RUN: %t ; test $? -eq 0
 // RUN: %t 1 2 3 ; test $? -eq 6
 

--- a/lit/affine/for_2acc_2types.mim
+++ b/lit/affine/for_2acc_2types.mim
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s --output-ll %t.ll -o - | FileCheck %s
-// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %mim %s --output-ll %t.ll -o - | %FileCheck %s
+// RUN: %clang %t.ll -o %t -Wno-override-module
 // RUN: %t ; test $? -eq 0
 // RUN: %t 1 2 3 ; test $? -eq 6
 

--- a/lit/affine/for_2acc_real.mim
+++ b/lit/affine/for_2acc_real.mim
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s --output-ll %t.ll -o - | FileCheck %s
-// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %mim %s --output-ll %t.ll -o - | %FileCheck %s
+// RUN: %clang %t.ll -o %t -Wno-override-module
 // RUN: %t ; test $? -eq 0
 // RUN: %t 1 2 3 ; test $? -eq 6
 

--- a/lit/affine/for_over_mem.mim
+++ b/lit/affine/for_over_mem.mim
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s --output-ll %t.ll -o - | FileCheck %s
-// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %mim %s --output-ll %t.ll -o - | %FileCheck %s
+// RUN: %clang %t.ll -o %t -Wno-override-module
 // RUN: %t 0 1 2 3 ; test $? -eq 1
 // RUN: %t 0 1 2 3 4 5 6 7 ; test $? -eq 15
 

--- a/lit/annex.mim
+++ b/lit/annex.mim
@@ -1,4 +1,4 @@
-// RUN: %mim %s --output-h - --bootstrap | FileCheck %s
+// RUN: %mim %s --output-h - --bootstrap | %FileCheck %s
 
 plugin math;
 

--- a/lit/autodiff/autodiff_mult_in_call.mim
+++ b/lit/autodiff/autodiff_mult_in_call.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim -p direct %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim -p direct %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 plugin autodiff;

--- a/lit/autodiff/autodiff_mult_in_call2.mim
+++ b/lit/autodiff/autodiff_mult_in_call2.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim -p direct %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim -p direct %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 plugin autodiff;

--- a/lit/autodiff/autodiff_mult_in_call2_2.mim
+++ b/lit/autodiff/autodiff_mult_in_call2_2.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim -p direct %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim -p direct %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin autodiff;
 

--- a/lit/autodiff/autodiff_mult_in_call2_3.mim
+++ b/lit/autodiff/autodiff_mult_in_call2_3.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim -p direct %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim -p direct %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 plugin autodiff;

--- a/lit/autodiff/autodiff_mult_in_call_cont.mim
+++ b/lit/autodiff/autodiff_mult_in_call_cont.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim -p direct %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim -p direct %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 plugin autodiff;

--- a/lit/autodiff/call_autodiff.mim
+++ b/lit/autodiff/call_autodiff.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim -p direct %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim -p direct %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 plugin autodiff;

--- a/lit/autodiff/call_autodiff_cont.mim
+++ b/lit/autodiff/call_autodiff_cont.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim -p direct  %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim -p direct  %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 plugin autodiff;

--- a/lit/autodiff/general/2out.mim
+++ b/lit/autodiff/general/2out.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim -p direct %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim -p direct %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 plugin autodiff;

--- a/lit/autodiff/general/42.mim
+++ b/lit/autodiff/general/42.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim -p direct %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim -p direct %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 plugin autodiff;

--- a/lit/autodiff/general/add_tuple.mim
+++ b/lit/autodiff/general/add_tuple.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim -p direct %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim -p direct %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 plugin autodiff;

--- a/lit/autodiff/general/cps_inline.mim
+++ b/lit/autodiff/general/cps_inline.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 

--- a/lit/autodiff/general/ds_inline.mim
+++ b/lit/autodiff/general/ds_inline.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 

--- a/lit/autodiff/general/invoke_ds.mim
+++ b/lit/autodiff/general/invoke_ds.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s -o - --output-ll %t.ll | FileCheck %s
+// RUN: %mim %s -o - --output-ll %t.ll | %FileCheck %s
 
 plugin core;
 plugin direct;

--- a/lit/autodiff/general/tangent_type_cast.mim
+++ b/lit/autodiff/general/tangent_type_cast.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 plugin autodiff;

--- a/lit/autodiff/general/zero_tuple.mim
+++ b/lit/autodiff/general/zero_tuple.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 plugin direct;

--- a/lit/autodiff/id_autodiff.mim
+++ b/lit/autodiff/id_autodiff.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim -p direct %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim -p direct %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin autodiff;
 

--- a/lit/autodiff/id_autodiff_info_out.mim
+++ b/lit/autodiff/id_autodiff_info_out.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim -p direct %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim -p direct %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 plugin autodiff;

--- a/lit/autodiff/id_autodiff_mult_in.mim
+++ b/lit/autodiff/id_autodiff_mult_in.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim -p direct %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim -p direct %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 plugin autodiff;

--- a/lit/autodiff/id_autodiff_mult_in_mem.mim
+++ b/lit/autodiff/id_autodiff_mult_in_mem.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim -p direct %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim -p direct %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 plugin autodiff;

--- a/lit/autodiff/id_autodiff_mult_in_mult.mim
+++ b/lit/autodiff/id_autodiff_mult_in_mult.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %mim -p direct %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim -p direct %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 plugin autodiff;

--- a/lit/autodiff/id_autodiff_mult_in_mult2.mim
+++ b/lit/autodiff/id_autodiff_mult_in_mult2.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim -p direct %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim -p direct %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 plugin autodiff;

--- a/lit/autodiff/multiply2_autodiff.mim
+++ b/lit/autodiff/multiply2_autodiff.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim -p direct %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim -p direct %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 plugin autodiff;

--- a/lit/autodiff/multiply_autodiff.mim
+++ b/lit/autodiff/multiply_autodiff.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim -p direct %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim -p direct %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 plugin autodiff;

--- a/lit/autodiff/multiply_autodiff_cond.mim
+++ b/lit/autodiff/multiply_autodiff_cond.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim -p direct %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim -p direct %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 plugin autodiff;

--- a/lit/autodiff/multiply_autodiff_cond2.mim
+++ b/lit/autodiff/multiply_autodiff_cond2.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim -p direct %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim -p direct %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 plugin autodiff;

--- a/lit/autodiff/pow_autodiff.mim.disabled
+++ b/lit/autodiff/pow_autodiff.mim.disabled
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim -d direct -d autodiff %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim -d direct -d autodiff %s --output-ll %t.ll -o - | %FileCheck %s
 
 import core;
 import autodiff;

--- a/lit/autodiff/second/double_diff.mim.disabled
+++ b/lit/autodiff/second/double_diff.mim.disabled
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim -d direct -d autodiff %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim -d direct -d autodiff %s --output-ll %t.ll -o - | %FileCheck %s
 
 import core;
 import autodiff;

--- a/lit/autodiff/second/snd_order.mim.disabled
+++ b/lit/autodiff/second/snd_order.mim.disabled
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim -d direct -d autodiff %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim -d direct -d autodiff %s --output-ll %t.ll -o - | %FileCheck %s
 
 import core;
 import autodiff;

--- a/lit/autodiff/second/snd_order_man.mim
+++ b/lit/autodiff/second/snd_order_man.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim -p direct %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim -p direct %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 plugin autodiff;

--- a/lit/autodiff/simple_autodiff.mim
+++ b/lit/autodiff/simple_autodiff.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim -p direct %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim -p direct %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 plugin autodiff;

--- a/lit/autodiff/square.mim
+++ b/lit/autodiff/square.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim -p direct %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim -p direct %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 plugin autodiff;

--- a/lit/autodiff/square_autodiff.mim
+++ b/lit/autodiff/square_autodiff.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim -p direct %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim -p direct %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 plugin autodiff;

--- a/lit/clos/bind.mim
+++ b/lit/clos/bind.mim
@@ -1,7 +1,7 @@
 // RUN: rm -f %t.ll
 // RUN: %mim -p clos %s --output-ll %t.ll
-// RUN: clang %S/../lib.c %t.ll -o %t -Wno-override-module
-// RUN: %t | FileCheck %s
+// RUN: %clang %S/../lib.c %t.ll -o %t -Wno-override-module
+// RUN: %t | %FileCheck %s
 
 plugin mem;
 plugin core;

--- a/lit/compile/default.mim
+++ b/lit/compile/default.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 import compile;

--- a/lit/compile/id.mim
+++ b/lit/compile/id.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim %s --output-ll %t.ll -o - | %FileCheck %s
 
 import core;
 import compile;

--- a/lit/compile/opt.mim
+++ b/lit/compile/opt.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim %s --output-ll %t.ll -o - | %FileCheck %s
 
 import mem;
 import core;

--- a/lit/compile/ret_wrap.mim
+++ b/lit/compile/ret_wrap.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.l
-// RUN: %mim %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 plugin compile;

--- a/lit/compile/two_phase.mim
+++ b/lit/compile/two_phase.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 import compile;

--- a/lit/compile/unused.mim
+++ b/lit/compile/unused.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 import compile;

--- a/lit/core/1tuple.mim
+++ b/lit/core/1tuple.mim
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll
 // RUN: %mim %s --output-ll %t.ll
-// RUN: clang %t.ll -o %t -Wno-override-module -c
+// RUN: %clang %t.ll -o %t -Wno-override-module -c
 plugin core;
 
 fun extern foo(mem: %mem.M, p: %mem.Ptr0 «23; I32»): [%mem.M, %mem.Ptr0 I32] =

--- a/lit/core/icmp.mim
+++ b/lit/core/icmp.mim
@@ -1,4 +1,4 @@
-// RUN: %mim %s -o - | FileCheck %s
+// RUN: %mim %s -o - | %FileCheck %s
 
 plugin core;
 

--- a/lit/core/idx.mim
+++ b/lit/core/idx.mim
@@ -1,4 +1,4 @@
-// RUN: %mim %s -o - | FileCheck %s
+// RUN: %mim %s -o - | %FileCheck %s
 
 plugin core;
 

--- a/lit/core/nat.mim
+++ b/lit/core/nat.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s -o - | FileCheck %s
+// RUN: %mim %s -o - | %FileCheck %s
 plugin core;
 
 fun extern f(a b:Nat): Nat = return (%core.nat.add (b, 0));

--- a/lit/core/normalize_add.mim
+++ b/lit/core/normalize_add.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s -o - | FileCheck %s
+// RUN: %mim %s -o - | %FileCheck %s
 
 plugin core;
 

--- a/lit/core/normalize_and_ff.mim
+++ b/lit/core/normalize_and_ff.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s -o - | FileCheck %s
+// RUN: %mim %s -o - | %FileCheck %s
 
 plugin core;
 

--- a/lit/core/normalize_and_ff_tt.mim
+++ b/lit/core/normalize_and_ff_tt.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s -o - | FileCheck %s
+// RUN: %mim %s -o - | %FileCheck %s
 
 //plugin core;
 

--- a/lit/core/normalize_and_icmps.mim
+++ b/lit/core/normalize_and_icmps.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s -o - | FileCheck %s
+// RUN: %mim %s -o - | %FileCheck %s
 
 plugin core;
 

--- a/lit/core/normalize_and_icmps_lit.mim
+++ b/lit/core/normalize_and_icmps_lit.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s -o - | FileCheck %s
+// RUN: %mim %s -o - | %FileCheck %s
 
 plugin core;
 

--- a/lit/core/normalize_and_tree.mim
+++ b/lit/core/normalize_and_tree.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s -o - | FileCheck %s
+// RUN: %mim %s -o - | %FileCheck %s
 
 plugin core;
 

--- a/lit/core/normalize_and_tt.mim
+++ b/lit/core/normalize_and_tt.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s -o - | FileCheck %s
+// RUN: %mim %s -o - | %FileCheck %s
 
 plugin core;
 

--- a/lit/core/normalize_and_tt_tt.mim
+++ b/lit/core/normalize_and_tt_tt.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s -o - | FileCheck %s
+// RUN: %mim %s -o - | %FileCheck %s
 
 plugin core;
 

--- a/lit/core/normalize_bitcast.mim
+++ b/lit/core/normalize_bitcast.mim
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s --output-ll %t.ll -o - | FileCheck %s
-// RUN: clang -c %t.ll -o %t -Wno-override-module
+// RUN: %mim %s --output-ll %t.ll -o - | %FileCheck %s
+// RUN: %clang -c %t.ll -o %t -Wno-override-module
 
 plugin core;
 

--- a/lit/core/normalize_icmp.mim
+++ b/lit/core/normalize_icmp.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s -o - | FileCheck %s
+// RUN: %mim %s -o - | %FileCheck %s
 
 plugin core;
 

--- a/lit/core/pow.mim
+++ b/lit/core/pow.mim
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll
 // RUN: %mim %s --output-ll %t.ll -o -
-// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %clang %t.ll -o %t -Wno-override-module
 // RUN: %t ; test $? -eq 81
 
 plugin core;

--- a/lit/core/reassociate.mim
+++ b/lit/core/reassociate.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s -o - | FileCheck %s
+// RUN: %mim %s -o - | %FileCheck %s
 
 plugin core;
 

--- a/lit/core/ret_add.mim
+++ b/lit/core/ret_add.mim
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll
 // RUN: %mim %s --output-ll %t.ll -o -
-// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %clang %t.ll -o %t -Wno-override-module
 // RUN: %t 1 2 ; test $? -eq 3
 // RUN: %t 4 5 ; test $? -eq 9
 

--- a/lit/core/ret_and.mim
+++ b/lit/core/ret_and.mim
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll
 // RUN: %mim %s --output-ll %t.ll -o -
-// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %clang %t.ll -o %t -Wno-override-module
 // RUN: %t 3 1 ; test $? -eq 1
 // RUN: %t 7 5 ; test $? -eq 5
 

--- a/lit/core/ret_lshr.mim
+++ b/lit/core/ret_lshr.mim
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll
 // RUN: %mim %s --output-ll %t.ll -o -
-// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %clang %t.ll -o %t -Wno-override-module
 // RUN: %t 2 1 ; test $? -eq 1
 // RUN: %t 16 3 ; test $? -eq 2
 

--- a/lit/core/ret_nand.mim
+++ b/lit/core/ret_nand.mim
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll
 // RUN: %mim %s --output-ll %t.ll
-// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %clang %t.ll -o %t -Wno-override-module
 // RUN: %t 3 10 ; test $? -eq 13
 
 plugin core;

--- a/lit/core/sub_bug.mim
+++ b/lit/core/sub_bug.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s -o - | FileCheck %s
+// RUN: %mim %s -o - | %FileCheck %s
 // see https://github.com/AnyDSL/MimIR/issues/253
 
 plugin core;

--- a/lit/core/unary_tuple.mim
+++ b/lit/core/unary_tuple.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 

--- a/lit/demo/const.mim
+++ b/lit/demo/const.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 plugin demo;

--- a/lit/direct/ds2cps.mim
+++ b/lit/direct/ds2cps.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 plugin direct;

--- a/lit/direct/ds2cps_ax_cps2ds.mim
+++ b/lit/direct/ds2cps_ax_cps2ds.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %mim %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 plugin direct;

--- a/lit/direct/ds2cps_ax_cps2ds_dependent.mim.disabled
+++ b/lit/direct/ds2cps_ax_cps2ds_dependent.mim.disabled
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 plugin direct;

--- a/lit/direct/ds2cps_ax_cps2ds_dependent2.mim
+++ b/lit/direct/ds2cps_ax_cps2ds_dependent2.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %mim %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 plugin direct;

--- a/lit/direct/ds2cps_ax_cps2ds_dependent_short.mim.disabled
+++ b/lit/direct/ds2cps_ax_cps2ds_dependent_short.mim.disabled
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim %s --output-ll %t.ll -o - | %FileCheck %s
 
 /*
 Current issue:

--- a/lit/direct/ds2cps_ax_cps2ds_twice.mim
+++ b/lit/direct/ds2cps_ax_cps2ds_twice.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 plugin direct;

--- a/lit/direct/ds2cps_ax_cps2ds_twice_diff.mim
+++ b/lit/direct/ds2cps_ax_cps2ds_twice_diff.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 plugin direct;

--- a/lit/direct/ds2cps_cps_only.mim
+++ b/lit/direct/ds2cps_cps_only.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim %s --output-ll %t.ll -o - | %FileCheck %s
 
 // sanity check that the pass do not interfere with normal operation
 

--- a/lit/direct/ds2cps_mixed.mim
+++ b/lit/direct/ds2cps_mixed.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 plugin direct;

--- a/lit/direct/ds2cps_mixed2.mim
+++ b/lit/direct/ds2cps_mixed2.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim %s --output-ll %t.ll -o - | %FileCheck %s
 
 // a chain of cps calls followed by a direct call
 

--- a/lit/direct/ds2cps_mixed_tuple.mim
+++ b/lit/direct/ds2cps_mixed_tuple.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim %s --output-ll %t.ll -o - | %FileCheck %s
 
 // test a cps call to a function that contains a direct call
 

--- a/lit/direct/ds_dependent.mim
+++ b/lit/direct/ds_dependent.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 plugin direct;

--- a/lit/error/domain.mim
+++ b/lit/error/domain.mim
@@ -1,4 +1,4 @@
-// RUN: (! %mim %s 2>&1) | FileCheck %s
+// RUN: (! %mim %s 2>&1) | %FileCheck %s
 plugin core;
 plugin math;
 

--- a/lit/error/double_extern_lam.mim
+++ b/lit/error/double_extern_lam.mim
@@ -1,4 +1,4 @@
-// RUN: (! %mim %s 2>&1) | FileCheck %s
+// RUN: (! %mim %s 2>&1) | %FileCheck %s
 lam extern a() = ();
 lam extern a() = ();
 // CHECK: error: redeclaration

--- a/lit/error/pi_redef.mim
+++ b/lit/error/pi_redef.mim
@@ -1,4 +1,4 @@
-// RUN: (! %mim %s 2>&1) | FileCheck %s
+// RUN: (! %mim %s 2>&1) | %FileCheck %s
 rec F = |~| Nat → Nat;
 rec F = |~| Nat → Nat;
 // CHECK: error: redeclaration

--- a/lit/error/unsupported_rec.mim
+++ b/lit/error/unsupported_rec.mim
@@ -1,3 +1,3 @@
-// RUN: (! %mim %s 2>&1) | FileCheck %s
+// RUN: (! %mim %s 2>&1) | %FileCheck %s
 rec S = Nat;
 // CHECK: error: unsupported expression

--- a/lit/fib.mim
+++ b/lit/fib.mim
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s --output-ll %t.ll -o - | FileCheck %s
-// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %mim %s --output-ll %t.ll -o - | %FileCheck %s
+// RUN: %clang %t.ll -o %t -Wno-override-module
 // RUN: %t ; test $? -eq 144
 
 plugin core;

--- a/lit/fun.mim
+++ b/lit/fun.mim
@@ -1,4 +1,4 @@
-// RUN: %mim %s -o - | FileCheck %s
+// RUN: %mim %s -o - | %FileCheck %s
 plugin core;
 
 lam Ptr(T: *): * = %mem.Ptr (T, 0);

--- a/lit/lam_var.mim
+++ b/lit/lam_var.mim
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll
 // RUN: %mim %s --output-ll %t.ll -o -
-// RUN: clang -c %t.ll -o %t -Wno-override-module
+// RUN: %clang -c %t.ll -o %t -Wno-override-module
 plugin core;
 
 fun extern test(cond: Bool, a: «3; I32», b: «3; I32», i: Idx 3): «3; I32» =

--- a/lit/lit.cfg.py
+++ b/lit/lit.cfg.py
@@ -10,6 +10,9 @@ config.test_source_root = os.path.dirname(__file__)
 config.test_exec_root = os.path.join(config.my_obj_root, 'test')
 
 config.substitutions.append(('%mim', config.mim))
+config.substitutions.append(('%clang', config.clang))
+config.substitutions.append(('%cpp_clang', config.clang_pp))
+config.substitutions.append(('%FileCheck', config.filecheck))
 
 # inhert env vars
 config.environment = os.environ

--- a/lit/lit.site.cfg.py.in
+++ b/lit/lit.site.cfg.py.in
@@ -7,6 +7,9 @@ if sys.platform == "win32":
     config.mim = r'@CMAKE_BINARY_DIR@/bin/mim.exe'
 else:
     config.mim = r'@LIT_VALGRIND_COMMANDLINE@@CMAKE_BINARY_DIR@/bin/mim'
+config.clang = r'@CLANG_EXECUTABLE@'
+config.clang_pp = r'@CLANG_PP_EXECUTABLE@'
+config.filecheck = r'@LLVM_FILECHECK_EXECUTABLE@'
 
 lit_config.load_config(
         config, os.path.join(config.my_src_root, "lit/lit.cfg.py"))

--- a/lit/main_loop.mim
+++ b/lit/main_loop.mim
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll
 // RUN: %mim %s --output-ll %t.ll -o -
-// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %clang %t.ll -o %t -Wno-override-module
 // RUN: %t ; test $? -eq 0
 // RUN: %t 1 2 3 ; test $? -eq 6
 

--- a/lit/math/exp.mim
+++ b/lit/math/exp.mim
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll
 // RUN: %mim %s --output-ll %t.ll
-// RUN: clang++ %t.ll -o %t -Wno-override-module
+// RUN: %cpp_clang %t.ll -o %t -Wno-override-module
 // RUN: %t foo bar; test $? -eq 64
 
 plugin math;

--- a/lit/math/tri.mim
+++ b/lit/math/tri.mim
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll
 // RUN: %mim %s --output-ll %t.ll
-// RUN: clang++ %t.ll -o %t -Wno-override-module
+// RUN: %cpp_clang %t.ll -o %t -Wno-override-module
 // RUN: %t foo; test $? -eq 98
 
 plugin math;

--- a/lit/matrix/get_shape.mim
+++ b/lit/matrix/get_shape.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s --output-ll %t.ll --output-mim - | FileCheck %s
+// RUN: %mim %s --output-ll %t.ll --output-mim - | %FileCheck %s
 
 plugin core;
 plugin matrix;

--- a/lit/matrix/init.mim
+++ b/lit/matrix/init.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim -o - %s | FileCheck %s
+// RUN: %mim -o - %s | %FileCheck %s
 
 plugin core;
 plugin matrix;

--- a/lit/matrix/init_const_no_ret.mim
+++ b/lit/matrix/init_const_no_ret.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim -o - %s | FileCheck %s
+// RUN: %mim -o - %s | %FileCheck %s
 
 plugin core;
 plugin matrix;

--- a/lit/matrix/init_no_ret.mim
+++ b/lit/matrix/init_no_ret.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim -o - %s | FileCheck %s
+// RUN: %mim -o - %s | %FileCheck %s
 
 plugin core;
 plugin matrix;

--- a/lit/matrix/map_reduce.mim
+++ b/lit/matrix/map_reduce.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim -o - %s | FileCheck %s
+// RUN: %mim -o - %s | %FileCheck %s
 
 plugin core;
 plugin matrix;

--- a/lit/matrix/map_reduce_mult_init.mim
+++ b/lit/matrix/map_reduce_mult_init.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim -o - %s | FileCheck %s
+// RUN: %mim -o - %s | %FileCheck %s
 
 plugin core;
 plugin matrix;

--- a/lit/matrix/map_reduce_mult_init_ret.mim
+++ b/lit/matrix/map_reduce_mult_init_ret.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim -o - %s | FileCheck %s
+// RUN: %mim -o - %s | %FileCheck %s
 
 plugin core;
 plugin matrix;

--- a/lit/matrix/map_reduce_transpose.mim.disabled
+++ b/lit/matrix/map_reduce_transpose.mim.disabled
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim -o - %s | FileCheck %s
+// RUN: %mim -o - %s | %FileCheck %s
 
 plugin core;
 plugin matrix;

--- a/lit/matrix/map_reduce_zip_add.mim
+++ b/lit/matrix/map_reduce_zip_add.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim -o - %s  | FileCheck %s
+// RUN: %mim -o - %s  | %FileCheck %s
 
 plugin core;
 plugin matrix;

--- a/lit/matrix/print_const.mim
+++ b/lit/matrix/print_const.mim
@@ -1,7 +1,7 @@
 // RUN: rm -f %t.ll
 // RUN: %mim -p clos -o - --output-ll %t.ll %s
-// RUN: clang %S/../lib.c %t.ll -o %t -Wno-override-module
-// RUN: %t 2 3 | FileCheck %s
+// RUN: %clang %S/../lib.c %t.ll -o %t -Wno-override-module
+// RUN: %t 2 3 | %FileCheck %s
 
 plugin core;
 plugin matrix;

--- a/lit/matrix/print_const_dyn_mat.mim
+++ b/lit/matrix/print_const_dyn_mat.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim -p direct -p math -o - %s | FileCheck %s
+// RUN: %mim -p direct -p math -o - %s | %FileCheck %s
 
 // TODO: allocation error due to dynamic size,
 // ./build/bin/mim lit/matrix/print_const_dyn_mat.mim -p direct -p clos -o - -VVVV --output-ll T.ll

--- a/lit/matrix/print_const_prod.mim
+++ b/lit/matrix/print_const_prod.mim
@@ -1,7 +1,7 @@
 // RUN: rm -f %t.ll
 // RUN: %mim -p clos -o - --output-ll %t.ll %s
-// RUN: clang %S/../lib.c %t.ll -o %t -Wno-override-module
-// RUN: %t 2 3 | FileCheck %s
+// RUN: %clang %S/../lib.c %t.ll -o %t -Wno-override-module
+// RUN: %t 2 3 | %FileCheck %s
 
 plugin core;
 plugin math;

--- a/lit/matrix/print_id_mat.mim
+++ b/lit/matrix/print_id_mat.mim
@@ -1,7 +1,7 @@
 // RUN: rm -f %t.ll
 // RUN: %mim -p clos -p math -o - --output-ll %t.ll %s
-// RUN: clang %S/../lib.c %t.ll -o %t -Wno-override-module
-// RUN: %t 2 3 | FileCheck %s
+// RUN: %clang %S/../lib.c %t.ll -o %t -Wno-override-module
+// RUN: %t 2 3 | %FileCheck %s
 
 plugin core;
 plugin matrix;

--- a/lit/matrix/print_prod2.mim
+++ b/lit/matrix/print_prod2.mim
@@ -1,7 +1,7 @@
 // RUN: rm -f %t.ll
 // RUN: %mim -p clos -o - --output-ll %t.ll %s
-// RUN: clang %S/../lib.c %t.ll -o %t -Wno-override-module
-// RUN: %t 2 3 | FileCheck %s
+// RUN: %clang %S/../lib.c %t.ll -o %t -Wno-override-module
+// RUN: %t 2 3 | %FileCheck %s
 
 plugin core;
 plugin math;

--- a/lit/matrix/product.mim.disabled
+++ b/lit/matrix/product.mim.disabled
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s -output-ll ll -o - | FileCheck %s
-// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %mim %s -output-ll ll -o - | %FileCheck %s
+// RUN: %clang %t.ll -o %t -Wno-override-module
 // RUN: %t ; test $? -eq 5
 // RUN: %t 1 2 3 ; test $? -eq 5
 // RUN: %t a b c d e f ; test $? -eq 5

--- a/lit/matrix/product_ext.mim.disabled
+++ b/lit/matrix/product_ext.mim.disabled
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll
-// RUN: %mim -e mim %s -e ll -o %t | FileCheck %s
-// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %mim -e mim %s -e ll -o %t | %FileCheck %s
+// RUN: %clang %t.ll -o %t -Wno-override-module
 // RUN: %t ; test $? -eq 5
 // RUN: %t 1 2 3 ; test $? -eq 5
 // RUN: %t a b c d e f ; test $? -eq 5

--- a/lit/matrix/read_const.mim
+++ b/lit/matrix/read_const.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s --output-ll %t.ll --output-mim - | FileCheck %s
+// RUN: %mim %s --output-ll %t.ll --output-mim - | %FileCheck %s
 
 plugin core;
 plugin matrix;

--- a/lit/matrix/read_map.mim.disabled
+++ b/lit/matrix/read_map.mim.disabled
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll
-// RUN: %mim -e mim %s -e ll -o %t | FileCheck %s
-// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %mim -e mim %s -e ll -o %t | %FileCheck %s
+// RUN: %clang %t.ll -o %t -Wno-override-module
 // RUN: %t ; test $? -eq 5
 // RUN: %t 1 2 3 ; test $? -eq 5
 // RUN: %t a b c d e f ; test $? -eq 5

--- a/lit/matrix/read_mat.mim.disabled
+++ b/lit/matrix/read_mat.mim.disabled
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll
 // RUN: %mim %s --output-ll %t.ll -o -
-// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %clang %t.ll -o %t -Wno-override-module
 
 plugin core;
 plugin matrix;

--- a/lit/matrix/read_mat2.mim
+++ b/lit/matrix/read_mat2.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim -o - %s | FileCheck %s
+// RUN: %mim -o - %s | %FileCheck %s
 
 plugin core;
 plugin matrix;

--- a/lit/matrix/read_transpose.mim
+++ b/lit/matrix/read_transpose.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim -o - %s | FileCheck %s
+// RUN: %mim -o - %s | %FileCheck %s
 
 plugin core;
 plugin matrix;

--- a/lit/matrix/read_transpose_run.mim
+++ b/lit/matrix/read_transpose_run.mim
@@ -1,4 +1,4 @@
 // RUN: rm -f %t.ll
 // RUN: FILE=%s;%mim -p matrix -p clos -o - ${FILE%_run.mim}.mim --output-ll %t.ll
-// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %clang %t.ll -o %t -Wno-override-module
 // RUN: %t ; test $? -eq 5

--- a/lit/matrix/test_write.mim
+++ b/lit/matrix/test_write.mim
@@ -1,7 +1,7 @@
 // RUN: rm -f %t.ll
 // RUN: %mim -p clos -o - --output-ll %t.ll %s
-// RUN: clang %S/../lib.c %t.ll -o %t -Wno-override-module
-// RUN: %t 2 3 | FileCheck %s
+// RUN: %clang %S/../lib.c %t.ll -o %t -Wno-override-module
+// RUN: %t 2 3 | %FileCheck %s
 
 plugin core;
 plugin matrix;

--- a/lit/matrix/transpose_init.mim
+++ b/lit/matrix/transpose_init.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim -o - %s | FileCheck %s
+// RUN: %mim -o - %s | %FileCheck %s
 
 plugin core;
 plugin matrix;

--- a/lit/mem/add_top_mem.mim
+++ b/lit/mem/add_top_mem.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s -o - | FileCheck %s
+// RUN: %mim %s -o - | %FileCheck %s
 
 plugin core;
 

--- a/lit/mem/add_top_mem2.mim
+++ b/lit/mem/add_top_mem2.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s -o - | FileCheck %s
+// RUN: %mim %s -o - | %FileCheck %s
 
 plugin core;
 

--- a/lit/mem/alloc_load_store.mim
+++ b/lit/mem/alloc_load_store.mim
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll
 // RUN: %mim %s --output-ll %t.ll -o -
-// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %clang %t.ll -o %t -Wno-override-module
 // RUN: %t; test $? -eq 1
 // RUN: %t 1 2 3; test $? -eq 4
 // RUN: %t 1 2 3 4 5; test $? -eq 6

--- a/lit/mem/malloc_load_store.mim
+++ b/lit/mem/malloc_load_store.mim
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll
 // RUN: %mim %s --output-ll %t.ll -o -
-// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %clang %t.ll -o %t -Wno-override-module
 // RUN: %t; test $? -eq 1
 // RUN: %t 1 2 3; test $? -eq 4
 // RUN: %t 1 2 3 4 5; test $? -eq 6

--- a/lit/mem/mem_rm.mim
+++ b/lit/mem/mem_rm.mim
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll
 // RUN: %mim %s --output-ll %t.ll
-// RUN: clang %t.ll -S -emit-llvm -Wno-override-module -o -
+// RUN: %clang %t.ll -S -emit-llvm -Wno-override-module -o -
 plugin core;
 
 fun extern f (a b: I32) as ab : I32 =

--- a/lit/mem/mslot_load_store.mim
+++ b/lit/mem/mslot_load_store.mim
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll ; \
 // RUN: %mim %s --output-ll %t.ll -o -
-// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %clang %t.ll -o %t -Wno-override-module
 // RUN: %t; test $? -eq 1
 // RUN: %t 1 2 3; test $? -eq 4
 // RUN: %t 1 2 3 4 5; test $? -eq 6

--- a/lit/mem/no_mem.mim
+++ b/lit/mem/no_mem.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 

--- a/lit/mem/slot_load_store.mim
+++ b/lit/mem/slot_load_store.mim
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll
 // RUN: %mim %s --output-ll %t.ll -o -
-// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %clang %t.ll -o %t -Wno-override-module
 // RUN: %t; test $? -eq 1
 // RUN: %t 1 2 3; test $? -eq 4
 // RUN: %t 1 2 3 4 5; test $? -eq 6

--- a/lit/mem/two_fun_mem.mim
+++ b/lit/mem/two_fun_mem.mim
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll
 // RUN: %mim %s --output-ll %t.ll -o -
-// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %clang %t.ll -o %t -Wno-override-module
 // RUN: %t; test $? -eq 5
 // RUN: %t 1; test $? -eq 7
 // RUN: %t 1 2; test $? -eq 9

--- a/lit/mem/two_fun_no_mem.mim
+++ b/lit/mem/two_fun_no_mem.mim
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll
 // RUN: %mim %s --output-ll %t.ll -o -
-// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %clang %t.ll -o %t -Wno-override-module
 // RUN: %t; test $? -eq 5
 // RUN: %t 1; test $? -eq 7
 // RUN: %t 1 2; test $? -eq 9

--- a/lit/opt/default.mim
+++ b/lit/opt/default.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim %s --output-ll %t.ll -o - | %FileCheck %s
 
 import core;
 import compile;

--- a/lit/pack.mim
+++ b/lit/pack.mim
@@ -1,4 +1,4 @@
-// RUN: %mim %s -o - | FileCheck %s
+// RUN: %mim %s -o - | %FileCheck %s
 plugin core;
 
 lam extern f(): «3; Nat» = ‹i: 3; %core.nat.add (1, %core.bitcast Nat i)›;

--- a/lit/parse_output_parse.mim.disabled
+++ b/lit/parse_output_parse.mim.disabled
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll %t.mim
-// RUN: %mim -o - %s > %t.mim && %mim %t.mim --output-ll %t.ll -o - | FileCheck %s
-// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %mim -o - %s > %t.mim && %mim %t.mim --output-ll %t.ll -o - | %FileCheck %s
+// RUN: %clang %t.ll -o %t -Wno-override-module
 // RUN: %t ; test $? -eq 1
 // RUN: %t 1 2 3 ; test $? -eq 4
 // RUN: %t a b c d e f ; test $? -eq 7

--- a/lit/prec.mim
+++ b/lit/prec.mim
@@ -1,4 +1,4 @@
-// RUN: %mim %s -o - | FileCheck %s
+// RUN: %mim %s -o - | %FileCheck %s
 
 lam extern f x: Nat : Nat = x;
 

--- a/lit/rec.mim
+++ b/lit/rec.mim
@@ -1,4 +1,4 @@
-// RUN: %mim %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim %s --output-ll %t.ll -o - | %FileCheck %s
 plugin core;
 
 lam is_even(i: Nat): Bool = (is_odd (%core.nat.sub (i, 1)), tt)#(%core.ncmp.e (i, 0))

--- a/lit/refly/debug.mim
+++ b/lit/refly/debug.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 plugin refly;

--- a/lit/refly/debug_perm.mim
+++ b/lit/refly/debug_perm.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s --output-ll %t.ll -o - | FileCheck %s
+// RUN: %mim %s --output-ll %t.ll -o - | %FileCheck %s
 
 plugin core;
 plugin refly;

--- a/lit/refly/refine.mim
+++ b/lit/refly/refine.mim
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll
-// RUN: %mim %s --output-ll %t.ll -o - | FileCheck %s
-// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %mim %s --output-ll %t.ll -o - | %FileCheck %s
+// RUN: %clang %t.ll -o %t -Wno-override-module
 // RUN: %t ; test $? -eq 42
 
 plugin core;

--- a/lit/regex/disj.mim
+++ b/lit/regex/disj.mim
@@ -1,4 +1,4 @@
-// RUN: %mim %s -o - -P %S | FileCheck %s
+// RUN: %mim %s -o - -P %S | %FileCheck %s
 
 import mem;
 plugin regex;

--- a/lit/regex/disj_lits.mim
+++ b/lit/regex/disj_lits.mim
@@ -1,4 +1,4 @@
-// RUN: %mim %s -o - -P %S | FileCheck %s
+// RUN: %mim %s -o - -P %S | %FileCheck %s
 
 import mem;
 plugin regex;

--- a/lit/regex/disj_lits_fold_d.mim
+++ b/lit/regex/disj_lits_fold_d.mim
@@ -1,4 +1,4 @@
-// RUN: %mim %s -o - -P %S | FileCheck %s
+// RUN: %mim %s -o - -P %S | %FileCheck %s
 
 import mem;
 plugin regex;

--- a/lit/regex/disj_lits_fold_w.mim
+++ b/lit/regex/disj_lits_fold_w.mim
@@ -1,4 +1,4 @@
-// RUN: %mim %s -o - -P %S | FileCheck %s
+// RUN: %mim %s -o - -P %S | %FileCheck %s
 
 import mem;
 plugin regex;

--- a/lit/regex/flatten_disj.mim
+++ b/lit/regex/flatten_disj.mim
@@ -1,4 +1,4 @@
-// RUN: %mim %s -o - -P %S | FileCheck %s
+// RUN: %mim %s -o - -P %S | %FileCheck %s
 
 import mem;
 plugin regex;

--- a/lit/regex/fold_0to0_to_0.mim
+++ b/lit/regex/fold_0to0_to_0.mim
@@ -1,4 +1,4 @@
-// RUN: %mim %s -o - -P %S | FileCheck %s
+// RUN: %mim %s -o - -P %S | %FileCheck %s
 
 import mem;
 plugin regex;

--- a/lit/regex/fold_0to8_to_range.mim
+++ b/lit/regex/fold_0to8_to_range.mim
@@ -1,4 +1,4 @@
-// RUN: %mim %s -o - -P %S | FileCheck %s
+// RUN: %mim %s -o - -P %S | %FileCheck %s
 
 import mem;
 plugin regex;

--- a/lit/regex/fold_0to9_to_d.mim
+++ b/lit/regex/fold_0to9_to_d.mim
@@ -1,4 +1,4 @@
-// RUN: %mim %s -o - -P %S | FileCheck %s
+// RUN: %mim %s -o - -P %S | %FileCheck %s
 
 import mem;
 plugin regex;

--- a/lit/regex/fold_azAZ_09_to_w.mim
+++ b/lit/regex/fold_azAZ_09_to_w.mim
@@ -1,4 +1,4 @@
-// RUN: %mim %s -o - -P %S | FileCheck %s
+// RUN: %mim %s -o - -P %S | %FileCheck %s
 
 import mem;
 plugin regex;

--- a/lit/regex/fold_disj_to_s.mim
+++ b/lit/regex/fold_disj_to_s.mim
@@ -1,4 +1,4 @@
-// RUN: %mim %s -o - -P %S | FileCheck %s
+// RUN: %mim %s -o - -P %S | %FileCheck %s
 
 import mem;
 plugin regex;

--- a/lit/regex/fold_disjs.mim
+++ b/lit/regex/fold_disjs.mim
@@ -1,4 +1,4 @@
-// RUN: %mim %s -o - -P %S | FileCheck %s
+// RUN: %mim %s -o - -P %S | %FileCheck %s
 
 import mem;
 plugin regex;

--- a/lit/regex/fold_optional_optional.mim
+++ b/lit/regex/fold_optional_optional.mim
@@ -1,4 +1,4 @@
-// RUN: %mim %s -o - -P %S | FileCheck %s
+// RUN: %mim %s -o - -P %S | %FileCheck %s
 
 import mem;
 plugin regex;

--- a/lit/regex/fold_optional_plus.mim
+++ b/lit/regex/fold_optional_plus.mim
@@ -1,4 +1,4 @@
-// RUN: %mim %s -o - -P %S | FileCheck %s
+// RUN: %mim %s -o - -P %S | %FileCheck %s
 
 import mem;
 plugin regex;

--- a/lit/regex/fold_optional_star.mim
+++ b/lit/regex/fold_optional_star.mim
@@ -1,4 +1,4 @@
-// RUN: %mim %s -o - -P %S | FileCheck %s
+// RUN: %mim %s -o - -P %S | %FileCheck %s
 
 import mem;
 plugin regex;

--- a/lit/regex/fold_plus_optional.mim
+++ b/lit/regex/fold_plus_optional.mim
@@ -1,4 +1,4 @@
-// RUN: %mim %s -o - -P %S | FileCheck %s
+// RUN: %mim %s -o - -P %S | %FileCheck %s
 
 import mem;
 plugin regex;

--- a/lit/regex/fold_plus_plus.mim
+++ b/lit/regex/fold_plus_plus.mim
@@ -1,4 +1,4 @@
-// RUN: %mim %s -o - -P %S | FileCheck %s
+// RUN: %mim %s -o - -P %S | %FileCheck %s
 
 import mem;
 plugin regex;

--- a/lit/regex/fold_plus_star.mim
+++ b/lit/regex/fold_plus_star.mim
@@ -1,4 +1,4 @@
-// RUN: %mim %s -o - -P %S | FileCheck %s
+// RUN: %mim %s -o - -P %S | %FileCheck %s
 
 import mem;
 plugin regex;

--- a/lit/regex/fold_ranges_lits.mim
+++ b/lit/regex/fold_ranges_lits.mim
@@ -1,4 +1,4 @@
-// RUN: %mim %s -o - -P %S | FileCheck %s
+// RUN: %mim %s -o - -P %S | %FileCheck %s
 
 import mem;
 plugin regex;

--- a/lit/regex/fold_star_optional.mim
+++ b/lit/regex/fold_star_optional.mim
@@ -1,4 +1,4 @@
-// RUN: %mim %s -o - -P %S | FileCheck %s
+// RUN: %mim %s -o - -P %S | %FileCheck %s
 
 import mem;
 plugin regex;

--- a/lit/regex/fold_star_plus.mim
+++ b/lit/regex/fold_star_plus.mim
@@ -1,4 +1,4 @@
-// RUN: %mim %s -o - -P %S | FileCheck %s
+// RUN: %mim %s -o - -P %S | %FileCheck %s
 
 plugin mem;
 plugin regex;

--- a/lit/regex/fold_star_star.mim
+++ b/lit/regex/fold_star_star.mim
@@ -1,4 +1,4 @@
-// RUN: %mim %s -o - -P %S | FileCheck %s
+// RUN: %mim %s -o - -P %S | %FileCheck %s
 
 import mem;
 plugin regex;

--- a/lit/regex/match_1or5or9.mim
+++ b/lit/regex/match_1or5or9.mim
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %mim %s -o - --output-ll %t.ll | FileCheck %s
-// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %mim %s -o - --output-ll %t.ll | %FileCheck %s
+// RUN: %clang %t.ll -o %t -Wno-override-module
 // RUN: %t "0"; test $? -eq 1
 // RUN: %t "1"; test $? -eq 0
 

--- a/lit/regex/match_lit.mim
+++ b/lit/regex/match_lit.mim
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %mim %s -o - --output-ll %t.ll | FileCheck %s
-// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %mim %s -o - --output-ll %t.ll | %FileCheck %s
+// RUN: %clang %t.ll -o %t -Wno-override-module
 // RUN: %t "g"; test $? -eq 0
 // RUN: %t "1"; test $? -eq 1
 

--- a/lit/regex/match_mail.mim
+++ b/lit/regex/match_mail.mim
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %mim %s -o - --output-ll %t.ll --aggr-lam-spec | FileCheck %s
-// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %mim %s -o - --output-ll %t.ll --aggr-lam-spec | %FileCheck %s
+// RUN: %clang %t.ll -o %t -Wno-override-module
 // RUN: %t "test@cs.uni-saarland.de"; test $? -eq 0
 // RUN: %t "tester@test.de"; test $? -eq 0
 // RUN: %t "a@a.de"; test $? -eq 0

--- a/lit/regex/match_manual.mim
+++ b/lit/regex/match_manual.mim
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %mim %s -o - --output-ll %t.ll | FileCheck %s
-// RUN: clang %t.ll -o %t -Wno-override-module %S/../lib.c
+// RUN: %mim %s -o - --output-ll %t.ll | %FileCheck %s
+// RUN: %clang %t.ll -o %t -Wno-override-module %S/../lib.c
 // RUN: %t "aa"; test $? -eq 1
 // RUN: %t "abbaa"; test $? -eq 1
 // RUN: %t "a"; test $? -eq 0

--- a/lit/regex/match_not_wds.mim
+++ b/lit/regex/match_not_wds.mim
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %mim %s -o - --output-ll %t.ll | FileCheck %s
-// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %mim %s -o - --output-ll %t.ll | %FileCheck %s
+// RUN: %clang %t.ll -o %t -Wno-override-module
 // RUN: %t "g5 "; test $? -eq 0
 // RUN: %t "g1g"; test $? -eq 1
 

--- a/lit/regex/match_sample.mim
+++ b/lit/regex/match_sample.mim
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %mim %s -o - --output-ll %t.ll --aggr-lam-spec | FileCheck %s
-// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %mim %s -o - --output-ll %t.ll --aggr-lam-spec | %FileCheck %s
+// RUN: %clang %t.ll -o %t -Wno-override-module
 // RUN: %t "asdf@"; test $? -eq 1
 // RUN: %t "asdf"; test $? -eq 0
 // RUN: %t "@asdf"; test $? -eq 0

--- a/lit/regex/match_test10.mim
+++ b/lit/regex/match_test10.mim
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %mim %s -o - --output-ll %t.ll --aggr-lam-spec | FileCheck %s
-// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %mim %s -o - --output-ll %t.ll --aggr-lam-spec | %FileCheck %s
+// RUN: %clang %t.ll -o %t -Wno-override-module
 // RUN: %t; test $? -eq 1
 
 plugin mem;

--- a/lit/regex/match_w.mim
+++ b/lit/regex/match_w.mim
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %mim %s -o - --output-ll %t.ll | FileCheck %s
-// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %mim %s -o - --output-ll %t.ll | %FileCheck %s
+// RUN: %clang %t.ll -o %t -Wno-override-module
 // RUN: %t "g"; test $? -eq 1
 // RUN: %t "1"; test $? -eq 1
 // RUN: %t "_"; test $? -eq 1

--- a/lit/regex/match_wds.mim
+++ b/lit/regex/match_wds.mim
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %mim %s -o - --output-ll %t.ll | FileCheck %s
-// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %mim %s -o - --output-ll %t.ll | %FileCheck %s
+// RUN: %clang %t.ll -o %t -Wno-override-module
 // RUN: %t "g1 "; test $? -eq 1
 
 plugin mem;

--- a/lit/regex/match_wds_cap.mim
+++ b/lit/regex/match_wds_cap.mim
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %mim %s -o - --output-ll %t.ll | FileCheck %s
-// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %mim %s -o - --output-ll %t.ll | %FileCheck %s
+// RUN: %clang %t.ll -o %t -Wno-override-module
 // RUN: %t " g5"; test $? -eq 1
 // RUN: %t "g1 "; test $? -eq 0
 

--- a/lit/regex/match_woptional.mim
+++ b/lit/regex/match_woptional.mim
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %mim %s -o - --output-ll %t.ll | FileCheck %s
-// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %mim %s -o - --output-ll %t.ll | %FileCheck %s
+// RUN: %clang %t.ll -o %t -Wno-override-module
 // RUN: %t "g1 "; test $? -eq 1
 // RUN: %t "# "; test $? -eq 1
 

--- a/lit/regex/match_woptionals.mim
+++ b/lit/regex/match_woptionals.mim
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %mim %s -o - --output-ll %t.ll | FileCheck %s
-// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %mim %s -o - --output-ll %t.ll | %FileCheck %s
+// RUN: %clang %t.ll -o %t -Wno-override-module
 // RUN: %t "g "; test $? -eq 1
 // RUN: %t " "; test $? -eq 1
 // RUN: %t "# "; test $? -eq 0

--- a/lit/regex/match_wors.mim
+++ b/lit/regex/match_wors.mim
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %mim %s -o - --output-ll %t.ll | FileCheck %s
-// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %mim %s -o - --output-ll %t.ll | %FileCheck %s
+// RUN: %clang %t.ll -o %t -Wno-override-module
 // RUN: %t "g1 "; test $? -eq 1
 
 plugin mem;

--- a/lit/regex/match_wplus.mim
+++ b/lit/regex/match_wplus.mim
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %mim %s -o - --output-ll %t.ll --aggr-lam-spec | FileCheck %s
-// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %mim %s -o - --output-ll %t.ll --aggr-lam-spec | %FileCheck %s
+// RUN: %clang %t.ll -o %t -Wno-override-module
 // RUN: %t "g1 "; test $? -eq 1
 
 plugin mem;

--- a/lit/regex/match_wplusa.mim
+++ b/lit/regex/match_wplusa.mim
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %mim %s -o - --output-ll %t.ll --aggr-lam-spec | FileCheck %s
-// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %mim %s -o - --output-ll %t.ll --aggr-lam-spec | %FileCheck %s
+// RUN: %clang %t.ll -o %t -Wno-override-module
 // RUN: %t "aa"; test $? -eq 1
 // RUN: %t "abca"; test $? -eq 1
 // RUN: %t "a"; test $? -eq 0

--- a/lit/regex/match_wstar.mim
+++ b/lit/regex/match_wstar.mim
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll ; \
-// RUN: %mim %s -o - --output-ll %t.ll --aggr-lam-spec | FileCheck %s
-// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %mim %s -o - --output-ll %t.ll --aggr-lam-spec | %FileCheck %s
+// RUN: %clang %t.ll -o %t -Wno-override-module
 // RUN: %t "g1 "; test $? -eq 1
 
 plugin mem;

--- a/lit/regex/swap_range_args.mim
+++ b/lit/regex/swap_range_args.mim
@@ -1,4 +1,4 @@
-// RUN: %mim %s -o - -P %S | FileCheck %s
+// RUN: %mim %s -o - -P %S | %FileCheck %s
 
 import mem;
 plugin regex;

--- a/lit/regex/tree_conj1.mim
+++ b/lit/regex/tree_conj1.mim
@@ -1,4 +1,4 @@
-// RUN: %mim %s -o - -P %S | FileCheck %s
+// RUN: %mim %s -o - -P %S | %FileCheck %s
 
 import mem;
 plugin regex;

--- a/lit/regex/tree_conj2.mim
+++ b/lit/regex/tree_conj2.mim
@@ -1,4 +1,4 @@
-// RUN: %mim %s -o - -P %S | FileCheck %s
+// RUN: %mim %s -o - -P %S | %FileCheck %s
 
 import mem;
 plugin regex;

--- a/lit/regex/tree_conj3.mim
+++ b/lit/regex/tree_conj3.mim
@@ -1,4 +1,4 @@
-// RUN: %mim %s -o - -P %S | FileCheck %s
+// RUN: %mim %s -o - -P %S | %FileCheck %s
 
 import mem;
 plugin regex;

--- a/lit/ret_argc.mim
+++ b/lit/ret_argc.mim
@@ -1,6 +1,6 @@
 // RUN: rm -f %t.ll
 // RUN: %mim %s --output-ll %t.ll -o -
-// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %clang %t.ll -o %t -Wno-override-module
 // RUN: %t ; test $? -eq 1
 // RUN: %t 1 2 3 ; test $? -eq 4
 // RUN: %t a b c d e f ; test $? -eq 7

--- a/lit/str.mim
+++ b/lit/str.mim
@@ -1,7 +1,7 @@
 // RUN: rm -f %t.ll
 // RUN: %mim --output-ll %t.ll %s
-// RUN: clang %S/lib.c %t.ll -o %t -Wno-override-module
-// RUN: %t | FileCheck %s
+// RUN: %clang %S/lib.c %t.ll -o %t -Wno-override-module
+// RUN: %t | %FileCheck %s
 plugin core;
 
 cfun println_char[%mem.M, I8]: %mem.M;


### PR DESCRIPTION
This lets to override or use version llvm in lit test-suite.
llvm official ppa provides is as version lets to have multiple versions, while changing symlink is burdensome and unrealible.