### PR TITLE
aie2p: add AIE2P NPU plugin with GEMM kernels

### DIFF
--- a/include/mim/plug/aie2p/phase/lower_aie2p.h
+++ b/include/mim/plug/aie2p/phase/lower_aie2p.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <absl/container/flat_hash_map.h>
+
+#include <mim/phase.h>
+
+namespace mim::plug::aie2p::phase {
+
+/// Lowers AIE2P intrinsic axioms to CPS-wrapped LLVM intrinsic calls.
+/// Uses a map-based design: adding a new intrinsic = 1 line in the map + 1 line in .mim.
+class LowerAIE2P : public RWPhase {
+public:
+    LowerAIE2P(World& world, flags_t annex)
+        : RWPhase(world, annex) {}
+
+    const Def* rewrite_imm_App(const App*) final;
+
+private:
+    const Def* lower_to_cps_intrinsic(const Def* arg_rewritten, const Def* dom, const Def* ret, const char* llvm_name);
+
+    using IntrinsicMap = absl::flat_hash_map<flags_t, const char*>;
+    static const IntrinsicMap intrinsic_names_;
+
+    absl::flat_hash_map<flags_t, const Def*> wrapped_cache_;
+};
+
+} // namespace mim::plug::aie2p::phase

--- a/lit/aie2p/clb.mim
+++ b/lit/aie2p/clb.mim
@@ -1,0 +1,15 @@
+// RUN: rm -f %t.ll
+// RUN: %mim %s --output-ll %t.ll
+// RUN: FileCheck %s < %t.ll
+
+plugin aie2p;
+import core;
+import compile;
+import opt;
+import aie2p;
+
+fun extern main(x: I32): I32 =
+    let y = %aie2p.clb (x);
+    return y;
+
+// CHECK: call i32 @llvm.aie2p.clb(i32

--- a/lit/aie2p/coreid.mim
+++ b/lit/aie2p/coreid.mim
@@ -1,0 +1,15 @@
+// RUN: rm -f %t.ll
+// RUN: %mim %s --output-ll %t.ll
+// RUN: FileCheck %s < %t.ll
+
+plugin aie2p;
+import core;
+import compile;
+import opt;
+import aie2p;
+
+fun extern main(x: I32): I32 =
+    let y = %aie2p.get_coreid ();
+    return y;
+
+// CHECK: call i32 @llvm.aie2p.get.coreid(

--- a/lit/aie2p/gemm_tile.mim
+++ b/lit/aie2p/gemm_tile.mim
@@ -1,0 +1,36 @@
+plugin aie2p;
+import core;
+import compile;
+import opt;
+import aie2p;
+
+let K_nat = ⊤:Nat;
+
+con extern gemm_tile [
+    mem: %mem.M 0,
+    A: %mem.Ptr («4; «32; I16»», 0),
+    B: %mem.Ptr («4; «32; I16»», 0),
+    C_out: %mem.Ptr («16; I32», 0),
+    shift: I32,
+    round: I32,
+    return: Cn [%mem.M 0]
+] =
+    let zero_acc = ‹16; 0:I64›;
+
+    %affine.For k_body k_exit (0I32, 4I32, 1I32, (mem, zero_acc))
+    where
+        con k_body [k: I32, [mem: %mem.M 0, acc: «16; I64»], continue: Cn [%mem.M 0, «16; I64»]] =
+            let a_lea = %mem.lea (A, %core.conv.u K_nat k);
+            let (mem, a_vec) = %mem.load (mem, a_lea);
+            let b_lea = %mem.lea (B, %core.conv.u K_nat k);
+            let (mem, b_vec) = %mem.load (mem, b_lea);
+            // conf=90: mac_elem_16_2 unsigned (amode=1, bmode=3, variant=2)
+            // C[i] += A[i] * B[i] for i=0..15 (element-wise, 16-lane)
+            let new_acc = %aie2p.mac_i16_i64 (a_vec, b_vec, acc, 90I32);
+            continue (mem, new_acc);
+
+        con k_exit [mem: %mem.M 0, acc: «16; I64»] =
+            let result = %aie2p.srs_i32_16 (acc, shift, round);
+            let mem = %mem.store (mem, C_out, result);
+            return (mem);
+    end;

--- a/lit/aie2p/iron/Makefile
+++ b/lit/aie2p/iron/Makefile
@@ -1,0 +1,96 @@
+# Build pipeline: MimIR GEMM kernel → IRON NPU xclbin
+#
+# Prerequisites:
+#   - MimIR built at MIMIR_BUILD (default: ../../../build)
+#   - Peano (llvm-aie) installed via ironenv or at PEANO_DIR
+#   - ironenv activated for design.mlir and xclbin steps
+#
+# Usage:
+#   make                    # full build → build/final.xclbin (element-wise MAC)
+#   make matmul             # full build → build/final_matmul.xclbin (mac_4x4x8)
+#   make build/gemm_tile.ll # MimIR → LLVM IR only (no ironenv needed)
+#   make build/gemm_tile.o  # + Peano cross-compile (no ironenv needed)
+#   make clean
+
+MIMIR_BUILD ?= ../../../build
+PEANO_DIR   ?= $(shell python3 -c "import llvm_aie; print(llvm_aie.get_install_dir())" 2>/dev/null)
+
+.PHONY: all matmul tiled clean check-peano
+
+all: build/final.xclbin
+
+matmul: build/final_matmul.xclbin
+
+tiled: build/final_32x32x32.xclbin
+
+# === Element-wise MAC kernel (existing) ===
+
+# Step 1: MimIR → LLVM IR
+build/gemm_tile.ll: gemm_tile_iron.mim | build
+	$(MIMIR_BUILD)/bin/mim $< --output-ll $@
+
+# Step 2: LLVM IR → AIE2P ELF object (Peano cross-compiler)
+build/gemm_tile.o: build/gemm_tile.ll | check-peano
+	$(PEANO_DIR)/bin/clang++ -c -O2 --target=aie2p-none-unknown-elf -x ir $< -o $@ -Wno-override-module
+
+# Step 3: IRON Python → MLIR (requires ironenv)
+build/design.mlir: design.py | build
+	python3 $< > $@
+
+# Step 4: MLIR + kernel .o → xclbin + DMA instructions (requires ironenv + aiecc.py)
+build/final.xclbin: build/design.mlir build/gemm_tile.o
+	cd build && aiecc.py --alloc-scheme=basic-sequential \
+		--aie-generate-xclbin --no-compile-host --xclbin-name=final.xclbin \
+		--no-xchesscc --no-xbridge --peano $(PEANO_DIR) \
+		--aie-generate-npu-insts --npu-insts-name=insts.txt \
+		design.mlir
+
+# === Matmul MAC kernel (mac_4x4x8) ===
+
+build/gemm_tile_matmul.ll: gemm_tile_matmul.mim | build
+	$(MIMIR_BUILD)/bin/mim $< --output-ll $@
+
+build/gemm_tile_matmul.o: build/gemm_tile_matmul.ll | check-peano
+	$(PEANO_DIR)/bin/clang++ -c -O2 --target=aie2p-none-unknown-elf -x ir $< -o $@ -Wno-override-module
+
+build/design_matmul.mlir: design_matmul.py | build
+	python3 $< > $@
+
+build/final_matmul.xclbin: build/design_matmul.mlir build/gemm_tile_matmul.o
+	cd build && cp gemm_tile_matmul.o gemm_tile.o && \
+	aiecc.py --alloc-scheme=basic-sequential \
+		--aie-generate-xclbin --no-compile-host --xclbin-name=final_matmul.xclbin \
+		--no-xchesscc --no-xbridge --peano $(PEANO_DIR) \
+		--aie-generate-npu-insts --npu-insts-name=insts_matmul.txt \
+		design_matmul.mlir
+
+# === 32x32x32 tiled matmul ===
+
+build/gemm_tile_32x32x32.ll: gemm_tile_32x32x32.mim | build
+	$(MIMIR_BUILD)/bin/mim $< --output-ll $@
+
+build/gemm_tile_32x32x32.o: build/gemm_tile_32x32x32.ll | check-peano
+	$(PEANO_DIR)/bin/clang++ -c -O2 --target=aie2p-none-unknown-elf -x ir $< -o $@ -Wno-override-module
+
+build/design_32x32x32.mlir: design_32x32x32.py | build
+	python3 $< > $@
+
+build/final_32x32x32.xclbin: build/design_32x32x32.mlir build/gemm_tile_32x32x32.o
+	cd build && cp gemm_tile_32x32x32.o gemm_tile.o && \
+	aiecc.py --alloc-scheme=basic-sequential \
+		--aie-generate-xclbin --no-compile-host --xclbin-name=final_32x32x32.xclbin \
+		--no-xchesscc --no-xbridge --peano $(PEANO_DIR) \
+		--aie-generate-npu-insts --npu-insts-name=insts_32x32x32.txt \
+		design_32x32x32.mlir
+
+build:
+	mkdir -p build
+
+check-peano:
+	@if [ -z "$(PEANO_DIR)" ] || [ ! -d "$(PEANO_DIR)" ]; then \
+		echo "Error: PEANO_DIR not found. Activate ironenv or set PEANO_DIR."; \
+		exit 1; \
+	fi
+
+clean:
+	rm -rf build

--- a/lit/aie2p/iron/benchmark.py
+++ b/lit/aie2p/iron/benchmark.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Benchmark: MimIR vs mlir-aie reference for 32x32x32 single-core i16 GEMM."""
+
+import argparse
+import numpy as np
+import time
+import sys
+import os
+
+def run_kernel(xclbin_path, instr_path, a_buf, b_buf, c_buf, warmup=10, iters=100):
+    """Run a kernel and return latencies in microseconds."""
+    import pyxrt as xrt
+
+    with open(instr_path, "r") as f:
+        instr_text = f.read().split("\n")
+        instr_text = [l for l in instr_text if l != ""]
+        instr_v = np.array([int(i, 16) for i in instr_text], dtype=np.uint32)
+
+    device = xrt.device(0)
+    xclbin = xrt.xclbin(xclbin_path)
+    device.register_xclbin(xclbin)
+    context = xrt.hw_context(device, xclbin.get_uuid())
+
+    kernel = xrt.kernel(context, "MLIR_AIE")
+
+    bo_instr = xrt.bo(device, len(instr_v) * 4, xrt.bo.cacheable, kernel.group_id(1))
+    bo_a = xrt.bo(device, a_buf.nbytes, xrt.bo.host_only, kernel.group_id(3))
+    bo_b = xrt.bo(device, b_buf.nbytes, xrt.bo.host_only, kernel.group_id(4))
+    bo_c = xrt.bo(device, c_buf.nbytes, xrt.bo.host_only, kernel.group_id(5))
+
+    bo_instr.write(instr_v, 0)
+    bo_instr.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_DIR_TO_DEVICE)
+    bo_a.write(a_buf, 0)
+    bo_a.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_DIR_TO_DEVICE)
+    bo_b.write(b_buf, 0)
+    bo_b.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_DIR_TO_DEVICE)
+
+    # Warmup
+    for _ in range(warmup):
+        bo_c.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_DIR_TO_DEVICE)
+        kernel(bo_instr, len(instr_v), bo_a, bo_b, bo_c)
+        bo_c.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_DIR_FROM_DEVICE)
+
+    # Timed runs
+    latencies = []
+    for _ in range(iters):
+        bo_c.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_DIR_TO_DEVICE)
+        t0 = time.perf_counter()
+        kernel(bo_instr, len(instr_v), bo_a, bo_b, bo_c)
+        bo_c.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_DIR_FROM_DEVICE)
+        t1 = time.perf_counter()
+        latencies.append((t1 - t0) * 1e6)
+
+    c_out = np.zeros_like(c_buf)
+    bo_c.read(c_out, 0)
+    return latencies, c_out
+
+
+def pack_a_subtiles(A, M=32, K=32, tile_m=4, tile_k=4):
+    """Pack A (M×K i16) into sub-tiles of «16; I32» (4×4 i16 packed as 16 i32)."""
+    rows = M // tile_m
+    cols = K // tile_k
+    # each sub-tile: 4×4 i16 → 8 i32 → padded to 16 i32 (only first 8 used by hardware)
+    packed = np.zeros(rows * cols * 16, dtype=np.int32)
+    for r in range(rows):
+        for c in range(cols):
+            block = A[r*tile_m:(r+1)*tile_m, c*tile_k:(c+1)*tile_k].astype(np.int16)
+            flat16 = block.flatten()
+            # pack pairs of i16 into i32
+            flat32 = np.zeros(8, dtype=np.int32)
+            for j in range(8):
+                lo = int(flat16[2*j]) & 0xFFFF
+                hi = int(flat16[2*j+1]) & 0xFFFF
+                flat32[j] = lo | (hi << 16)
+            idx = (r * cols + c) * 16
+            packed[idx:idx+8] = flat32
+    return packed
+
+
+def pack_b_subtiles(B, K=32, N=32, tile_k=4, tile_n=8):
+    """Pack B (K×N i16) into sub-tiles of «32; I16»."""
+    rows = K // tile_k
+    cols = N // tile_n
+    packed = np.zeros(rows * cols * 32, dtype=np.int16)
+    for r in range(rows):
+        for c in range(cols):
+            block = B[r*tile_k:(r+1)*tile_k, c*tile_n:(c+1)*tile_n].astype(np.int16)
+            idx = (r * cols + c) * 32
+            packed[idx:idx+32] = block.flatten()
+    return packed
+
+
+def unpack_c_subtiles(c_flat, M=32, N=32, tile_m=4, tile_n=8):
+    """Unpack C sub-tiles «32; I16» back to M×N matrix."""
+    rows = M // tile_m
+    cols = N // tile_n
+    C = np.zeros((M, N), dtype=np.int16)
+    for r in range(rows):
+        for c in range(cols):
+            idx = (r * cols + c) * 32
+            block = c_flat[idx:idx+32].reshape(tile_m, tile_n)
+            C[r*tile_m:(r+1)*tile_m, c*tile_n:(c+1)*tile_n] = block
+    return C
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Benchmark MimIR vs mlir-aie 32x32x32 GEMM")
+    parser.add_argument("--mimir-xclbin", required=True, help="MimIR xclbin path")
+    parser.add_argument("--mimir-instr", required=True, help="MimIR instr path")
+    parser.add_argument("--ref-xclbin", default=None, help="mlir-aie reference xclbin path")
+    parser.add_argument("--ref-instr", default=None, help="mlir-aie reference instr path")
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--iters", type=int, default=100)
+    args = parser.parse_args()
+
+    M, K, N = 32, 32, 32
+    FLOPS = 2 * M * K * N  # 65536
+
+    # All-ones input
+    A = np.ones((M, K), dtype=np.int16)
+    B = np.ones((K, N), dtype=np.int16)
+
+    # === MimIR kernel ===
+    print(f"=== MimIR 32x32x32 GEMM (warmup={args.warmup}, iters={args.iters}) ===")
+    a_packed = pack_a_subtiles(A).view(np.uint8)
+    b_packed = pack_b_subtiles(B).view(np.uint8)
+    c_buf = np.zeros(M // 4 * N // 8 * 32, dtype=np.int16).view(np.uint8)
+
+    mimir_lats, c_raw = run_kernel(
+        args.mimir_xclbin, args.mimir_instr,
+        a_packed, b_packed, c_buf,
+        warmup=args.warmup, iters=args.iters
+    )
+    c_mimir = unpack_c_subtiles(c_raw.view(np.int16))
+    expected = (A.astype(np.int32) @ B.astype(np.int32)).astype(np.int16)
+    mimir_correct = np.array_equal(c_mimir, expected)
+
+    avg_m = np.mean(mimir_lats)
+    min_m = np.min(mimir_lats)
+    max_m = np.max(mimir_lats)
+    print(f"  Avg: {avg_m:.1f} us  ({FLOPS/avg_m/1000:.3f} GFLOPS)")
+    print(f"  Min: {min_m:.1f} us  ({FLOPS/min_m/1000:.3f} GFLOPS)")
+    print(f"  Max: {max_m:.1f} us")
+    print(f"  Correct: {mimir_correct}")
+
+    # === mlir-aie reference ===
+    if args.ref_xclbin and args.ref_instr:
+        print(f"\n=== mlir-aie reference 32x32x32 GEMM ===")
+        # The reference uses row-major i16 layout directly
+        a_ref = A.flatten().view(np.uint8)
+        b_ref = B.flatten().view(np.uint8)
+        c_ref_buf = np.zeros(M * N, dtype=np.int32).view(np.uint8)
+
+        ref_lats, c_ref_raw = run_kernel(
+            args.ref_xclbin, args.ref_instr,
+            a_ref, b_ref, c_ref_buf,
+            warmup=args.warmup, iters=args.iters
+        )
+        c_ref = c_ref_raw.view(np.int32).reshape(M, N)
+        ref_correct = np.array_equal(c_ref, A.astype(np.int32) @ B.astype(np.int32))
+
+        avg_r = np.mean(ref_lats)
+        min_r = np.min(ref_lats)
+        max_r = np.max(ref_lats)
+        print(f"  Avg: {avg_r:.1f} us  ({FLOPS/avg_r/1000:.3f} GFLOPS)")
+        print(f"  Min: {min_r:.1f} us  ({FLOPS/min_r/1000:.3f} GFLOPS)")
+        print(f"  Max: {max_r:.1f} us")
+        print(f"  Correct: {ref_correct}")
+
+        print(f"\n=== Comparison ===")
+        print(f"  MimIR avg:    {avg_m:.1f} us")
+        print(f"  mlir-aie avg: {avg_r:.1f} us")
+        print(f"  Ratio:        {avg_m/avg_r:.2f}x (lower is better for MimIR)")
+    else:
+        print("\nNo reference xclbin provided. Use --ref-xclbin and --ref-instr to compare.")
+
+
+if __name__ == "__main__":
+    os.chdir(os.path.dirname(os.path.abspath(__file__)))
+    main()

--- a/lit/aie2p/iron/design.py
+++ b/lit/aie2p/iron/design.py
@@ -1,0 +1,61 @@
+"""IRON design for single-core AIE2P GEMM tile kernel.
+
+Generates MLIR for a minimal NPU2 design that:
+  - Transfers one A tile (4x32 i16) and one B tile (4x32 i16) from host to compute
+  - Calls the MimIR-compiled gemm_tile kernel
+  - Transfers one C tile (16 i32) back to host
+
+Usage (requires ironenv):
+  python3 design.py > build/design.mlir
+"""
+
+import numpy as np
+
+from aie.iron import Kernel, ObjectFifo, Program, Runtime, Worker
+from aie.iron.placers import SequentialPlacer
+from aie.iron.device import NPU2Col1
+
+# --- Tile buffer types (what the kernel sees) ---
+a_ty = np.ndarray[(4, 32), np.dtype[np.int16]]
+b_ty = np.ndarray[(4, 32), np.dtype[np.int16]]
+c_ty = np.ndarray[(16,), np.dtype[np.int32]]
+
+# --- Host buffer types (flat 1D for DMA) ---
+A_ty = np.ndarray[(4 * 32,), np.dtype[np.int16]]
+B_ty = np.ndarray[(4 * 32,), np.dtype[np.int16]]
+C_ty = np.ndarray[(16,), np.dtype[np.int32]]
+
+# --- Kernel declaration ---
+# Name must match the exported symbol in the .o file.
+gemm_kernel = Kernel("gemm_tile", "gemm_tile.o", [a_ty, b_ty, c_ty])
+
+# --- ObjectFifos: host <-> compute tile ---
+of_a = ObjectFifo(a_ty, name="inA")
+of_b = ObjectFifo(b_ty, name="inB")
+of_c = ObjectFifo(c_ty, name="outC")
+
+
+# --- Worker: acquire tiles, call kernel, release ---
+def core_fn(of_a, of_b, of_c, kernel):
+    elem_a = of_a.acquire(1)
+    elem_b = of_b.acquire(1)
+    elem_c = of_c.acquire(1)
+    kernel(elem_a, elem_b, elem_c)
+    of_a.release(1)
+    of_b.release(1)
+    of_c.release(1)
+
+
+worker = Worker(core_fn, [of_a.cons(), of_b.cons(), of_c.prod(), gemm_kernel])
+
+# --- Runtime DMA sequence ---
+rt = Runtime()
+with rt.sequence(A_ty, B_ty, C_ty) as (A, B, C):
+    rt.start(worker)
+    rt.fill(of_a.prod(), A)
+    rt.fill(of_b.prod(), B)
+    rt.drain(of_c.cons(), C, wait=True)
+
+# --- Resolve and emit MLIR ---
+module = Program(NPU2Col1(), rt).resolve_program(SequentialPlacer())
+print(module)

--- a/lit/aie2p/iron/design_32x32x32.py
+++ b/lit/aie2p/iron/design_32x32x32.py
@@ -1,0 +1,64 @@
+"""IRON design for single-core AIE2P 32x32x32 tiled GEMM kernel using mac_4x4x8.
+
+Generates MLIR for a minimal NPU2 design that:
+  - Transfers A (64 sub-tiles of 16 i32 = 4096 bytes) from host to compute
+  - Transfers B (32 sub-tiles of 32 i16 = 2048 bytes) from host to compute
+  - Calls the MimIR-compiled gemm_tile kernel (triple-nested loops, 256 MAC calls)
+  - Transfers C (32 sub-tiles of 32 i16 = 2048 bytes) back to host
+
+Usage (requires ironenv):
+  python3 design_32x32x32.py > build/design_32x32x32.mlir
+"""
+
+import numpy as np
+
+from aie.iron import Kernel, ObjectFifo, Program, Runtime, Worker
+from aie.iron.placers import SequentialPlacer
+from aie.iron.device import NPU2Col1
+
+# --- Tile buffer types (what the kernel sees) ---
+# A: 64 sub-tiles (rowA=8 × colA=8), each 16 i32 (= 4×4 i16 packed as 16 i32)
+a_ty = np.ndarray[(64, 16), np.dtype[np.int32]]
+# B: 32 sub-tiles (colA=8 × colB=4), each 32 i16 (= 4×8 i16)
+b_ty = np.ndarray[(32, 32), np.dtype[np.int16]]
+# C: 32 sub-tiles (rowA=8 × colB=4), each 32 i16 (= 4×8 i16 output)
+c_ty = np.ndarray[(32, 32), np.dtype[np.int16]]
+
+# --- Host buffer types (flat 1D for DMA) ---
+A_ty = np.ndarray[(64 * 16,), np.dtype[np.int32]]   # 1024 i32
+B_ty = np.ndarray[(32 * 32,), np.dtype[np.int16]]   # 1024 i16
+C_ty = np.ndarray[(32 * 32,), np.dtype[np.int16]]   # 1024 i16
+
+# --- Kernel declaration ---
+gemm_kernel = Kernel("gemm_tile", "gemm_tile.o", [a_ty, b_ty, c_ty])
+
+# --- ObjectFifos: host <-> compute tile ---
+of_a = ObjectFifo(a_ty, name="inA")
+of_b = ObjectFifo(b_ty, name="inB")
+of_c = ObjectFifo(c_ty, name="outC")
+
+
+# --- Worker: acquire tiles, call kernel, release ---
+def core_fn(of_a, of_b, of_c, kernel):
+    elem_a = of_a.acquire(1)
+    elem_b = of_b.acquire(1)
+    elem_c = of_c.acquire(1)
+    kernel(elem_a, elem_b, elem_c)
+    of_a.release(1)
+    of_b.release(1)
+    of_c.release(1)
+
+
+worker = Worker(core_fn, [of_a.cons(), of_b.cons(), of_c.prod(), gemm_kernel])
+
+# --- Runtime DMA sequence ---
+rt = Runtime()
+with rt.sequence(A_ty, B_ty, C_ty) as (A, B, C):
+    rt.start(worker)
+    rt.fill(of_a.prod(), A)
+    rt.fill(of_b.prod(), B)
+    rt.drain(of_c.cons(), C, wait=True)
+
+# --- Resolve and emit MLIR ---
+module = Program(NPU2Col1(), rt).resolve_program(SequentialPlacer())
+print(module)

--- a/lit/aie2p/iron/design_matmul.py
+++ b/lit/aie2p/iron/design_matmul.py
@@ -1,0 +1,64 @@
+"""IRON design for single-core AIE2P GEMM tile kernel using mac_4x4x8 matmul.
+
+Generates MLIR for a minimal NPU2 design that:
+  - Transfers one A tile (4x16 i32 = K x «16; I32») from host to compute
+  - Transfers one B tile (4x32 i16 = K x «32; I16») from host to compute
+  - Calls the MimIR-compiled gemm_tile matmul kernel
+  - Transfers one C tile (32 i16 = «32; I16») back to host
+
+Usage (requires ironenv):
+  python3 design_matmul.py > build/design_matmul.mlir
+"""
+
+import numpy as np
+
+from aie.iron import Kernel, ObjectFifo, Program, Runtime, Worker
+from aie.iron.placers import SequentialPlacer
+from aie.iron.device import NPU2Col1
+
+# --- Tile buffer types (what the kernel sees) ---
+# A: K=4 rows of 16 i32 (each row = 32 i16 packed as 16 i32, 64 bytes)
+a_ty = np.ndarray[(4, 16), np.dtype[np.int32]]
+# B: K=4 rows of 32 i16 (each row = 32 i16, 64 bytes)
+b_ty = np.ndarray[(4, 32), np.dtype[np.int16]]
+# C: 32 i16 output (64 bytes)
+c_ty = np.ndarray[(32,), np.dtype[np.int16]]
+
+# --- Host buffer types (flat 1D for DMA) ---
+A_ty = np.ndarray[(4 * 16,), np.dtype[np.int32]]
+B_ty = np.ndarray[(4 * 32,), np.dtype[np.int16]]
+C_ty = np.ndarray[(32,), np.dtype[np.int16]]
+
+# --- Kernel declaration ---
+gemm_kernel = Kernel("gemm_tile", "gemm_tile.o", [a_ty, b_ty, c_ty])
+
+# --- ObjectFifos: host <-> compute tile ---
+of_a = ObjectFifo(a_ty, name="inA")
+of_b = ObjectFifo(b_ty, name="inB")
+of_c = ObjectFifo(c_ty, name="outC")
+
+
+# --- Worker: acquire tiles, call kernel, release ---
+def core_fn(of_a, of_b, of_c, kernel):
+    elem_a = of_a.acquire(1)
+    elem_b = of_b.acquire(1)
+    elem_c = of_c.acquire(1)
+    kernel(elem_a, elem_b, elem_c)
+    of_a.release(1)
+    of_b.release(1)
+    of_c.release(1)
+
+
+worker = Worker(core_fn, [of_a.cons(), of_b.cons(), of_c.prod(), gemm_kernel])
+
+# --- Runtime DMA sequence ---
+rt = Runtime()
+with rt.sequence(A_ty, B_ty, C_ty) as (A, B, C):
+    rt.start(worker)
+    rt.fill(of_a.prod(), A)
+    rt.fill(of_b.prod(), B)
+    rt.drain(of_c.cons(), C, wait=True)
+
+# --- Resolve and emit MLIR ---
+module = Program(NPU2Col1(), rt).resolve_program(SequentialPlacer())
+print(module)

--- a/lit/aie2p/iron/gemm_tile_32x32x32.mim
+++ b/lit/aie2p/iron/gemm_tile_32x32x32.mim
@@ -1,0 +1,75 @@
+plugin aie2p;
+import core;
+import compile;
+import opt;
+import aie2p;
+
+let K_nat = ⊤:Nat;
+
+// 32x32x32 tiled GEMM kernel using mac_4x4x8 (non-blocked).
+//
+// Sub-tile layout (linear, row-major blocks):
+//   A: 64 sub-tiles (rowA=8 × colA=8), each «16; I32» (4×4 i16 packed as 16 i32)
+//   B: 32 sub-tiles (colA=8 × colB=4), each «32; I16» (4×8 i16)
+//   C: 32 sub-tiles (rowA=8 × colB=4), each «32; I16» (4×8 i16 output)
+//
+// Non-blocked: 1 accumulator per k-loop
+//   for z = 0..8 (rowA):
+//     for j = 0..4 (colB):
+//       acc = zero
+//       for k = 0..8 (colA):
+//         a = A[z*8+k], b = B[k*4+j]
+//         acc = mac(a, b, acc, 26)
+//       C[z*4+j] = srs(acc)
+//
+// 256 mac_4x4x8 calls, 65536 FLOPs, 512 loads
+con extern gemm_tile [
+    mem: %mem.M 0,
+    A: %mem.Ptr («64; «16; I32»», 0),
+    B: %mem.Ptr («32; «32; I16»», 0),
+    C_out: %mem.Ptr («32; «32; I16»», 0),
+    return: Cn [%mem.M 0]
+] =
+    // z-loop: 0..8 (rowA)
+    %affine.For z_body z_exit (0I32, 8I32, 1I32, mem)
+    where
+        con z_body [z: I32, mem: %mem.M 0, cont_z: Cn [%mem.M 0]] =
+            // j-loop: 0..4 (colB)
+            %affine.For j_body j_exit (0I32, 4I32, 1I32, mem)
+            where
+                con j_body [j: I32, mem: %mem.M 0, cont_j: Cn [%mem.M 0]] =
+                    let zero_acc = ‹32; 0:I64›;
+                    // k-loop: 0..8, state = (mem, acc)
+                    %affine.For k_body k_exit (0I32, 8I32, 1I32, (mem, zero_acc))
+                    where
+                        con k_body [k: I32,
+                            [mem: %mem.M 0, acc: «32; I64»],
+                            cont_k: Cn [%mem.M 0, «32; I64»]
+                        ] =
+                            // A load: a = A[z*8+k]
+                            let a_idx = %core.wrap.add 0 (%core.wrap.mul 0 (z, 8I32), k);
+                            let a_lea = %mem.lea (A, %core.conv.u K_nat a_idx);
+                            let (mem, a) = %mem.load (mem, a_lea);
+                            // B load: b = B[k*4+j]
+                            let b_idx = %core.wrap.add 0 (%core.wrap.mul 0 (k, 4I32), j);
+                            let b_lea = %mem.lea (B, %core.conv.u K_nat b_idx);
+                            let (mem, b) = %mem.load (mem, b_lea);
+                            // MAC
+                            let new_acc = %aie2p.mac_4x4x8 (a, b, acc, 26I32);
+                            cont_k (mem, new_acc);
+
+                        con k_exit [mem: %mem.M 0, acc: «32; I64»] =
+                            // SRS accumulator → i16 vector
+                            let result = %aie2p.srs_i16_32 (acc, 0I32, 0I32);
+                            // Store to C[z*4+j]
+                            let c_idx = %core.wrap.add 0 (%core.wrap.mul 0 (z, 4I32), j);
+                            let c_lea = %mem.lea (C_out, %core.conv.u K_nat c_idx);
+                            let mem = %mem.store (mem, c_lea, result);
+                            cont_j (mem);
+                    end;
+
+                con j_exit [mem: %mem.M 0] = cont_z (mem);
+            end;
+
+        con z_exit [mem: %mem.M 0] = return (mem);
+    end;

--- a/lit/aie2p/iron/gemm_tile_32x32x32_blocked.mim
+++ b/lit/aie2p/iron/gemm_tile_32x32x32_blocked.mim
@@ -1,0 +1,107 @@
+plugin aie2p;
+import core;
+import compile;
+import opt;
+import aie2p;
+
+let K_nat = ⊤:Nat;
+
+// 32x32x32 tiled GEMM kernel using mac_4x4x8 — 2×2 register blocking.
+//
+// Sub-tile layout (same as non-blocked):
+//   A: 64 sub-tiles (rowA=8 × colA=8), each «16; I32»
+//   B: 32 sub-tiles (colA=8 × colB=4), each «32; I16»
+//   C: 32 sub-tiles (rowA=8 × colB=4), each «32; I16»
+//
+// 2×2 blocked: 4 accumulators per k-loop, 2× data reuse
+//   for z = 0..8 step 2 (rowA pairs):
+//     for j = 0..4 step 2 (colB pairs):
+//       acc00 = acc01 = acc10 = acc11 = zero
+//       for k = 0..8 (colA):
+//         a0 = A[(z+0)*8+k], a1 = A[(z+1)*8+k]
+//         b0 = B[k*4+(j+0)], b1 = B[k*4+(j+1)]
+//         acc00 = mac(a0, b0, acc00, 26)
+//         acc01 = mac(a0, b1, acc01, 26)
+//         acc10 = mac(a1, b0, acc10, 26)
+//         acc11 = mac(a1, b1, acc11, 26)
+//       C[(z+0)*4+(j+0)] = srs(acc00)
+//       C[(z+0)*4+(j+1)] = srs(acc01)
+//       C[(z+1)*4+(j+0)] = srs(acc10)
+//       C[(z+1)*4+(j+1)] = srs(acc11)
+//
+// 256 mac_4x4x8 calls, 65536 FLOPs, 256 loads (vs 512 non-blocked)
+con extern gemm_tile [
+    mem: %mem.M 0,
+    A: %mem.Ptr («64; «16; I32»», 0),
+    B: %mem.Ptr («32; «32; I16»», 0),
+    C_out: %mem.Ptr («32; «32; I16»», 0),
+    return: Cn [%mem.M 0]
+] =
+    // z-loop: 0..8 step 2 (rowA pairs)
+    %affine.For z_body z_exit (0I32, 8I32, 2I32, mem)
+    where
+        con z_body [z: I32, mem: %mem.M 0, cont_z: Cn [%mem.M 0]] =
+            // j-loop: 0..4 step 2 (colB pairs)
+            %affine.For j_body j_exit (0I32, 4I32, 2I32, mem)
+            where
+                con j_body [j: I32, mem: %mem.M 0, cont_j: Cn [%mem.M 0]] =
+                    let zero_acc = ‹32; 0:I64›;
+                    // k-loop: 0..8, state = (mem, acc00, acc01, acc10, acc11)
+                    %affine.For k_body k_exit (0I32, 8I32, 1I32, (mem, zero_acc, zero_acc, zero_acc, zero_acc))
+                    where
+                        con k_body [k: I32,
+                            [mem: %mem.M 0, acc00: «32; I64», acc01: «32; I64», acc10: «32; I64», acc11: «32; I64»],
+                            cont_k: Cn [%mem.M 0, «32; I64», «32; I64», «32; I64», «32; I64»]
+                        ] =
+                            // A loads: a0 = A[(z+0)*8+k], a1 = A[(z+1)*8+k]
+                            let z1 = %core.wrap.add 0 (z, 1I32);
+                            let a0_idx = %core.wrap.add 0 (%core.wrap.mul 0 (z, 8I32), k);
+                            let a1_idx = %core.wrap.add 0 (%core.wrap.mul 0 (z1, 8I32), k);
+                            let a0_lea = %mem.lea (A, %core.conv.u K_nat a0_idx);
+                            let (mem, a0) = %mem.load (mem, a0_lea);
+                            let a1_lea = %mem.lea (A, %core.conv.u K_nat a1_idx);
+                            let (mem, a1) = %mem.load (mem, a1_lea);
+                            // B loads: b0 = B[k*4+(j+0)], b1 = B[k*4+(j+1)]
+                            let j1 = %core.wrap.add 0 (j, 1I32);
+                            let b0_idx = %core.wrap.add 0 (%core.wrap.mul 0 (k, 4I32), j);
+                            let b1_idx = %core.wrap.add 0 (%core.wrap.mul 0 (k, 4I32), j1);
+                            let b0_lea = %mem.lea (B, %core.conv.u K_nat b0_idx);
+                            let (mem, b0) = %mem.load (mem, b0_lea);
+                            let b1_lea = %mem.lea (B, %core.conv.u K_nat b1_idx);
+                            let (mem, b1) = %mem.load (mem, b1_lea);
+                            // 4 MACs (2×2 blocking)
+                            let new_acc00 = %aie2p.mac_4x4x8 (a0, b0, acc00, 26I32);
+                            let new_acc01 = %aie2p.mac_4x4x8 (a0, b1, acc01, 26I32);
+                            let new_acc10 = %aie2p.mac_4x4x8 (a1, b0, acc10, 26I32);
+                            let new_acc11 = %aie2p.mac_4x4x8 (a1, b1, acc11, 26I32);
+                            cont_k (mem, new_acc00, new_acc01, new_acc10, new_acc11);
+
+                        con k_exit [mem: %mem.M 0, acc00: «32; I64», acc01: «32; I64», acc10: «32; I64», acc11: «32; I64»] =
+                            // SRS all 4 accumulators
+                            let r00 = %aie2p.srs_i16_32 (acc00, 0I32, 0I32);
+                            let r01 = %aie2p.srs_i16_32 (acc01, 0I32, 0I32);
+                            let r10 = %aie2p.srs_i16_32 (acc10, 0I32, 0I32);
+                            let r11 = %aie2p.srs_i16_32 (acc11, 0I32, 0I32);
+                            // Store C[(z+0)*4+(j+0..1)], C[(z+1)*4+(j+0..1)]
+                            let z1 = %core.wrap.add 0 (z, 1I32);
+                            let j1 = %core.wrap.add 0 (j, 1I32);
+                            let c00_idx = %core.wrap.add 0 (%core.wrap.mul 0 (z, 4I32), j);
+                            let c01_idx = %core.wrap.add 0 (%core.wrap.mul 0 (z, 4I32), j1);
+                            let c10_idx = %core.wrap.add 0 (%core.wrap.mul 0 (z1, 4I32), j);
+                            let c11_idx = %core.wrap.add 0 (%core.wrap.mul 0 (z1, 4I32), j1);
+                            let c00_lea = %mem.lea (C_out, %core.conv.u K_nat c00_idx);
+                            let c01_lea = %mem.lea (C_out, %core.conv.u K_nat c01_idx);
+                            let c10_lea = %mem.lea (C_out, %core.conv.u K_nat c10_idx);
+                            let c11_lea = %mem.lea (C_out, %core.conv.u K_nat c11_idx);
+                            let mem = %mem.store (mem, c00_lea, r00);
+                            let mem = %mem.store (mem, c01_lea, r01);
+                            let mem = %mem.store (mem, c10_lea, r10);
+                            let mem = %mem.store (mem, c11_lea, r11);
+                            cont_j (mem);
+                    end;
+
+                con j_exit [mem: %mem.M 0] = cont_z (mem);
+            end;
+
+        con z_exit [mem: %mem.M 0] = return (mem);
+    end;

--- a/lit/aie2p/iron/gemm_tile_iron.mim
+++ b/lit/aie2p/iron/gemm_tile_iron.mim
@@ -1,0 +1,36 @@
+plugin aie2p;
+import core;
+import compile;
+import opt;
+import aie2p;
+
+let K_nat = ⊤:Nat;
+
+// IRON-compatible kernel: 3 pointer args, no scalars.
+// Shift and round are hardcoded to 0 for IRON's Kernel() ABI.
+con extern gemm_tile [
+    mem: %mem.M 0,
+    A: %mem.Ptr («4; «32; I16»», 0),
+    B: %mem.Ptr («4; «32; I16»», 0),
+    C_out: %mem.Ptr («16; I32», 0),
+    return: Cn [%mem.M 0]
+] =
+    let zero_acc = ‹16; 0:I64›;
+
+    %affine.For k_body k_exit (0I32, 4I32, 1I32, (mem, zero_acc))
+    where
+        con k_body [k: I32, [mem: %mem.M 0, acc: «16; I64»], continue: Cn [%mem.M 0, «16; I64»]] =
+            let a_lea = %mem.lea (A, %core.conv.u K_nat k);
+            let (mem, a_vec) = %mem.load (mem, a_lea);
+            let b_lea = %mem.lea (B, %core.conv.u K_nat k);
+            let (mem, b_vec) = %mem.load (mem, b_lea);
+            // conf=90: mac_elem_16_2 unsigned (amode=1, bmode=3, variant=2)
+            // C[i] += A[i] * B[i] for i=0..15 (element-wise, 16-lane)
+            let new_acc = %aie2p.mac_i16_i64 (a_vec, b_vec, acc, 90I32);
+            continue (mem, new_acc);
+
+        con k_exit [mem: %mem.M 0, acc: «16; I64»] =
+            let result = %aie2p.srs_i32_16 (acc, 0I32, 0I32);
+            let mem = %mem.store (mem, C_out, result);
+            return (mem);
+    end;

--- a/lit/aie2p/iron/gemm_tile_matmul.mim
+++ b/lit/aie2p/iron/gemm_tile_matmul.mim
@@ -1,0 +1,40 @@
+plugin aie2p;
+import core;
+import compile;
+import opt;
+import aie2p;
+
+let K_nat = ⊤:Nat;
+
+// GEMM tile kernel using mac_4x4x8 (ACC2048 true matmul).
+// A: K x «16; I32» — each row is 32 i16 packed as 16 i32 (512 bits)
+// B: K x «32; I16» — each row is 32 i16 (512 bits)
+// C_out: «32; I16» — 32 i16 output (after SRS from ACC2048)
+//
+// Computes: acc = Σ_{k=0}^{K-1} mac_4x4x8(A[k], B[k], acc, conf=26)
+//           C = srs(acc)
+con extern gemm_tile [
+    mem: %mem.M 0,
+    A: %mem.Ptr («4; «16; I32»», 0),
+    B: %mem.Ptr («4; «32; I16»», 0),
+    C_out: %mem.Ptr («32; I16», 0),
+    return: Cn [%mem.M 0]
+] =
+    let zero_acc = ‹32; 0:I64›;
+
+    %affine.For k_body k_exit (0I32, 4I32, 1I32, (mem, zero_acc))
+    where
+        con k_body [k: I32, [mem: %mem.M 0, acc: «32; I64»], continue: Cn [%mem.M 0, «32; I64»]] =
+            let a_lea = %mem.lea (A, %core.conv.u K_nat k);
+            let (mem, a_vec) = %mem.load (mem, a_lea);
+            let b_lea = %mem.lea (B, %core.conv.u K_nat k);
+            let (mem, b_vec) = %mem.load (mem, b_lea);
+            // conf=26: unsigned mac_4x4_4x8 matmul
+            let new_acc = %aie2p.mac_4x4x8 (a_vec, b_vec, acc, 26I32);
+            continue (mem, new_acc);
+
+        con k_exit [mem: %mem.M 0, acc: «32; I64»] =
+            let result = %aie2p.srs_i16_32 (acc, 0I32, 0I32);
+            let mem = %mem.store (mem, C_out, result);
+            return (mem);
+    end;

--- a/lit/aie2p/iron/test.py
+++ b/lit/aie2p/iron/test.py
@@ -1,0 +1,141 @@
+"""Host test for AIE2P GEMM tile kernel on NPU hardware.
+
+Loads the xclbin and instruction binary, fills A and B with all-ones,
+runs the kernel, and verifies non-zero output.
+
+Usage:
+  python3 test.py -x build/final.xclbin -i build/insts.txt
+
+Requires: pyxrt (from /opt/xilinx/xrt/python/)
+"""
+
+import argparse
+import os
+import struct
+import sys
+import time
+
+import numpy as np
+
+# pyxrt lives at /opt/xilinx/xrt/python/ — ensure it's importable
+XRT_PYTHON = "/opt/xilinx/xrt/python"
+if XRT_PYTHON not in sys.path:
+    sys.path.insert(0, XRT_PYTHON)
+
+import pyxrt as xrt
+
+A_SIZE = 4 * 32  # 128 i16 values (256 bytes)
+B_SIZE = 4 * 32  # 128 i16 values (256 bytes)
+C_SIZE = 16      # 16 i32 values  (64 bytes)
+
+
+def load_instr_binary(filepath):
+    """Load DMA instruction sequence from binary file."""
+    size = os.path.getsize(filepath)
+    with open(filepath, "rb") as f:
+        return list(struct.unpack(f"{size // 4}I", f.read()))
+
+
+def load_instr_text(filepath):
+    """Load DMA instruction sequence from text file (one hex value per line)."""
+    with open(filepath, "r") as f:
+        return [int(line, 16) for line in f if line.strip()]
+
+
+def load_instructions(filepath):
+    """Auto-detect format and load instruction sequence."""
+    try:
+        return load_instr_text(filepath)
+    except (ValueError, UnicodeDecodeError):
+        return load_instr_binary(filepath)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="AIE2P GEMM tile NPU test")
+    parser.add_argument("-x", "--xclbin", required=True, help="Path to .xclbin")
+    parser.add_argument("-i", "--instr", required=True, help="Path to instruction file")
+    parser.add_argument("-k", "--kernel", default="MLIR_AIE", help="Kernel name")
+    args = parser.parse_args()
+
+    # Load instructions
+    instr_v = load_instructions(args.instr)
+    print(f"Loaded {len(instr_v)} instructions from {args.instr}")
+
+    # Set up XRT device and kernel
+    device = xrt.device(0)
+    xclbin = xrt.xclbin(args.xclbin)
+    device.register_xclbin(xclbin)
+    context = xrt.hw_context(device, xclbin.get_uuid())
+    xkernels = xclbin.get_kernels()
+    xkernel = [k for k in xkernels if args.kernel in k.get_name()][0]
+    kernel = xrt.kernel(context, xkernel.get_name())
+
+    # Allocate buffer objects
+    bo_instr = xrt.bo(device, len(instr_v) * 4, xrt.bo.cacheable, kernel.group_id(1))
+    bo_a = xrt.bo(device, A_SIZE * 2, xrt.bo.host_only, kernel.group_id(3))   # i16 = 2 bytes
+    bo_b = xrt.bo(device, B_SIZE * 2, xrt.bo.host_only, kernel.group_id(4))   # i16 = 2 bytes
+    bo_c = xrt.bo(device, C_SIZE * 4, xrt.bo.host_only, kernel.group_id(5))   # i32 = 4 bytes
+
+    # Fill inputs: all ones
+    buf_a = np.ones(A_SIZE, dtype=np.int16)
+    buf_b = np.ones(B_SIZE, dtype=np.int16)
+    bo_a.write(buf_a, 0)
+    bo_b.write(buf_b, 0)
+    bo_instr.write(np.array(instr_v, dtype=np.uint32), 0)
+
+    # Sync to device
+    bo_instr.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
+    bo_a.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
+    bo_b.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
+
+    # Warmup run
+    print("Warmup run...")
+    run = kernel(3, bo_instr, len(instr_v), bo_a, bo_b, bo_c)
+    r = run.wait()
+    assert r == xrt.ert_cmd_state.ERT_CMD_STATE_COMPLETED, f"Warmup failed with state: {r}"
+
+    # Re-sync buffers for timed run
+    bo_c.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE)
+    bo_instr.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
+    bo_a.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
+    bo_b.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
+
+    # Timed run
+    print("Timed run...")
+    t0 = time.perf_counter()
+    run = kernel(3, bo_instr, len(instr_v), bo_a, bo_b, bo_c)
+    r = run.wait()
+    t1 = time.perf_counter()
+    assert r == xrt.ert_cmd_state.ERT_CMD_STATE_COMPLETED, f"Kernel failed with state: {r}"
+    latency_us = (t1 - t0) * 1e6
+    macs = 2 * 4 * 16  # K=4, 16 lanes (element-wise MAC)
+    print(f"Latency: {latency_us:.1f} us, MACs: {macs}, GFLOPS: {macs / (1000 * latency_us):.6f}")
+
+    # Read back results
+    bo_c.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE)
+    buf_c = bo_c.read(C_SIZE * 4, 0)
+    result = np.frombuffer(buf_c, dtype=np.int32)
+
+    print(f"Output C[0:16]: {result}")
+
+    # Compute reference: element-wise MAC with conf=90 (mac_elem_16_2)
+    # C[i] = sum_{k=0}^{K-1} A[k][i] * B[k][i]  for i=0..15
+    # Only the first 16 elements of each 32-element vector are used.
+    K = 4
+    a_mat = buf_a.reshape(K, 32)
+    b_mat = buf_b.reshape(K, 32)
+    expected = np.zeros(C_SIZE, dtype=np.int32)
+    for k in range(K):
+        expected += (a_mat[k, :16].astype(np.int32) * b_mat[k, :16].astype(np.int32))
+
+    print(f"Expected:       {expected}")
+    if np.array_equal(result, expected):
+        print("PASS: output matches reference")
+    else:
+        print("FAIL: output mismatch")
+        print(f"  diff: {result - expected}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/lit/aie2p/iron/test_32x32x32.py
+++ b/lit/aie2p/iron/test_32x32x32.py
@@ -1,0 +1,233 @@
+"""Host test for AIE2P 32x32x32 tiled GEMM kernel on NPU hardware.
+
+Loads the xclbin and instruction binary, fills A and B with test patterns,
+runs the tiled matmul kernel, and verifies output.
+
+Sub-tile layout:
+  A: 64 sub-tiles (rowA=8 × colA=8), each 16 i32 (4×4 i16 packed as 16 i32)
+  B: 32 sub-tiles (colA=8 × colB=4), each 32 i16 (4×8 i16)
+  C: 32 sub-tiles (rowA=8 × colB=4), each 32 i16 (4×8 i16 output)
+
+The kernel performs 256 mac_4x4x8 calls (8×4×8 loop nest), 65536 FLOPs total.
+
+Usage:
+  python3 test_32x32x32.py -x build/final_32x32x32.xclbin -i build/insts_32x32x32.txt
+
+Requires: pyxrt (from /opt/xilinx/xrt/python/)
+"""
+
+import argparse
+import os
+import struct
+import sys
+import time
+
+import numpy as np
+
+# pyxrt lives at /opt/xilinx/xrt/python/ — ensure it's importable
+XRT_PYTHON = "/opt/xilinx/xrt/python"
+if XRT_PYTHON not in sys.path:
+    sys.path.insert(0, XRT_PYTHON)
+
+import pyxrt as xrt
+
+# Tile dimensions
+M, K, N = 32, 32, 32
+r, s, t = 4, 4, 8  # mac_4x4x8 microkernel shape
+rowA = M // r       # 8
+colA = K // s       # 8
+colB = N // t       # 4
+
+# Buffer sizes
+A_ELEMS = rowA * colA * 16   # 64 * 16 = 1024 i32
+B_ELEMS = colA * colB * 32   # 32 * 32 = 1024 i16
+C_ELEMS = rowA * colB * 32   # 32 * 32 = 1024 i16
+
+
+def load_instructions(filepath):
+    """Auto-detect format and load instruction sequence."""
+    try:
+        with open(filepath, "r") as f:
+            return [int(line, 16) for line in f if line.strip()]
+    except (ValueError, UnicodeDecodeError):
+        size = os.path.getsize(filepath)
+        with open(filepath, "rb") as f:
+            return list(struct.unpack(f"{size // 4}I", f.read()))
+
+
+def pack_a_subtiles(A_host):
+    """Pack a 32×32 i16 matrix into 64 sub-tiles of 16 i32 (4×4 i16 packed as i32).
+
+    Sub-tile [z*colA + k] holds rows z*4..z*4+3, cols k*4..k*4+3.
+    Each pair of consecutive i16 values is packed into one i32: low | (high << 16).
+    """
+    buf = np.zeros(A_ELEMS, dtype=np.int32)
+    for z in range(rowA):
+        for k in range(colA):
+            tile_idx = z * colA + k
+            block = A_host[z*r:(z+1)*r, k*s:(k+1)*s]  # 4×4 i16
+            # Flatten to 16 i16, pack pairs into 8 i32... but mac_4x4x8 takes 16 i32
+            # The hardware reads 512 bits = 16 i32. The 4×4 block is 16 i16 = 256 bits.
+            # Pack: each i32 holds one pair of i16 values
+            flat = block.flatten().astype(np.uint16)  # 16 i16
+            packed = np.zeros(16, dtype=np.int32)
+            for i in range(0, 16, 2):
+                packed[i // 2] = int(flat[i]) | (int(flat[i + 1]) << 16)
+            # Remaining 8 i32 are don't-care (zero)
+            buf[tile_idx * 16: tile_idx * 16 + 16] = packed
+    return buf
+
+
+def pack_b_subtiles(B_host):
+    """Pack a 32×32 i16 matrix into 32 sub-tiles of 32 i16 (4×8 blocks).
+
+    Sub-tile [k*colB + j] holds rows k*4..k*4+3, cols j*8..j*8+7.
+    """
+    buf = np.zeros(B_ELEMS, dtype=np.int16)
+    for k in range(colA):
+        for j in range(colB):
+            tile_idx = k * colB + j
+            block = B_host[k*s:(k+1)*s, j*t:(j+1)*t]  # 4×8 i16
+            buf[tile_idx * 32: tile_idx * 32 + 32] = block.flatten()
+    return buf
+
+
+def unpack_c_subtiles(buf_c):
+    """Unpack 32 sub-tiles of 32 i16 into a 32×32 i16 matrix.
+
+    Sub-tile [z*colB + j] holds rows z*4..z*4+3, cols j*8..j*8+7.
+    """
+    C_host = np.zeros((M, N), dtype=np.int16)
+    for z in range(rowA):
+        for j in range(colB):
+            tile_idx = z * colB + j
+            block = buf_c[tile_idx * 32: tile_idx * 32 + 32].reshape(r, t)
+            C_host[z*r:(z+1)*r, j*t:(j+1)*t] = block
+    return C_host
+
+
+def main():
+    parser = argparse.ArgumentParser(description="AIE2P 32x32x32 tiled GEMM NPU test")
+    parser.add_argument("-x", "--xclbin", required=True, help="Path to .xclbin")
+    parser.add_argument("-i", "--instr", required=True, help="Path to instruction file")
+    parser.add_argument("-k", "--kernel", default="MLIR_AIE", help="Kernel name")
+    parser.add_argument("--structured", action="store_true",
+                        help="Run structured test with sub-tile indexing verification")
+    parser.add_argument("--warmup", type=int, default=1, help="Number of warmup iterations")
+    parser.add_argument("--iters", type=int, default=1, help="Number of timed iterations")
+    args = parser.parse_args()
+
+    # Load instructions
+    instr_v = load_instructions(args.instr)
+    print(f"Loaded {len(instr_v)} instructions from {args.instr}")
+
+    # Set up XRT device and kernel
+    device = xrt.device(0)
+    xclbin = xrt.xclbin(args.xclbin)
+    device.register_xclbin(xclbin)
+    context = xrt.hw_context(device, xclbin.get_uuid())
+    xkernels = xclbin.get_kernels()
+    xkernel = [k for k in xkernels if args.kernel in k.get_name()][0]
+    kernel = xrt.kernel(context, xkernel.get_name())
+
+    # Allocate buffer objects
+    bo_instr = xrt.bo(device, len(instr_v) * 4, xrt.bo.cacheable, kernel.group_id(1))
+    bo_a = xrt.bo(device, A_ELEMS * 4, xrt.bo.host_only, kernel.group_id(3))   # i32 = 4 bytes
+    bo_b = xrt.bo(device, B_ELEMS * 2, xrt.bo.host_only, kernel.group_id(4))   # i16 = 2 bytes
+    bo_c = xrt.bo(device, C_ELEMS * 2, xrt.bo.host_only, kernel.group_id(5))   # i16 = 2 bytes
+
+    if args.structured:
+        print("=== Structured test (sub-tile indexing verification) ===")
+        # Create small-valued matrices to avoid i16 overflow
+        np.random.seed(42)
+        A_host = np.random.randint(0, 4, size=(M, K), dtype=np.int16)
+        B_host = np.random.randint(0, 4, size=(K, N), dtype=np.int16)
+        buf_a = pack_a_subtiles(A_host)
+        buf_b = pack_b_subtiles(B_host)
+        expected_full = A_host.astype(np.int32) @ B_host.astype(np.int32)
+        expected = expected_full.astype(np.int16)
+        print(f"A sample [0,:8]: {A_host[0,:8]}")
+        print(f"B sample [0,:8]: {B_host[0,:8]}")
+    else:
+        print("=== All-ones test ===")
+        # A: all i32 = 0x00010001 (two i16=1 packed per i32)
+        buf_a = np.full(A_ELEMS, 0x00010001, dtype=np.int32)
+        # B: all i16 = 1
+        buf_b = np.ones(B_ELEMS, dtype=np.int16)
+        # Expected: each output i16 = K_tile = 32
+        # (mac_4x4x8 contributes K_inner=4 per call, × colA=8 iterations in k-loop)
+        expected = np.full((M, N), K, dtype=np.int16)
+
+    bo_a.write(buf_a, 0)
+    bo_b.write(buf_b, 0)
+    bo_instr.write(np.array(instr_v, dtype=np.uint32), 0)
+
+    # Sync to device
+    bo_instr.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
+    bo_a.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
+    bo_b.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
+
+    # Warmup runs
+    print(f"Warmup ({args.warmup} iterations)...")
+    for _ in range(args.warmup):
+        run = kernel(3, bo_instr, len(instr_v), bo_a, bo_b, bo_c)
+        state = run.wait()
+        assert state == xrt.ert_cmd_state.ERT_CMD_STATE_COMPLETED, f"Warmup failed with state: {state}"
+
+    # 256 mac_4x4x8 calls, each: 4*4*8=128 MACs, ×2 for multiply-accumulate
+    total_flops = 2 * rowA * colB * colA * r * s * t  # 2 * 8 * 4 * 8 * 4 * 4 * 8 = 65536
+
+    # Timed runs
+    print(f"Timed runs ({args.iters} iterations)...")
+    zero_c = np.zeros(C_ELEMS * 2, dtype=np.uint8)
+    times_us = []
+    for i in range(args.iters):
+        bo_c.write(zero_c, 0)
+        bo_c.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
+        bo_instr.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
+        bo_a.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
+        bo_b.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
+        t0 = time.perf_counter()
+        run = kernel(3, bo_instr, len(instr_v), bo_a, bo_b, bo_c)
+        state = run.wait()
+        t1 = time.perf_counter()
+        assert state == xrt.ert_cmd_state.ERT_CMD_STATE_COMPLETED, f"Iteration {i} failed: {state}"
+        bo_c.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE)
+        times_us.append((t1 - t0) * 1e6)
+
+    avg_us = sum(times_us) / len(times_us)
+    min_us = min(times_us)
+    max_us = max(times_us)
+    print(f"\nAvg NPU matmul time: {avg_us:.1f} us")
+    print(f"Avg NPU gflops: {total_flops / (1000 * avg_us):.6f}")
+    print(f"\nMin NPU matmul time: {min_us:.1f} us")
+    print(f"Max NPU gflops: {total_flops / (1000 * min_us):.6f}")
+    print(f"\nMax NPU matmul time: {max_us:.1f} us")
+    print(f"Min NPU gflops: {total_flops / (1000 * max_us):.6f}")
+
+    # Read back results
+    bo_c.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE)
+    raw_c = bo_c.read(C_ELEMS * 2, 0)
+    result_flat = np.frombuffer(raw_c, dtype=np.int16).copy()
+    result = unpack_c_subtiles(result_flat)
+
+    print(f"Output C[0,:8]: {result[0,:8]}")
+    print(f"Expected[0,:8]: {expected[0,:8]}")
+
+    if np.array_equal(result, expected):
+        print("PASS: output matches reference")
+    else:
+        diff = result.astype(np.int32) - expected.astype(np.int32)
+        mismatches = np.count_nonzero(diff)
+        print(f"FAIL: {mismatches}/{M*N} elements mismatch")
+        print(f"  max abs diff: {np.max(np.abs(diff))}")
+        # Show first few mismatches
+        rows, cols = np.where(diff != 0)
+        for idx in range(min(10, len(rows))):
+            r_i, c_i = rows[idx], cols[idx]
+            print(f"  C[{r_i},{c_i}] = {result[r_i,c_i]}, expected {expected[r_i,c_i]}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/lit/aie2p/iron/test_matmul.py
+++ b/lit/aie2p/iron/test_matmul.py
@@ -1,0 +1,139 @@
+"""Host test for AIE2P GEMM tile kernel using mac_4x4x8 matmul on NPU hardware.
+
+Loads the xclbin and instruction binary, fills A and B with test patterns,
+runs the matmul kernel, and verifies output.
+
+The mac_4x4x8 intrinsic performs a 4x4x8 matmul (conf=26, unsigned):
+  A is 32 i16 values packed as 16 i32 (512 bits)
+  B is 32 i16 values (512 bits)
+  acc is v32i64 (ACC2048)
+
+Usage:
+  python3 test_matmul.py -x build/final.xclbin -i build/insts.txt
+
+Requires: pyxrt (from /opt/xilinx/xrt/python/)
+"""
+
+import argparse
+import os
+import struct
+import sys
+import time
+
+import numpy as np
+
+# pyxrt lives at /opt/xilinx/xrt/python/ — ensure it's importable
+XRT_PYTHON = "/opt/xilinx/xrt/python"
+if XRT_PYTHON not in sys.path:
+    sys.path.insert(0, XRT_PYTHON)
+
+import pyxrt as xrt
+
+K = 4          # number of MAC iterations
+A_ELEMS = K * 16   # 64 i32 values (= K * 16 packed i32, each holding 2 i16)
+B_ELEMS = K * 32   # 128 i16 values
+C_ELEMS = 32       # 32 i16 output values
+
+
+def load_instructions(filepath):
+    """Auto-detect format and load instruction sequence."""
+    try:
+        with open(filepath, "r") as f:
+            return [int(line, 16) for line in f if line.strip()]
+    except (ValueError, UnicodeDecodeError):
+        size = os.path.getsize(filepath)
+        with open(filepath, "rb") as f:
+            return list(struct.unpack(f"{size // 4}I", f.read()))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="AIE2P matmul GEMM tile NPU test")
+    parser.add_argument("-x", "--xclbin", required=True, help="Path to .xclbin")
+    parser.add_argument("-i", "--instr", required=True, help="Path to instruction file")
+    parser.add_argument("-k", "--kernel", default="MLIR_AIE", help="Kernel name")
+    args = parser.parse_args()
+
+    # Load instructions
+    instr_v = load_instructions(args.instr)
+    print(f"Loaded {len(instr_v)} instructions from {args.instr}")
+
+    # Set up XRT device and kernel
+    device = xrt.device(0)
+    xclbin = xrt.xclbin(args.xclbin)
+    device.register_xclbin(xclbin)
+    context = xrt.hw_context(device, xclbin.get_uuid())
+    xkernels = xclbin.get_kernels()
+    xkernel = [k for k in xkernels if args.kernel in k.get_name()][0]
+    kernel = xrt.kernel(context, xkernel.get_name())
+
+    # Allocate buffer objects
+    bo_instr = xrt.bo(device, len(instr_v) * 4, xrt.bo.cacheable, kernel.group_id(1))
+    bo_a = xrt.bo(device, A_ELEMS * 4, xrt.bo.host_only, kernel.group_id(3))   # i32 = 4 bytes
+    bo_b = xrt.bo(device, B_ELEMS * 2, xrt.bo.host_only, kernel.group_id(4))   # i16 = 2 bytes
+    bo_c = xrt.bo(device, C_ELEMS * 2, xrt.bo.host_only, kernel.group_id(5))   # i16 = 2 bytes
+
+    # Fill inputs: all ones
+    # A: 64 i32 values — each i32 packs two i16=1 values: 0x00010001 = 65537
+    buf_a = np.full(A_ELEMS, 0x00010001, dtype=np.int32)
+    # B: 128 i16 values — all ones
+    buf_b = np.ones(B_ELEMS, dtype=np.int16)
+    bo_a.write(buf_a, 0)
+    bo_b.write(buf_b, 0)
+    bo_instr.write(np.array(instr_v, dtype=np.uint32), 0)
+
+    # Sync to device
+    bo_instr.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
+    bo_a.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
+    bo_b.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
+
+    # Warmup run
+    print("Warmup run...")
+    run = kernel(3, bo_instr, len(instr_v), bo_a, bo_b, bo_c)
+    r = run.wait()
+    assert r == xrt.ert_cmd_state.ERT_CMD_STATE_COMPLETED, f"Warmup failed with state: {r}"
+
+    # Re-sync buffers for timed run
+    bo_c.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE)
+    bo_instr.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
+    bo_a.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
+    bo_b.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
+
+    # Timed run
+    print("Timed run...")
+    t0 = time.perf_counter()
+    run = kernel(3, bo_instr, len(instr_v), bo_a, bo_b, bo_c)
+    r = run.wait()
+    t1 = time.perf_counter()
+    assert r == xrt.ert_cmd_state.ERT_CMD_STATE_COMPLETED, f"Kernel failed with state: {r}"
+    latency_us = (t1 - t0) * 1e6
+    # mac_4x4x8: 4*4*8=128 MACs per call, K=4 iterations
+    macs = 2 * K * 4 * 4 * 8  # multiply-accumulate = 2 ops
+    print(f"Latency: {latency_us:.1f} us, MACs: {macs}, GFLOPS: {macs / (1000 * latency_us):.6f}")
+
+    # Read back results
+    bo_c.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE)
+    buf_c = bo_c.read(C_ELEMS * 2, 0)
+    result = np.frombuffer(buf_c, dtype=np.int16).copy()
+
+    print(f"Output C[0:32]: {result}")
+
+    # Compute reference: 4x4x8 matmul with all-ones
+    # mac_4x4x8 = M=4, K_inner=4, N=8 (4x4 * 4x8 = 4x8)
+    # C[i][j] = sum_{k=0}^{3} A[i][k] * B[k][j]
+    # For a single mac_4x4x8 with all-ones: C[i][j] = 4 (inner dim K_inner=4)
+    # Over K=4 outer iterations: C[i][j] = 4 * 4 = 16
+    # Output is 4x8 = 32 i16 values.
+    K_inner = 4  # matmul inner dimension
+    expected = np.full(C_ELEMS, K * K_inner, dtype=np.int16)
+
+    print(f"Expected:       {expected}")
+    if np.array_equal(result, expected):
+        print("PASS: output matches reference")
+    else:
+        print("FAIL: output mismatch")
+        print(f"  diff: {result.astype(np.int32) - expected.astype(np.int32)}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/lit/aie2p/mac.mim
+++ b/lit/aie2p/mac.mim
@@ -1,0 +1,16 @@
+// RUN: rm -f %t.ll
+// RUN: %mim %s --output-ll %t.ll
+// RUN: FileCheck %s < %t.ll
+
+plugin aie2p;
+import core;
+import compile;
+import opt;
+import aie2p;
+
+con extern mac_test(a: «32; I16», b: «32; I16», acc: «16; I64», conf: I32,
+                    return: Cn [«16; I64»]) =
+    let result = %aie2p.mac_i16_i64 (a, b, acc, conf);
+    return (result);
+
+// CHECK: call {{.*}} @llvm.aie2p.I512.I512.ACC1024.mac.conf(

--- a/lit/aie2p/mac_4x4x8.mim
+++ b/lit/aie2p/mac_4x4x8.mim
@@ -1,0 +1,16 @@
+// RUN: rm -f %t.ll
+// RUN: %mim %s --output-ll %t.ll
+// RUN: FileCheck %s < %t.ll
+
+plugin aie2p;
+import core;
+import compile;
+import opt;
+import aie2p;
+
+con extern mac_test(a: «16; I32», b: «32; I16», acc: «32; I64», conf: I32,
+                    return: Cn [«32; I64»]) =
+    let result = %aie2p.mac_4x4x8 (a, b, acc, conf);
+    return (result);
+
+// CHECK: call {{.*}} @llvm.aie2p.I512.I512.ACC2048.mac.conf(

--- a/lit/aie2p/srs.mim
+++ b/lit/aie2p/srs.mim
@@ -1,0 +1,16 @@
+// RUN: rm -f %t.ll
+// RUN: %mim %s --output-ll %t.ll
+// RUN: FileCheck %s < %t.ll
+
+plugin aie2p;
+import core;
+import compile;
+import opt;
+import aie2p;
+
+con extern srs_test(acc: «32; I64», shift: I32, round: I32,
+                   return: Cn [«32; I16»]) =
+    let result = %aie2p.srs_i16_32 (acc, shift, round);
+    return (result);
+
+// CHECK: call {{.*}} @llvm.aie2p.I512.v32.acc64.srs(

--- a/lit/aie2p/srs_i32_16.mim
+++ b/lit/aie2p/srs_i32_16.mim
@@ -1,0 +1,16 @@
+// RUN: rm -f %t.ll
+// RUN: %mim %s --output-ll %t.ll
+// RUN: FileCheck %s < %t.ll
+
+plugin aie2p;
+import core;
+import compile;
+import opt;
+import aie2p;
+
+con extern srs_test(acc: «16; I64», shift: I32, round: I32,
+                   return: Cn [«16; I32»]) =
+    let result = %aie2p.srs_i32_16 (acc, shift, round);
+    return (result);
+
+// CHECK: call {{.*}} @llvm.aie2p.I512.v16.acc64.srs(

--- a/src/mim/plug/CMakeLists.txt
+++ b/src/mim/plug/CMakeLists.txt
@@ -17,6 +17,7 @@ set(MIM_PLUGINS
     tensor
     tuple
     vec
+    aie2p
 )
 
 list(TRANSFORM MIM_PLUGINS PREPEND "mim_internal_" OUTPUT_VARIABLE MIM_INTERNAL_PLUGINS)

--- a/src/mim/plug/aie2p/CMakeLists.txt
+++ b/src/mim/plug/aie2p/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_mim_plugin(aie2p
+    SOURCES
+        aie2p.cpp
+        phase/lower_aie2p.cpp
+    INSTALL
+)

--- a/src/mim/plug/aie2p/aie2p.cpp
+++ b/src/mim/plug/aie2p/aie2p.cpp
@@ -1,0 +1,20 @@
+#include <mim/config.h>
+#include <mim/pass.h>
+
+#include "mim/plug/aie2p/autogen.h"
+#include "mim/plug/aie2p/phase/lower_aie2p.h"
+
+namespace mim::plug::aie2p {
+void register_stages(mim::Flags2Stages& stages) {
+    Stage::hook<aie2p::lower_aie2p_phase, aie2p::phase::LowerAIE2P>(stages);
+}
+} // namespace mim::plug::aie2p
+
+extern "C" MIM_EXPORT mim::Plugin mim_get_plugin() {
+    return {
+        "aie2p",
+        nullptr, // normalizers
+        mim::plug::aie2p::register_stages,
+        nullptr // backends
+    };
+}

--- a/src/mim/plug/aie2p/aie2p.mim
+++ b/src/mim/plug/aie2p/aie2p.mim
@@ -1,0 +1,21 @@
+import core;
+import compile;
+
+axm %aie2p.get_coreid: [] -> I32;
+/// Count leading bits: (i32) -> i32. Maps to llvm.aie2p.clb.
+axm %aie2p.clb: I32 -> I32;
+/// Shift-round-saturate: (v32i64, i32 shift, i32 round_mode) -> v32i16.
+/// Maps to llvm.aie2p.I512.v32.acc64.srs.
+axm %aie2p.srs_i16_32: [«32; I64», I32, I32] -> «32; I16»;
+/// MAC: (v32i16, v32i16, acc=v16i64, i32 conf) -> v16i64.
+/// Maps to llvm.aie2p.I512.I512.ACC1024.mac.conf.
+axm %aie2p.mac_i16_i64: [«32; I16», «32; I16», «16; I64», I32] -> «16; I64»;
+/// SRS v16: (v16i64, i32 shift, i32 round_mode) -> v16i32.
+/// Maps to llvm.aie2p.I512.v16.acc64.srs.
+axm %aie2p.srs_i32_16: [«16; I64», I32, I32] -> «16; I32»;
+/// MAC 4x4x8 matmul: (v16i32 A_packed, v32i16 B, v32i64 acc, i32 conf) -> v32i64.
+/// Maps to llvm.aie2p.I512.I512.ACC2048.mac.conf.
+/// A is 32 i16 values bitcast to 16 i32; B is 32 i16 values.
+/// conf=26 unsigned, conf=794 signed.
+axm %aie2p.mac_4x4x8: [«16; I32», «32; I16», «32; I64», I32] -> «32; I64»;
+axm %aie2p.lower_aie2p_phase: %compile.Phase;

--- a/src/mim/plug/aie2p/phase/lower_aie2p.cpp
+++ b/src/mim/plug/aie2p/phase/lower_aie2p.cpp
@@ -1,0 +1,76 @@
+#include "mim/plug/aie2p/phase/lower_aie2p.h"
+
+#include <cassert>
+
+#include <mim/lam.h>
+
+#include "mim/plug/aie2p/autogen.h"
+#include "mim/plug/direct/direct.h"
+
+namespace mim::plug::aie2p::phase {
+
+const LowerAIE2P::IntrinsicMap LowerAIE2P::intrinsic_names_ = {
+    { Annex::Base<get_coreid>,                 "llvm.aie2p.get.coreid"},
+    {        Annex::Base<clb>,                        "llvm.aie2p.clb"},
+    { Annex::Base<srs_i16_32>,         "llvm.aie2p.I512.v32.acc64.srs"},
+    {Annex::Base<mac_i16_i64>, "llvm.aie2p.I512.I512.ACC1024.mac.conf"},
+    { Annex::Base<srs_i32_16>,         "llvm.aie2p.I512.v16.acc64.srs"},
+    {  Annex::Base<mac_4x4x8>, "llvm.aie2p.I512.I512.ACC2048.mac.conf"},
+};
+
+const Def*
+LowerAIE2P::lower_to_cps_intrinsic(const Def* arg_rewritten, const Def* dom, const Def* ret, const char* llvm_name) {
+    auto& new_w  = new_world();
+    auto& cached = wrapped_cache_[reinterpret_cast<flags_t>(llvm_name)];
+
+    if (!cached) {
+        auto cn_ret = new_w.cn(ret);
+
+        if (auto sigma = dom->isa<Sigma>(); sigma && sigma->num_ops() >= 2) {
+            // Multi-arg intrinsic: create flat LLVM-facing lambda + forwarding lambda.
+            DefVec flat_doms;
+            for (auto op : sigma->ops())
+                flat_doms.push_back(op);
+            flat_doms.push_back(cn_ret);
+            auto flat_lam = new_w.mut_con(flat_doms)->set(llvm_name);
+
+            // Forwarding lambda with 2-element domain for cps2ds_dep compatibility.
+            auto fwd_lam   = new_w.mut_con({dom, cn_ret})->set("fwd");
+            auto sigma_var = fwd_lam->var(2, 0);
+            auto cont_var  = fwd_lam->var(2, 1);
+            DefVec call_args;
+            for (size_t i = 0; i < sigma->num_ops(); ++i)
+                call_args.push_back(sigma_var->proj(sigma->num_ops(), i));
+            call_args.push_back(cont_var);
+            fwd_lam->app(true, flat_lam, call_args);
+
+            cached = direct::op_cps2ds_dep(fwd_lam);
+        } else {
+            // Single-arg / unit intrinsic: 2-element domain works directly.
+            auto cps_lam = new_w.mut_con({dom, cn_ret})->set(llvm_name);
+            cached       = direct::op_cps2ds_dep(cps_lam);
+        }
+    }
+    return new_w.app(cached, arg_rewritten);
+}
+
+const Def* LowerAIE2P::rewrite_imm_App(const App* app) {
+    if (is_bootstrapping()) return Rewriter::rewrite_imm_App(app);
+
+    auto arg_rewritten = rewrite(app->arg());
+    if (!arg_rewritten) return Rewriter::rewrite_imm_App(app);
+
+    auto [axm, curry, _] = Axm::get(app);
+    if (!axm || curry != 0) return Rewriter::rewrite_imm_App(app);
+
+    auto it = intrinsic_names_.find(axm->base());
+    if (it == intrinsic_names_.end()) return Rewriter::rewrite_imm_App(app);
+
+    auto dom = rewrite(app->arg()->type());
+    auto ret = rewrite(app->type());
+    if (!dom || !ret) return Rewriter::rewrite_imm_App(app);
+
+    return lower_to_cps_intrinsic(arg_rewritten, dom, ret, it->second);
+}
+
+} // namespace mim::plug::aie2p::phase

--- a/src/mim/plug/core/be/ll.cpp
+++ b/src/mim/plug/core/be/ll.cpp
@@ -243,11 +243,14 @@ void Emitter::start() {
 
 void Emitter::emit_imported(Lam* lam) {
     // TODO merge with declare method
-    print(func_decls_, "declare {} {}(", convert_ret_pi(lam->type()->ret_pi()), id(lam));
+    const Pi* ret_pi = lam->type()->ret_pi();
+    print(func_decls_, "declare {} {}(", convert_ret_pi(ret_pi), id(lam));
 
     auto doms = lam->doms();
     for (auto sep = ""; auto dom : doms.view().rsubspan(1)) {
         if (Axm::isa<mem::M>(dom)) continue;
+        if (dom == world().sigma()) continue;  // unit — not an LLVM arg
+        if (ret_pi && dom == ret_pi) continue; // CPS continuation — not an LLVM arg
         print(func_decls_, "{}{}", sep, convert(dom));
         sep = ", ";
     }
@@ -554,8 +557,12 @@ std::string Emitter::emit_bb(BB& bb, const Def* def) {
         auto t_tup = convert(tuple->type());
         if (auto li = Lit::isa(index)) {
             if (isa_mem_sigma_2(tuple->type())) return v_tup;
-            // Adjust index, if mem is present.
-            auto v_i = Axm::isa<mem::M>(tuple->proj(0)->type()) ? std::to_string(*li - 1) : std::to_string(*li);
+            // Adjust index: skip all erased %mem.M elements before the target index.
+            size_t mem_count = 0;
+            if (auto sigma = tuple->type()->isa<Sigma>())
+                for (size_t i = 0; i < *li && i < sigma->num_ops(); ++i)
+                    if (Axm::isa<mem::M>(sigma->op(i))) ++mem_count;
+            auto v_i = std::to_string(*li - mem_count);
             return bb.assign(name, "extractvalue {} {}, {}", t_tup, v_tup, v_i);
         }
 

--- a/src/mim/plug/core/be/ll.cpp
+++ b/src/mim/plug/core/be/ll.cpp
@@ -66,6 +66,16 @@ const Def* isa_mem_sigma_2(const Def* type) {
         if (sigma->num_ops() == 2 && Axm::isa<mem::M>(sigma->op(0))) return sigma->op(1);
     return {};
 }
+static std::optional<std::pair<nat_t, const Def*>> is_simd(const Def* type) {
+    if (auto arr = type->isa<Arr>()) {
+        if (auto l = Lit::isa(arr->arity()); l && *l > 1 && (*l & (*l - 1)) == 0) { // power of 2 only
+            if (arr->body()->isa<Nat>() || Idx::isa(arr->body()) || Axm::isa<math::F>(arr->body()))
+                return std::pair{*l, arr->body()};
+        }
+    }
+    return {};
+}
+
 } // namespace
 
 struct BB {
@@ -169,15 +179,18 @@ std::string Emitter::convert(const Def* type) {
             case 64: return types_[type] = "double";
             default: fe::unreachable();
         }
-    } else if (auto ptr = Axm::isa<mem::Ptr>(type)) {
-        auto [pointee, addr_space] = ptr->args<2>();
-        // TODO addr_space
-        print(s, "{}*", convert(pointee));
+    } else if (Axm::isa<mem::Ptr>(type)) {
+        return types_[type] = "ptr";
     } else if (auto arr = type->isa<Arr>()) {
-        auto t_elem = convert(arr->body());
-        u64 size    = 0;
-        if (auto arity = Lit::isa(arr->arity())) size = *arity;
-        print(s, "[{} x {}]", size, t_elem);
+        if (auto se = is_simd(arr)) {
+            auto [size, elem] = *se;
+            print(s, "<{} x {}>", size, convert(elem));
+        } else {
+            auto t_elem = convert(arr->body());
+            u64 size    = 0;
+            if (auto arity = Lit::isa(arr->arity())) size = *arity;
+            print(s, "[{} x {}]", size, t_elem);
+        }
     } else if (auto pi = type->isa<Pi>()) {
         assert(Pi::isa_returning(pi) && "should never have to convert type of BB");
         print(s, "{} (", convert_ret_pi(pi->ret_pi()));
@@ -260,8 +273,7 @@ void Emitter::emit_imported(Lam* lam) {
 
 std::string Emitter::prepare() {
     auto internal = root()->is_external() ? "" : "internal ";
-    auto ret_t    = convert_ret_pi(root()->type()->ret_pi());
-    print(func_impls_, "define {} {} {}(", internal, ret_t, id(root()));
+    print(func_impls_, "define {}{} {}(", internal, convert_ret_pi(root()->type()->ret_pi()), id(root()));
 
     auto vars = root()->vars();
     for (auto sep = ""; auto var : vars.view().rsubspan(1)) {
@@ -325,12 +337,17 @@ void Emitter::emit_epilogue(Lam* lam) {
             case 1: return bb.tail("ret {} {}", convert(types[0]), values[0]);
             default: {
                 std::string prev = "undef";
-                auto type        = convert(world().sigma(types));
+                auto ret_sigma   = world().sigma(types);
+                auto type        = convert(ret_sigma);
+                bool simd        = is_simd(ret_sigma).has_value();
                 for (size_t i = 0, n = values.size(); i != n; ++i) {
                     auto v_elem = values[i];
                     auto t_elem = convert(types[i]);
                     auto namei  = "%ret_val." + std::to_string(i);
-                    bb.tail("{} = insertvalue {} {}, {} {}, {}", namei, type, prev, t_elem, v_elem, i);
+                    if (simd)
+                        bb.tail("{} = insertelement {} {}, {} {}, i32 {}", namei, type, prev, t_elem, v_elem, i);
+                    else
+                        bb.tail("{} = insertvalue {} {}, {} {}, {}", namei, type, prev, t_elem, v_elem, i);
                     prev = namei;
                 }
 
@@ -377,13 +394,13 @@ void Emitter::emit_epilogue(Lam* lam) {
         }
         return bb.tail("br label {}", id(callee));
     } else if (auto longjmp = Axm::isa<clos::longjmp>(app)) {
-        declare("void @longjmp(i8*, i32) noreturn");
+        declare("void @longjmp(ptr, i32) noreturn");
 
         auto [mem, jbuf, tag] = app->args<3>();
         emit_unsafe(mem);
         auto v_jb  = emit(jbuf);
         auto v_tag = emit(tag);
-        bb.tail("call void @longjmp(i8* {}, i32 {})", v_jb, v_tag);
+        bb.tail("call void @longjmp(ptr {}, i32 {})", v_jb, v_tag);
         return bb.tail("unreachable");
     } else if (Pi::isa_returning(app->callee_type())) { // function call
         auto v_callee = emit(app->callee());
@@ -419,20 +436,9 @@ void Emitter::emit_epilogue(Lam* lam) {
             auto t_ret = convert_ret_pi(ret_lam->type());
             bb.tail("{} = call {} {}({, })", name, t_ret, v_callee, args);
 
-            for (size_t i = 0, j = 0, e = ret_lam->num_vars(); i != e; ++i) {
-                auto phi = ret_lam->var(i);
-                if (Axm::isa<mem::M>(phi->type())) continue;
-
-                auto namej = name;
-                if (e > 2) {
-                    namej += '.' + std::to_string(j);
-                    bb.tail("{} = extractvalue {} {}, {}", namej, t_ret, name, j);
-                }
-                assert(!Axm::isa<mem::M>(phi->type()));
-                lam2bb_[ret_lam].phis[phi].emplace_back(namej, id(lam, true));
-                locals_[phi] = id(phi);
-                ++j;
-            }
+            auto phi = ret_lam->var();
+            lam2bb_[ret_lam].phis[phi].emplace_back(name, id(lam, true));
+            locals_[phi] = id(phi);
         }
 
         return bb.tail("br label {}", id(ret_lam));
@@ -452,10 +458,11 @@ std::string Emitter::emit_bb(BB& bb, const Def* def) {
         }
 
         if (tuple->is_closed()) {
-            bool is_array = tuple->type()->isa<Arr>();
+            bool is_vec   = is_simd(tuple->type()).has_value();
+            bool is_array = !is_vec && tuple->type()->isa<Arr>();
 
             std::string s;
-            s += is_array ? "[" : "{";
+            s += is_vec ? "<" : (is_array ? "[" : "{");
             auto sep = "";
             for (size_t i = 0, n = tuple->num_projs(); i != n; ++i) {
                 auto e = tuple->proj(n, i);
@@ -466,18 +473,22 @@ std::string Emitter::emit_bb(BB& bb, const Def* def) {
                 }
             }
 
-            return s += is_array ? "]" : "}";
+            return s += is_vec ? ">" : (is_array ? "]" : "}");
         }
 
         std::string prev = "undef";
         auto t           = convert(tuple->type());
+        bool simd_tup    = is_simd(tuple->type()).has_value();
         for (size_t src = 0, dst = 0, n = tuple->num_projs(); src != n; ++src) {
             auto e = tuple->proj(n, src);
             if (auto elem = emit_unsafe(e); !elem.empty()) {
                 auto elem_t = convert(e->type());
                 // TODO: check dst vs src
                 auto namei = name + "." + std::to_string(dst);
-                prev       = bb.assign(namei, "insertvalue {} {}, {} {}, {}", t, prev, elem_t, elem, dst);
+                if (simd_tup)
+                    prev = bb.assign(namei, "insertelement {} {}, {} {}, i32 {}", t, prev, elem_t, elem, dst);
+                else
+                    prev = bb.assign(namei, "insertvalue {} {}, {} {}, {}", t, prev, elem_t, elem, dst);
                 dst++;
             }
         }
@@ -563,7 +574,15 @@ std::string Emitter::emit_bb(BB& bb, const Def* def) {
                 for (size_t i = 0; i < *li && i < sigma->num_ops(); ++i)
                     if (Axm::isa<mem::M>(sigma->op(i))) ++mem_count;
             auto v_i = std::to_string(*li - mem_count);
-            return bb.assign(name, "extractvalue {} {}, {}", t_tup, v_tup, v_i);
+            if (is_simd(tuple->type()))
+                return bb.assign(name, "extractelement {} {}, i32 {}", t_tup, v_tup, v_i);
+            else
+                return bb.assign(name, "extractvalue {} {}, {}", t_tup, v_tup, v_i);
+        }
+
+        if (is_simd(tuple->type())) {
+            auto v_i = emit(index);
+            return bb.assign(name, "extractelement {} {}, i32 {}", t_tup, v_tup, v_i);
         }
 
         auto t_elem     = convert(extract->type());
@@ -571,10 +590,10 @@ std::string Emitter::emit_bb(BB& bb, const Def* def) {
 
         print(lam2bb_[root()].body().emplace_front(),
               "{}.alloca = alloca {} ; copy to alloca to emulate extract with store + gep + load", name, t_tup);
-        print(bb.body().emplace_back(), "store {} {}, {}* {}.alloca", t_tup, v_tup, t_tup, name);
-        print(bb.body().emplace_back(), "{}.gep = getelementptr inbounds {}, {}* {}.alloca, i64 0, {} {}", name, t_tup,
-              t_tup, name, t_i, v_i);
-        return bb.assign(name, "load {}, {}* {}.gep", t_elem, t_elem, name);
+        print(bb.body().emplace_back(), "store {} {}, ptr {}.alloca", t_tup, v_tup, name);
+        print(bb.body().emplace_back(), "{}.gep = getelementptr inbounds {}, ptr {}.alloca, i64 0, {} {}", name, t_tup,
+              name, t_i, v_i);
+        return bb.assign(name, "load {}, ptr {}.gep", t_elem, name);
     } else if (auto insert = def->isa<Insert>()) {
         assert(!Axm::isa<mem::M>(insert->tuple()->proj(0)->type()));
         auto t_tup = convert(insert->tuple()->type());
@@ -583,22 +602,30 @@ std::string Emitter::emit_bb(BB& bb, const Def* def) {
         auto v_val = emit(insert->value());
         if (auto idx = Lit::isa(insert->index())) {
             auto v_idx = emit(insert->index());
-            return bb.assign(name, "insertvalue {} {}, {} {}, {}", t_tup, v_tup, t_val, v_val, v_idx);
+            if (is_simd(insert->tuple()->type()))
+                return bb.assign(name, "insertelement {} {}, {} {}, i32 {}", t_tup, v_tup, t_val, v_val, v_idx);
+            else
+                return bb.assign(name, "insertvalue {} {}, {} {}, {}", t_tup, v_tup, t_val, v_val, v_idx);
         } else {
+            if (is_simd(insert->tuple()->type())) {
+                auto v_idx = emit(insert->index());
+                return bb.assign(name, "insertelement {} {}, {} {}, i32 {}", t_tup, v_tup, t_val, v_val, v_idx);
+            }
             auto t_elem     = convert(insert->value()->type());
             auto [v_i, t_i] = emit_gep_index(insert->index());
             print(lam2bb_[root()].body().emplace_front(),
                   "{}.alloca = alloca {} ; copy to alloca to emulate insert with store + gep + load", name, t_tup);
-            print(bb.body().emplace_back(), "store {} {}, {}* {}.alloca", t_tup, v_tup, t_tup, name);
-            print(bb.body().emplace_back(), "{}.gep = getelementptr inbounds {}, {}* {}.alloca, i64 0, {} {}", name,
-                  t_tup, t_tup, name, t_i, v_i);
-            print(bb.body().emplace_back(), "store {} {}, {}* {}.gep", t_val, v_val, t_val, name);
-            return bb.assign(name, "load {}, {}* {}.alloca", t_tup, t_tup, name);
+            print(bb.body().emplace_back(), "store {} {}, ptr {}.alloca", t_tup, v_tup, name);
+            print(bb.body().emplace_back(), "{}.gep = getelementptr inbounds {}, ptr {}.alloca, i64 0, {} {}", name,
+                  t_tup, name, t_i, v_i);
+            print(bb.body().emplace_back(), "store {} {}, ptr {}.gep", t_val, v_val, name);
+            return bb.assign(name, "load {}, ptr {}.alloca", t_tup, name);
         }
     } else if (auto global = def->isa<Global>()) {
         auto v_init                = emit(global->init());
         auto [pointee, addr_space] = Axm::as<mem::Ptr>(global->type())->args<2>();
-        print(vars_decls_, "{} = global {} {}\n", name, convert(pointee), v_init);
+        auto t_pointee             = convert(pointee);
+        print(vars_decls_, "{} = global {} {}\n", name, t_pointee, v_init);
         return globals_[global] = name;
     } else if (auto nat = Axm::isa<core::nat>(def)) {
         auto [a, b] = nat->args<2>([this](auto def) { return emit(def); });
@@ -769,9 +796,9 @@ std::string Emitter::emit_bb(BB& bb, const Def* def) {
 
         if (auto lit = Lit::isa(bitcast->arg()); lit && *lit == 0) return "zeroinitializer";
         // clang-format off
-        if (src_type_ptr && dst_type_ptr) return bb.assign(name,  "bitcast {} {} to {}", t_src, v_src, t_dst);
-        if (src_type_ptr)                 return bb.assign(name, "ptrtoint {} {} to {}", t_src, v_src, t_dst);
-        if (dst_type_ptr)                 return bb.assign(name, "inttoptr {} {} to {}", t_src, v_src, t_dst);
+        if (src_type_ptr && dst_type_ptr) return v_src; // ptr → ptr is a no-op with opaque pointers
+        if (src_type_ptr)                 return bb.assign(name, "ptrtoint ptr {} to {}", v_src, t_dst);
+        if (dst_type_ptr)                 return bb.assign(name, "inttoptr {} {} to ptr", t_src, v_src);
         // clang-format on
 
         auto size2width = [&](const Def* type) {
@@ -794,31 +821,24 @@ std::string Emitter::emit_bb(BB& bb, const Def* def) {
         auto pointee   = Axm::as<mem::Ptr>(ptr->type())->arg(0);
         auto v_ptr     = emit(ptr);
         auto t_pointee = convert(pointee);
-        auto t_ptr     = convert(ptr->type());
         if (pointee->isa<Sigma>())
-            return bb.assign(name, "getelementptr inbounds {}, {} {}, i64 0, i32 {}", t_pointee, t_ptr, v_ptr,
-                             Lit::as(i));
+            return bb.assign(name, "getelementptr inbounds {}, ptr {}, i64 0, i32 {}", t_pointee, v_ptr, Lit::as(i));
 
         assert(pointee->isa<Arr>());
         auto [v_i, t_i] = emit_gep_index(i);
 
-        return bb.assign(name, "getelementptr inbounds {}, {} {}, i64 0, {} {}", t_pointee, t_ptr, v_ptr, t_i, v_i);
+        return bb.assign(name, "getelementptr inbounds {}, ptr {}, i64 0, {} {}", t_pointee, v_ptr, t_i, v_i);
     } else if (auto malloc = Axm::isa<mem::malloc>(def)) {
-        declare("i8* @malloc(i64)");
+        declare("ptr @malloc(i64)");
 
         emit_unsafe(malloc->arg(0));
-        auto size  = emit(malloc->arg(1));
-        auto ptr_t = convert(Axm::as<mem::Ptr>(def->proj(1)->type()));
-        bb.assign(name + "i8", "call i8* @malloc(i64 {})", size);
-        return bb.assign(name, "bitcast i8* {} to {}", name + "i8", ptr_t);
+        auto size = emit(malloc->arg(1));
+        return bb.assign(name, "call ptr @malloc(i64 {})", size);
     } else if (auto free = Axm::isa<mem::free>(def)) {
-        declare("void @free(i8*)");
+        declare("void @free(ptr)");
         emit_unsafe(free->arg(0));
-        auto ptr   = emit(free->arg(1));
-        auto ptr_t = convert(Axm::as<mem::Ptr>(free->arg(1)->type()));
-
-        bb.assign(name + "i8", "bitcast {} {} to i8*", ptr_t, ptr);
-        bb.tail("call void @free(i8* {})", name + "i8");
+        auto v_ptr = emit(free->arg(1));
+        bb.tail("call void @free(ptr {})", v_ptr);
         return {};
     } else if (auto mslot = Axm::isa<mem::mslot>(def)) {
         auto [Ta, msi]             = mslot->uncurry_args<2>();
@@ -830,28 +850,24 @@ std::string Emitter::emit_bb(BB& bb, const Def* def) {
         print(bb.body().emplace_back(), "{} = alloca {}", name, convert(pointee));
         return name;
     } else if (auto free = Axm::isa<mem::free>(def)) {
-        declare("void @free(i8*)");
+        declare("void @free(ptr)");
 
         emit_unsafe(free->arg(0));
         auto v_ptr = emit(free->arg(1));
-        auto t_ptr = convert(Axm::as<mem::Ptr>(free->arg(1)->type()));
-
-        bb.assign(name + "i8", "bitcast {} {} to i8*", t_ptr, v_ptr);
-        bb.tail("call void @free(i8* {})", name + "i8");
+        bb.tail("call void @free(ptr {})", v_ptr);
         return {};
     } else if (auto load = Axm::isa<mem::load>(def)) {
         emit_unsafe(load->arg(0));
         auto v_ptr     = emit(load->arg(1));
-        auto t_ptr     = convert(load->arg(1)->type());
-        auto t_pointee = convert(Axm::as<mem::Ptr>(load->arg(1)->type())->arg(0));
-        return bb.assign(name, "load {}, {} {}", t_pointee, t_ptr, v_ptr);
+        auto pointee   = Axm::as<mem::Ptr>(load->arg(1)->type())->arg(0);
+        auto t_pointee = convert(pointee);
+        return bb.assign(name, "load {}, ptr {}", t_pointee, v_ptr);
     } else if (auto store = Axm::isa<mem::store>(def)) {
         emit_unsafe(store->arg(0));
         auto v_ptr = emit(store->arg(1));
         auto v_val = emit(store->arg(2));
-        auto t_ptr = convert(store->arg(1)->type());
         auto t_val = convert(store->arg(2)->type());
-        print(bb.body().emplace_back(), "store {} {}, {} {}", t_val, v_val, t_ptr, v_ptr);
+        print(bb.body().emplace_back(), "store {} {}, ptr {}", t_val, v_val, v_ptr);
         return {};
     } else if (auto q = Axm::isa<clos::alloc_jmpbuf>(def)) {
         declare("i64 @jmpbuf_size()");
@@ -861,12 +877,12 @@ std::string Emitter::emit_bb(BB& bb, const Def* def) {
         bb.assign(size, "call i64 @jmpbuf_size()");
         return bb.assign(name, "alloca i8, i64 {}", size);
     } else if (auto setjmp = Axm::isa<clos::setjmp>(def)) {
-        declare("i32 @_setjmp(i8*) returns_twice");
+        declare("i32 @_setjmp(ptr) returns_twice");
 
         auto [mem, jmpbuf] = setjmp->arg()->projs<2>();
         emit_unsafe(mem);
         auto v_jb = emit(jmpbuf);
-        return bb.assign(name, "call i32 @_setjmp(i8* {})", v_jb);
+        return bb.assign(name, "call i32 @_setjmp(ptr {})", v_jb);
     } else if (auto arith = Axm::isa<math::arith>(def)) {
         auto [mode, ab] = arith->uncurry_args<2>();
         auto [a, b]     = ab->projs<2>([this](auto def) { return emit(def); });

--- a/src/mim/plug/opt/opt.mim
+++ b/src/mim/plug/opt/opt.mim
@@ -18,6 +18,7 @@ import gpu;
 import matrix;
 import refly;
 import regex;
+import aie2p;
 ///
 /// ## Passes, Phases, and Pipelines
 ///
@@ -33,6 +34,7 @@ lam extern _default_compile (): %compile.Phase =
         %compile.pass2phase (%compile.eta_red_pass ff),
         %compile.pass2phase %compile.tail_rec_elim_pass,
         %compile.pass2phase (cond_pass "regex" %regex.lower_regex),
+        cond_phase "aie2p" %aie2p.lower_aie2p_phase,
         // optimize
         %compile.phases tt (
             %compile.beta_red_phase,


### PR DESCRIPTION
- AIE2P NPU plugin with 6 intrinsics (`get_coreid`, `clb`, `srs_i16_32`, `srs_i32_16`, `mac_i16_i64`, `mac_4x4x8`) for AMD Ryzen AI (AIE2P architecture/Krackan Point/AMD Ryzen AI 7 350)
- GEMM tile kernels with IRON NPU integration (requires Peano + NPU hardware)

Testing: NPU hardware (requires Peano + IRON + XRT + AMD NPU):                                                                                  
  - 3 GEMM kernels verified on AMD Ryzen AI: element-wise MAC, 4×4×8 matmul, 32×32×32 tiled                                                              
  - From `lit/aie2p/iron/`:                                                                                                                              
    ```bash                                                                                                                                              
    source /opt/xilinx/xrt/setup.sh && source ironenv/bin/activate                                                                                       
    make                    # element-wise MAC → build/final.xclbin                                                                                      
    make matmul             # 4×4×8 matmul → build/final_matmul.xclbin                                                                                   
    make tiled              # 32×32×32 tiled → build/final_32x32x32.xclbin                                                                               
    python3 test.py -x build/final.xclbin -i build/insts.txt                                                                                             
    python3 test_matmul.py -x build/final_matmul.xclbin -i build/insts_matmul.txt                                                                        
    python3 test_32x32x32.py -x build/final_32x32x32.xclbin -i build/insts_32x32x32.txt --iters 100 --warmup 10