### PR TITLE
autodiff: add float differentiation rules for math.arith

### DIFF
--- a/lit/autodiff/float_2arg_autodiff.mim
+++ b/lit/autodiff/float_2arg_autodiff.mim
@@ -1,0 +1,34 @@
+// RUN: rm -f %t.ll
+// RUN: %mim -p direct %s --output-ll %t.ll
+// RUN: clang %t.ll -o %t -lm -Wno-override-module
+// RUN: %t; test $? -eq 231
+
+plugin math;
+plugin autodiff;
+
+// f(k1, k2) = k1 * k2, df/dk1 = k2, df/dk2 = k1
+fun f(k1 k2: %math.F64): %math.F64 =
+    return (%math.arith.mul 0 (k1, k2));
+
+con extern main [mem : %mem.M 0, argc : I32, argv : %mem.Ptr (%mem.Ptr (I8, 0), 0), return : Cn [%mem.M 0, I32]] =
+    let f_diff = %autodiff.ad f;
+    let k1 = 3.0:(%math.F64);
+    let k2 = 5.0:(%math.F64);
+    f_diff ((k1, k2), ret_cont)
+    where
+        con ret_cont [r: %math.F64, pb: Cn[%math.F64, Cn[%math.F64, %math.F64]]] =
+            pb(1.0:(%math.F64), pb_ret_cont)
+            where
+                con pb_ret_cont [dk1: %math.F64, dk2: %math.F64] =
+                    // f(3,5) = 15, df/dk1 = 5, df/dk2 = 3
+                    // encode 10000*15 + 100*5 + 3 = 150503
+                    let r_i   = %core.bitcast I32 (%math.conv.f2u ⊤:Nat r);
+                    let dk1_i = %core.bitcast I32 (%math.conv.f2u ⊤:Nat dk1);
+                    let dk2_i = %core.bitcast I32 (%math.conv.f2u ⊤:Nat dk2);
+                    let a = %core.wrap.mul 0 (10000I32, r_i);
+                    let b = %core.wrap.add 0 (a, %core.wrap.mul 0 (100I32, dk1_i));
+                    let d = %core.wrap.add 0 (b, dk2_i);
+                    return (mem, d);
+            end;
+    end;
+

--- a/lit/autodiff/float_add_autodiff.mim
+++ b/lit/autodiff/float_add_autodiff.mim
@@ -1,0 +1,31 @@
+// RUN: rm -f %t.ll
+// RUN: %mim -p direct %s --output-ll %t.ll
+// RUN: clang %t.ll -o %t -lm -Wno-override-module
+// RUN: %t; test $? -eq 90
+
+plugin math;
+plugin autodiff;
+
+// f(x) = x + x, f'(x) = 2
+fun f(a: %math.F64): %math.F64 =
+    return (%math.arith.add 0 (a, a));
+
+con extern main [mem : %mem.M 0, argc : I32, argv : %mem.Ptr (%mem.Ptr (I8, 0), 0), return : Cn [%mem.M 0, I32]] =
+    let f_diff = %autodiff.ad f;
+    let c = 3.0:(%math.F64);
+    f_diff (c, ret_cont)
+    where
+        con ret_cont [r: %math.F64, pb: Cn[%math.F64, Cn[%math.F64]]] =
+            pb(1.0:(%math.F64), pb_ret_cont)
+            where
+                con pb_ret_cont [pr: %math.F64] =
+                    // f'(3) = 2, f(3) = 6, encode 100*6 + 2 = 602
+                    let grad_i = %math.conv.f2u ⊤:Nat pr;
+                    let res_i  = %math.conv.f2u ⊤:Nat r;
+                    let c = %core.wrap.mul 0 (100I32, %core.bitcast I32 res_i);
+                    let d = %core.wrap.add 0 (c, %core.bitcast I32 grad_i);
+                    return (mem, d);
+            end;
+    end;
+
+// f(3) = 6, f'(3) = 2, encoded as 100*6 + 2 = 602, exit code = 602 mod 256 = 90

--- a/lit/autodiff/float_chain_autodiff.mim
+++ b/lit/autodiff/float_chain_autodiff.mim
@@ -1,0 +1,31 @@
+// RUN: rm -f %t.ll
+// RUN: %mim -p direct %s --output-ll %t.ll
+// RUN: clang %t.ll -o %t -lm -Wno-override-module
+// RUN: %t; test $? -eq 183
+
+plugin math;
+plugin autodiff;
+
+// f(x) = x*x + x, f'(x) = 2x + 1
+fun f(a: %math.F64): %math.F64 =
+    let sq = %math.arith.mul 0 (a, a);
+    return (%math.arith.add 0 (sq, a));
+
+con extern main [mem : %mem.M 0, argc : I32, argv : %mem.Ptr (%mem.Ptr (I8, 0), 0), return : Cn [%mem.M 0, I32]] =
+    let f_diff = %autodiff.ad f;
+    let c = 3.0:(%math.F64);
+    f_diff (c, ret_cont)
+    where
+        con ret_cont [r: %math.F64, pb: Cn[%math.F64, Cn[%math.F64]]] =
+            pb(1.0:(%math.F64), pb_ret_cont)
+            where
+                con pb_ret_cont [pr: %math.F64] =
+                    // f(3) = 9+3 = 12, f'(3) = 6+1 = 7, encode 100*12 + 7 = 1207
+                    let grad_i = %math.conv.f2u ⊤:Nat pr;
+                    let res_i  = %math.conv.f2u ⊤:Nat r;
+                    let c = %core.wrap.mul 0 (100I32, %core.bitcast I32 res_i);
+                    let d = %core.wrap.add 0 (c, %core.bitcast I32 grad_i);
+                    return (mem, d);
+            end;
+    end;
+

--- a/lit/autodiff/float_mul_autodiff.mim
+++ b/lit/autodiff/float_mul_autodiff.mim
@@ -1,0 +1,30 @@
+// RUN: rm -f %t.ll
+// RUN: %mim -p direct %s --output-ll %t.ll
+// RUN: clang %t.ll -o %t -lm -Wno-override-module
+// RUN: %t; test $? -eq 138
+
+plugin math;
+plugin autodiff;
+
+// f(x) = x * x, f'(x) = 2x
+fun f(a: %math.F64): %math.F64 =
+    return (%math.arith.mul 0 (a, a));
+
+con extern main [mem : %mem.M 0, argc : I32, argv : %mem.Ptr (%mem.Ptr (I8, 0), 0), return : Cn [%mem.M 0, I32]] =
+    let f_diff = %autodiff.ad f;
+    let c = 3.0:(%math.F64);
+    f_diff (c, ret_cont)
+    where
+        con ret_cont [r: %math.F64, pb: Cn[%math.F64, Cn[%math.F64]]] =
+            pb(1.0:(%math.F64), pb_ret_cont)
+            where
+                con pb_ret_cont [pr: %math.F64] =
+                    // f(3) = 9, f'(3) = 6, encode 100*9 + 6 = 906
+                    let grad_i = %math.conv.f2u ⊤:Nat pr;
+                    let res_i  = %math.conv.f2u ⊤:Nat r;
+                    let c = %core.wrap.mul 0 (100I32, %core.bitcast I32 res_i);
+                    let d = %core.wrap.add 0 (c, %core.bitcast I32 grad_i);
+                    return (mem, d);
+            end;
+    end;
+

--- a/src/mim/plug/autodiff/autodiff.cpp
+++ b/src/mim/plug/autodiff/autodiff.cpp
@@ -3,6 +3,7 @@
 #include <mim/config.h>
 #include <mim/phase.h>
 
+#include <mim/plug/math/math.h>
 #include <mim/plug/mem/mem.h>
 
 #include "mim/plug/autodiff/pass/eval.h"
@@ -115,6 +116,7 @@ const Def* autodiff_type_fun(const Def* ty) {
     // Also handles autodiff call from axm declaration => abstract => leave it.
     world.DLOG("AutoDiff on type: {} <{}>", ty, ty->node_name());
     if (Idx::isa(ty)) return ty;
+    if (math::isa_f(ty)) return ty;
     if (ty == world.type_nat()) return ty;
     if (auto arr = ty->isa<Arr>()) {
         auto shape   = arr->arity();
@@ -149,9 +151,12 @@ const Def* zero_def(const Def* T) {
         world.DLOG("zero_arr: {}", zero_arr);
         return zero_arr;
     } else if (Idx::isa(T)) {
-        // TODO: real
         auto zero = world.lit(T, 0)->set("zero");
         world.DLOG("zero_def for int is {}", zero);
+        return zero;
+    } else if (auto w = math::isa_f(T)) {
+        auto zero = math::lit_f(world, *w, 0.0);
+        world.DLOG("zero_def for float is {}", zero);
         return zero;
     } else if (auto sig = T->isa<Sigma>()) {
         auto ops = DefVec(sig->ops(), [&](const Def* op) { return world.app(world.annex<zero>(), op); });

--- a/src/mim/plug/autodiff/autodiff.mim
+++ b/src/mim/plug/autodiff/autodiff.mim
@@ -10,6 +10,7 @@ plugin mem;
 import compile;
 /// For derivatives:
 plugin core;
+plugin math;
 ///
 ///
 /// ## Types
@@ -111,3 +112,46 @@ fun extern internal_diff_core_wrap_add {s: Nat} (m: Nat) (ab: «2; Idx s»)@tt: 
 ///
 fun extern internal_diff_core_wrap_mul {s: Nat} (m: Nat) (a b: Idx s) as ab@tt: [Idx s, Cn[Idx s, Cn«2; Idx s»]] =
     return (%core.wrap.mul m ab, fn (i: Idx s)@tt: «2; Idx s» = return (%core.wrap.mul m (i, b), %core.wrap.mul m (i, a)));
+///
+/// ### %%math.arith.add (float)
+///
+/// s ↦ (s, s)
+///
+fun extern internal_diff_math_arith_add {pe: «2; Nat»} (m: Nat) (ab: «2; %math.F pe»)@tt:
+    [%math.F pe, Cn[%math.F pe, Cn«2; %math.F pe»]] =
+    return (%math.arith.add m ab,
+            fn (s: %math.F pe)@tt: «2; %math.F pe» = return ‹2; s›);
+///
+/// ### %%math.arith.sub (float)
+///
+/// s ↦ (s, -s)
+///
+fun extern internal_diff_math_arith_sub {pe: «2; Nat»} (m: Nat) (a b: %math.F pe) as ab@tt:
+    [%math.F pe, Cn[%math.F pe, Cn«2; %math.F pe»]] =
+    return (%math.arith.sub m ab,
+            fn (s: %math.F pe)@tt: «2; %math.F pe» =
+                return (s, %math.arith.sub m (0:(%math.F pe), s)));
+///
+/// ### %%math.arith.mul (float)
+///
+/// s ↦ (s*b, s*a)
+///
+fun extern internal_diff_math_arith_mul {pe: «2; Nat»} (m: Nat) (a b: %math.F pe) as ab@tt:
+    [%math.F pe, Cn[%math.F pe, Cn«2; %math.F pe»]] =
+    return (%math.arith.mul m ab,
+            fn (s: %math.F pe)@tt: «2; %math.F pe» =
+                return (%math.arith.mul m (s, b), %math.arith.mul m (s, a)));
+///
+/// ### %%math.arith.div (float)
+///
+/// s ↦ (s/b, -s*a/(b*b))
+///
+fun extern internal_diff_math_arith_div {pe: «2; Nat»} (m: Nat) (a b: %math.F pe) as ab@tt:
+    [%math.F pe, Cn[%math.F pe, Cn«2; %math.F pe»]] =
+    return (%math.arith.div m ab,
+            fn (s: %math.F pe)@tt: «2; %math.F pe» =
+                let da = %math.arith.div m (s, b);
+                let b2 = %math.arith.mul m (b, b);
+                let sa = %math.arith.mul m (s, a);
+                let db = %math.arith.sub m (0:(%math.F pe), %math.arith.div m (sa, b2));
+                return (da, db));

--- a/src/mim/plug/autodiff/normalizers.cpp
+++ b/src/mim/plug/autodiff/normalizers.cpp
@@ -1,4 +1,5 @@
 #include <mim/plug/core/core.h>
+#include <mim/plug/math/math.h>
 #include <mim/plug/mem/mem.h>
 
 #include "mim/axm.h"
@@ -72,6 +73,9 @@ const Def* normalize_add(const Def* type, const Def* callee, const Def* arg) {
         auto int_add = world.call(core::wrap::add, 0_n, Defs{a, b});
         world.DLOG("int add {} : {}", int_add, Idx::isa(int_add->type()));
         return int_add;
+    } else if (math::isa_f(type)) {
+        world.DLOG("add float");
+        return world.call(math::arith::add, 0_n, Defs{a, b});
     } else if (Axm::isa<mem::M>(type)) {
         // TODO: mem stays here (only resolved after direct simplification)
         return {};


### PR DESCRIPTION
This adds reverse-mode differentiation rules for floating-point operations:

  - `math.arith.add`: s ↦ (s, s)
  - `math.arith.sub`: s ↦ (s, -s)
  - `math.arith.mul`: s ↦ (s*b, s*a)
  - `math.arith.div`: s ↦ (s/b, -s*a/(b²))

Plus float `zero_def` (`math::lit_f(world, w, 0.0)`) and `math::isa_f` type handling in `autodiff_type_fun`, so the autodiff pass recognizes float types as differentiable scalars.

### Motivation

This is the base needed for differentiable scientific computing in MimIR - specifically differentiable ODE solving for parameter estimation in computational biology models (e.g., NAFLD liver fat dynamics). Float autodiff rules are required for any gradient-based optimization over continuous models.

### Changes

  - `autodiff.mim`: 4 differentiation rules for `math.arith.{add,sub,mul,div}`,
    `plugin math;` dependency
  - `autodiff.cpp`: `math::isa_f` in `autodiff_type_fun`, float `zero_def`
    using `math::lit_f`
  - `normalizers.cpp`: float case in `normalize_add`
  - 4 lit tests (compile + run + check exit code)
