### PR TITLE
fix(py): return lam instead of def in lam.set

### DIFF
--- a/py/bindings/lam.cpp
+++ b/py/bindings/lam.cpp
@@ -1,4 +1,5 @@
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
 
 #include <mim/def.h>
@@ -17,6 +18,7 @@ void init_lam(nb::module_& m) {
     nb::class_<Lam, Def>(m, "Lam", nb::never_destruct())
         .def("var", static_cast<const Def* (Lam::*)()>(&Def::var), nb::rv_policy::reference_internal)
         .def("app", [](Lam& l, bool filter, Def* callee, std::vector<Def*> args) { return l.app(filter, callee, Defs(args)); }, nb::rv_policy::reference_internal)
+        .def("set", static_cast<Lam* (Lam::*)(std::string)>(&Lam::set), nb::rv_policy::reference_internal)
         .def("externalize", &Lam::externalize);
 
     nb::class_<App, Def>(m, "App", nb::never_destruct())

--- a/py/tests/defs.py
+++ b/py/tests/defs.py
@@ -3,9 +3,15 @@ from __future__ import annotations
 
 import mim
 import pytest
+import platform
 
 
 def test_world(world):
+    # the nanobind has some weird ordering problem issue
+    # discovered by https://github.com/mimir/mimir/pull/417
+    if platform.system().lower() == "windows":
+        pass
+    
     m1 = world.mut_con([world.type_bool()])
     m2 = world.mut_con([world.type_bool(), world.type_i8()])
     m3 = world.mut_con([world.type_bool(), world.type_i8(), world.type_i32()])


### PR DESCRIPTION
## Background

`Lam`'s set method is inherited from `Def`

So after calling `.set` for a `Lam` in python, the result will be inferred as a `Def` and is not callable at type level.

## Solution

overwrite the method for `Lam` so nanobind will generate correct stubs.