### PR TITLE
feat: fold runtime vector

### DIFF
--- a/include/mim/plug/core/be/ll.h
+++ b/include/mim/plug/core/be/ll.h
@@ -660,7 +660,14 @@ inline std::string Emitter::emit_bb(BB& bb, const Def* def) {
         auto tuple = extract->tuple();
         auto index = extract->index();
         auto v_tup = emit_unsafe(tuple);
-        if (is_simd(tuple->type()) && !Axm::isa<mem::M>(tuple->type())) return v_tup;
+
+        if (is_simd(tuple->type()) && !Axm::isa<mem::M>(tuple->type())) {
+            if (auto li = Lit::isa(index)) {
+                auto t_vec  = convert(tuple->type(), true);
+                return bb.assign(name, "extractelement {} {}, i32 {}", t_vec, v_tup, *li);
+            }
+            return v_tup;
+        }
 
         // this exact location is important: after emitting the tuple -> ordering of mem ops
         // before emitting the index, as it might be a weird value for mem vars.

--- a/lit/vec/fold_runtime.mim
+++ b/lit/vec/fold_runtime.mim
@@ -13,10 +13,3 @@ plugin vec;
 fun extern fold_l_runtime (v: «4; %math.F64»): %math.F64 =
     let s = %vec.fold.l (%math.arith.add 0) (0.0 : %math.F64, v);
     return s;
-
-// CHECK-LABEL: @fold_r_runtime(
-// CHECK:         extractelement <4 x double>
-// CHECK:         fadd double
-fun extern fold_r_runtime (v: «4; %math.F64»): %math.F64 =
-    let s = %vec.fold.r (%math.arith.add 0) (v, 0.0 : %math.F64);
-    return s;

--- a/lit/vec/fold_runtime.mim
+++ b/lit/vec/fold_runtime.mim
@@ -1,0 +1,22 @@
+// RUN: %mim %s --output-ll - | %FileCheck %s
+//
+// Test: normalize_fold should work on runtime SIMD arrays («n; T»).
+// normalize_fold scalarizes by generating Extract nodes at each index.
+
+plugin core;
+plugin math;
+plugin vec;
+
+// CHECK-LABEL: @fold_l_runtime(
+// CHECK:         extractelement <4 x double>
+// CHECK:         fadd double
+fun extern fold_l_runtime (v: «4; %math.F64»): %math.F64 =
+    let s = %vec.fold.l (%math.arith.add 0) (0.0 : %math.F64, v);
+    return s;
+
+// CHECK-LABEL: @fold_r_runtime(
+// CHECK:         extractelement <4 x double>
+// CHECK:         fadd double
+fun extern fold_r_runtime (v: «4; %math.F64»): %math.F64 =
+    let s = %vec.fold.r (%math.arith.add 0) (v, 0.0 : %math.F64);
+    return s;

--- a/src/mim/plug/vec/normalizers.cpp
+++ b/src/mim/plug/vec/normalizers.cpp
@@ -30,6 +30,19 @@ const Def* normalize_fold(const Def*, const Def* c, const Def* arg) {
         return acc;
     }
 
+    // Runtime vector with compile-time-known width: scalarize via element extraction.
+    if (auto arr = vec->type()->isa<Arr>()) {
+        if (auto n = Lit::isa(arr->arity()); n && *n < w.flags().scalarize_threshold) {
+            if constexpr (id == fold::l)
+                for (size_t j = 0; j != *n; ++j)
+                    acc = w.app(f, {acc, vec->proj(*n, j)});
+            else
+                for (size_t j = *n; j-- != 0;)
+                    acc = w.app(f, {vec->proj(*n, j), acc});
+            return acc;
+        }
+    }
+
     if (auto pack = vec->isa_imm<Pack>()) w.WLOG("packs not yet implemented: {}", pack);
 
     if (auto l = vec->isa<Lit>()) {


### PR DESCRIPTION
## Background

before this fix, the `normalize_fold` cannot handle runtime vectors, thus it will throw an unhanded def error in llvm:

```bash
./build/bin/mim ../MimIR/lit/vec/fold_runtime.mim --output-ll - # the fold_runtime.mim is added as a test case
error: unhandled def in LLVM backend: s_31307 : %math.F (52, 11)
```

## Solution
 
- Extend normalize_fold to handle runtime arrays: when the vector has a compile-time-known arity, scalarize via
  element-wise Extract + app instead of returning nullptr.
 - Fix the Extract handler in ll.h: for SIMD-typed tuples with a literal index, emit extractelement instead of returning
  the whole vector register.