### PR TITLE
Bugfix/add_mim_plugin

### DIFF
--- a/cmake/Mim.cmake
+++ b/cmake/Mim.cmake
@@ -90,7 +90,7 @@ function(add_mim_plugin)
         OUTPUT
             ${AUTOGEN_H}
             ${PLUGIN_MD}
-        COMMAND $<TARGET_FILE:${MIM_TARGET_NAMESPACE}mim> ${PLUGIN_MIM} -P "${CMAKE_CURRENT_LIST_DIR}/.." --bootstrap
+        COMMAND $<TARGET_FILE:${MIM_TARGET_NAMESPACE}mim> ${PLUGIN_MIM} -P "${CMAKE_SOURCE_DIR}/src/mim/plug" -P "${CMAKE_CURRENT_LIST_DIR}/.." --bootstrap
             --output-h ${AUTOGEN_H}
             --output-md ${PLUGIN_MD}
         MAIN_DEPENDENCY ${PLUGIN_MIM}


### PR DESCRIPTION
If `add_mim_plugin` is run inside of `extra/plugin/CMakeLists.txt` the plugin search path for bootstrapping `autogen.h` expands to `mimir/extra` instead of `mimir/mim/src/plug` and an extra plugin can't import any in-tree plugins.