### PR TITLE
Generalize normalizing a multi-dim arity to a nested seq.

### DIFF
--- a/src/mim/world.cpp
+++ b/src/mim/world.cpp
@@ -502,13 +502,13 @@ const Def* World::seq(bool term, const Def* arity, const Def* body) {
     }
 
     // «(a, b, c); body» -> «a; «(b, c); body»»
-    if (auto tuple = arity->isa<Tuple>())
-        return seq(term, tuple->ops().front(), seq(term, tuple->ops().subspan(1), body));
+    // e.g. when var, but still has array type
+    if (auto arr_arity = arity->type()->isa<Seq>())
+        if (auto lit_arity_arity = Lit::isa(arr_arity->arity())) {
+            DefVec inner_arity(*lit_arity_arity - 1, [&](u64 i) { return arity->proj(*lit_arity_arity, i + 1); });
+            return seq(term, arity->proj(*lit_arity_arity, 0), seq(term, tuple(inner_arity), body));
+        }
 
-    // «‹n; x›; body» -> «x; «<n-1, x>; body»»
-    if (auto p = arity->isa<Pack>()) {
-        if (auto s = Lit::isa(p->arity())) return seq(term, p->body(), seq(term, pack(*s - 1, p->body()), body));
-    }
 
     if (term) {
         auto type = arr(arity, body->type());


### PR DESCRIPTION
We already normalized `«(a, b, c); body» -> «a; «(b, c); body»» -> «a; «b; «c; body»»»` and for packs `«‹n; x›; body» -> «x; «<n-1, x>; body»»`.
However, this only applied, when the actual node was a Tuple or Pack. This did not work, in cases, where e.g. the shape was a Var, but had a (known-size) array as type.
This fixes this, by only inspecting the type for the dimensionality of the arity.

This is needed for tensor changes.