### PR TITLE
Don't emit the body for 0-sized arrays.

### DIFF
--- a/include/mim/ast/ast.h
+++ b/include/mim/ast/ast.h
@@ -739,13 +739,13 @@ private:
 /// `«dbg: arity; body»` or `‹dbg: arity; body›`
 class SeqExpr : public Expr {
 public:
-    SeqExpr(Loc loc, bool is_arr, Ptr<IdPtrn>&& arity, Ptr<Expr>&& body)
+    SeqExpr(Loc loc, bool is_pack, Ptr<IdPtrn>&& arity, Ptr<Expr>&& body)
         : Expr(loc)
-        , is_arr_(is_arr)
+        , is_pack_(is_pack)
         , arity_(std::move(arity))
         , body_(std::move(body)) {}
 
-    bool is_arr() const { return is_arr_; }
+    bool is_pack() const { return is_pack_; }
     const IdPtrn* arity() const { return arity_.get(); }
     const Expr* body() const { return body_.get(); }
 
@@ -755,7 +755,7 @@ public:
 private:
     const Def* emit_(Emitter&) const override;
 
-    bool is_arr_;
+    bool is_pack_;
     Ptr<IdPtrn> arity_;
     Ptr<Expr> body_;
 };

--- a/include/mim/world.h
+++ b/include/mim/world.h
@@ -394,23 +394,13 @@ public:
     const Sigma* sigma() { return data_.sigma; } ///< The unit type within Type 0.
     ///@}
 
-    /// @name Arr
+    /// @name Arr & Pack
     ///@{
     // clang-format off
-    const Def* unit(bool term) { return term ? (const Def*)tuple() : sigma(); }
-
-    Seq* mut_seq(bool term, const Def* type) { return term ? (Seq*)insert<Pack>(type) : insert<Arr>(type); }
-    const Def* seq(bool term, const Def* arity, const Def* body);
-    const Def* seq(bool term, Defs shape, const Def* body);
-    const Def* seq(bool term, u64 n, const Def* body) { return seq(term, lit_nat(n), body); }
-    const Def* seq(bool term, View<u64> shape, const Def* body) { return seq(term, DefVec(shape.size(), [&](size_t i) { return lit_nat(shape[i]); }), body); }
-    const Def* seq_unsafe(bool term, const Def* body) { return seq(term, top_nat(), body); }
-
     template<level_t level = 0>
     Arr* mut_arr() {
         return mut_arr(type<level>());
     }
-
     Arr * mut_arr (const Def* type) { return mut_seq(false, type)->as<Arr >(); }
     Pack* mut_pack(const Def* type) { return mut_seq(true , type)->as<Pack>(); }
     const Def* arr (const Def* arity, const Def* body) { return seq(false, arity, body); }
@@ -427,6 +417,21 @@ public:
     const Def* prod(bool term, Defs ops) { return term ? tuple(ops) : sigma(ops); }
     const Def* prod(bool term) { return term ? (const Def*)tuple() : (const Def*)sigma(); }
     // clang-format on
+    ///@}
+
+    /// @name Seq
+    /// These either build a Pack or an Arr depending on the first argument.
+    /// Oftentimes, the logic for Pack%s and Arr%ays can be quite similar; these methods help factoring such code.
+    ///@{
+    const Def* unit(bool is_pack) { return is_pack ? (const Def*)tuple() : sigma(); }
+    Seq* mut_seq(bool is_pack, const Def* type) { return is_pack ? (Seq*)insert<Pack>(type) : insert<Arr>(type); }
+    const Def* seq(bool is_pack, const Def* arity, const Def* body);
+    const Def* seq(bool is_pack, Defs shape, const Def* body);
+    const Def* seq(bool is_pack, u64 n, const Def* body) { return seq(is_pack, lit_nat(n), body); }
+    const Def* seq(bool is_pack, View<u64> shape, const Def* body) {
+        return seq(is_pack, DefVec(shape.size(), [&](size_t i) { return lit_nat(shape[i]); }), body);
+    }
+    const Def* seq_unsafe(bool is_pack, const Def* body) { return seq(is_pack, top_nat(), body); }
     ///@}
 
     /// @name Tuple

--- a/src/mim/ast/emit.cpp
+++ b/src/mim/ast/emit.cpp
@@ -324,24 +324,18 @@ const Def* TupleExpr::emit_(Emitter& e) const {
 
 const Def* SeqExpr::emit_(Emitter& e) const {
     auto s = arity()->emit_type(e);
-    if (auto lit_s = Lit::isa(s); lit_s && *lit_s == 0) return e.world().unit(true);
+    if (auto lit_s = Lit::isa(s); lit_s && *lit_s == 0) return e.world().unit(is_pack());
 
     if (arity()->dbg().is_anon()) { // immutable
         auto b = body()->emit(e);
-        return is_arr() ? e.world().arr(s, b) : e.world().pack(s, b);
+        return e.world().seq(is_pack(), s, b);
     }
 
     auto t = e.world().type_infer_univ();
     auto a = e.world().mut_arr(t);
     a->set_arity(s);
 
-    if (is_arr()) {
-        auto var = a->var();
-        arity()->emit_value(e, var);
-        a->set_body(body()->emit(e));
-        if (auto imm = a->immutabilize()) return imm;
-        return a;
-    } else {
+    if (is_pack()) {
         auto p   = e.world().mut_pack(a);
         auto var = p->var();
         arity()->emit_value(e, var);
@@ -350,6 +344,12 @@ const Def* SeqExpr::emit_(Emitter& e) const {
         p->set(b);
         if (auto imm = p->immutabilize()) return imm;
         return p;
+    } else {
+        auto var = a->var();
+        arity()->emit_value(e, var);
+        a->set_body(body()->emit(e));
+        if (auto imm = a->immutabilize()) return imm;
+        return a;
     }
 }
 

--- a/src/mim/ast/emit.cpp
+++ b/src/mim/ast/emit.cpp
@@ -324,6 +324,8 @@ const Def* TupleExpr::emit_(Emitter& e) const {
 
 const Def* SeqExpr::emit_(Emitter& e) const {
     auto s = arity()->emit_type(e);
+    if (auto lit_s = Lit::isa(s); lit_s && *lit_s == 0) return e.world().unit(true);
+
     if (arity()->dbg().is_anon()) { // immutable
         auto b = body()->emit(e);
         return is_arr() ? e.world().arr(s, b) : e.world().pack(s, b);

--- a/src/mim/ast/parser.cpp
+++ b/src/mim/ast/parser.cpp
@@ -357,8 +357,8 @@ Ptr<Expr> Parser::parse_primary_expr(std::string_view ctxt) {
 }
 
 Ptr<Expr> Parser::parse_seq_expr() {
-    auto track  = tracker();
-    bool is_arr = accept(Tag::D_quote_l) ? true : (eat(Tag::D_angle_l), false);
+    auto track   = tracker();
+    bool is_pack = accept(Tag::D_angle_l) ? true : (eat(Tag::D_quote_l), false);
 
     std::deque<std::pair<Ptr<IdPtrn>, Ptr<Expr>>> arities;
 
@@ -369,18 +369,18 @@ Ptr<Expr> Parser::parse_seq_expr() {
             eat(Tag::T_colon);
         }
 
-        auto expr = parse_expr(is_arr ? "shape of an array" : "shape of a pack");
+        auto expr = parse_expr(is_pack ? "shape of pack" : "shape of a array");
         auto ptrn = IdPtrn::make_id(ast(), dbg, std::move(expr));
         arities.emplace_back(std::move(ptrn), std::move(expr));
     } while (accept(Tag::T_comma));
 
-    expect(Tag::T_semicolon, is_arr ? "array" : "pack");
-    auto body = parse_expr(is_arr ? "body of an array" : "body of a pack");
-    expect(is_arr ? Tag::D_quote_r : Tag::D_angle_r,
-           is_arr ? "closing delimiter of an array" : "closing delimiter of a pack");
+    expect(Tag::T_semicolon, is_pack ? "pack" : "array");
+    auto body = parse_expr(is_pack ? "body of a pack" : "body of an array");
+    expect(is_pack ? Tag::D_angle_r : Tag::D_quote_r,
+           is_pack ? "closing delimiter of a pack" : "closing delimiter of an array");
 
     for (auto& [ptrn, expr] : arities | std::ranges::views::reverse)
-        body = ptr<SeqExpr>(track, is_arr, std::move(ptrn), std::move(body));
+        body = ptr<SeqExpr>(track, is_pack, std::move(ptrn), std::move(body));
 
     return body;
 }
@@ -450,9 +450,8 @@ Ptr<Expr> Parser::parse_pi_expr() {
     auto ptrn = parse_ptrn(Brckt_Style | Implicit, "domain of a "s + entity, prec);
     auto dom  = ptr<PiExpr::Dom>(domt, std::move(ptrn));
 
-    auto codom = tag != Tag::K_Cn
-                   ? (expect(Tag::T_arrow, entity), parse_expr("codomain of a "s + entity, Prec::Arrow))
-                   : nullptr;
+    auto codom = tag != Tag::K_Cn ? (expect(Tag::T_arrow, entity), parse_expr("codomain of a "s + entity, Prec::Arrow))
+                                  : nullptr;
 
     if (tag == Tag::K_Fn) dom->add_ret(ast(), codom ? std::move(codom) : ptr<HoleExpr>(curr_));
     return ptr<PiExpr>(track, tag, std::move(dom), std::move(codom));

--- a/src/mim/ast/stream.cpp
+++ b/src/mim/ast/stream.cpp
@@ -162,7 +162,7 @@ std::ostream& SigmaExpr::stream(Tab& tab, std::ostream& os) const { return ptrn(
 std::ostream& TupleExpr::stream(Tab& tab, std::ostream& os) const { return print(os, "({, })", R(tab, elems())); }
 
 std::ostream& SeqExpr::stream(Tab& tab, std::ostream& os) const {
-    return print(os, "{}{}; {}{}", is_arr() ? "«" : "‹", S(tab, arity()), S(tab, body()), is_arr() ? "»" : "›");
+    return print(os, "{}{}; {}{}", is_pack() ? "‹" : "«", S(tab, arity()), S(tab, body()), is_pack() ? "›" : "»");
 }
 
 std::ostream& ExtractExpr::stream(Tab& tab, std::ostream& os) const {

--- a/src/mim/rewrite.cpp
+++ b/src/mim/rewrite.cpp
@@ -144,7 +144,7 @@ const Def* Rewriter::rewrite_mut_Seq(Seq* seq) {
         return map(seq, new_seq);
     }
 
-    auto new_arity = rewrite(seq->arity());
+    auto new_arity = rewrite(seq->arity())->zonk();
     auto l         = Lit::isa(new_arity);
     if (l && *l == 0) return world().prod(seq->is_intro());
 


### PR DESCRIPTION
One can write something like `<i: nb; s#(b#i)>`, where `b = ()` and `nb` is the size of `b`, i.e. 0. This seems like it could be useful/legal, as we don't really care about the body, when the array is empty anyways...

I am somewhat assuming that there might be more places where this might strike.