### PR TITLE
Rewrite Pack var with Array var when building type

### DIFF
--- a/lit/bug/pack_not_closed.mim
+++ b/lit/bug/pack_not_closed.mim
@@ -1,3 +1,5 @@
+// RUN: %mim %s -o -
+
 lam extern test {n: Nat} {Ts: «n; ★»} [values: «i: n; Ts#i»]
   : [Nat, «i: n; Ts#i»]
   = (0, ‹i: n; values#i›);

--- a/lit/bug/pack_not_closed.mim
+++ b/lit/bug/pack_not_closed.mim
@@ -1,0 +1,2 @@
+lam extern test {n: Nat} {Ts: «n; ★»} [values: «i: n; Ts#i»]
+  = ‹i: n; values#i›;

--- a/lit/bug/pack_not_closed.mim
+++ b/lit/bug/pack_not_closed.mim
@@ -1,4 +1,4 @@
-// RUN: %mim %s -o -
+// RUN: %mim %s -O 1
 
 lam extern test {n: Nat} {Ts: «n; ★»} [values: «i: n; Ts#i»]
   : [Nat, «i: n; Ts#i»]

--- a/lit/bug/pack_not_closed.mim
+++ b/lit/bug/pack_not_closed.mim
@@ -1,2 +1,3 @@
 lam extern test {n: Nat} {Ts: «n; ★»} [values: «i: n; Ts#i»]
-  = ‹i: n; values#i›;
+  : [Nat, «i: n; Ts#i»]
+  = (0, ‹i: n; values#i›);

--- a/src/mim/ast/emit.cpp
+++ b/src/mim/ast/emit.cpp
@@ -340,8 +340,12 @@ const Def* SeqExpr::emit_(Emitter& e) const {
         auto var = p->var();
         arity()->emit_value(e, var);
         auto b = body()->emit(e);
-        a->set_body(b->type());
         p->set(b);
+        auto arr_b = b->type();
+        if (auto pvar = var->isa<Var>())
+            // Use array var in array body instead of pack var
+            arr_b = VarRewriter(pvar, a->var()).rewrite(arr_b);
+        a->set_body(arr_b);
         if (auto imm = p->immutabilize()) return imm;
         return p;
     } else {


### PR DESCRIPTION
fixes #414

When emitting a Pack from mim, check whether it has a Var and rewrite it with the Arr's var if so before setting the Arr's body. This prevents the Pack's var from being free in its type, which caused any expression containing dependent Packs to not be closed, as in the linked issue.