### PR TITLE
Fix `lam %p.t.s (a): b =..` ending up twice in autogen.h

### DIFF
--- a/lit/annex.mim
+++ b/lit/annex.mim
@@ -6,5 +6,13 @@ let %annex.Vec3.xyz = [x: %math.F64, y: %math.F64, z: %math.F64];
 let %annex.Vec3.rgb = [r: %math.F64, g: %math.F64, w: %math.F64];
 rec %annex.Vec3.rpi: □ = %annex.Vec3.xyz → %annex.Vec3.rpi;
 let %annex.Vec3.zero = 0;
+lam %annex.Vec3.unit [i: Idx 3]: %annex.Vec3.xyz =
+    (%annex.Vec3.xyz (1.0:%math.F64, 0.0:%math.F64, 0.0:%math.F64),
+     %annex.Vec3.xyz (0.0:%math.F64, 1.0:%math.F64, 0.0:%math.F64),
+     %annex.Vec3.xyz (0.0:%math.F64, 0.0:%math.F64, 1.0:%math.F64)
+    )#i;
+
 
 // CHECK: zero = 0x8f3c66400000003
+// CHECK: unit = 0x8f3c66400000004
+// CHECK-NOT: unit = 0x8f3c66400000005

--- a/src/mim/ast/bind.cpp
+++ b/src/mim/ast/bind.cpp
@@ -316,7 +316,6 @@ void RecDecl::bind(Scopes& s) const {
         curr->bind_decl(s);
     for (auto curr = this; curr; curr = curr->next())
         curr->bind_body(s);
-    annex_ = s.ast().name2annex(dbg(), &sub_);
 }
 
 void RecDecl::bind_decl(Scopes& s) const {
@@ -328,6 +327,8 @@ void RecDecl::bind_decl(Scopes& s) const {
         s.ast().error(body()->loc(), "unsupported expression for a recursive declaration");
 
     s.bind(dbg(), this);
+    annex_ = s.ast().name2annex(dbg(), &sub_);
+
 }
 
 void RecDecl::bind_body(Scopes& s) const { body()->bind(s); }


### PR DESCRIPTION
Currently, when bootstrapping a `lam` annex, with a subtag, this subtag will be duplicated as `name2annex` is called twice for the same lam. Once in `RecDecl::bind` and once in `LamDecl::bind_decl`. By moving the call from `RecDecl::bind` to `RecDecl::bind_decl`, this no longer happens as `LamDecl` overrides `RecDecl::bind_decl`.