### PR TITLE
Always reduce pack#index

### DIFF
--- a/py/CMakeLists.txt
+++ b/py/CMakeLists.txt
@@ -26,7 +26,7 @@ set(MIM_PY_VENV_STAMP "${MIM_PY_VENV}/.mim-stamp")
 add_custom_command(
     OUTPUT "${MIM_PY_VENV_STAMP}"
     COMMAND "${CMAKE_COMMAND}" -E rm -rf "${MIM_PY_VENV}"
-    COMMAND $<$<PLATFORM_ID:Windows>:"${MIM_PY_BOOTSTRAP_PYTHON}"> $<$<PLATFORM_ID:Windows>:-m> $<$<PLATFORM_ID:Windows>:ensurepip> $<$<PLATFORM_ID:Windows>:--upgrade>
+    COMMAND $<$<PLATFORM_ID:Windows>:${MIM_PY_BOOTSTRAP_PYTHON}> -m ensurepip --upgrade
     COMMAND "${MIM_PY_BOOTSTRAP_PYTHON}" -m venv "${MIM_PY_VENV}"
     COMMAND "${MIM_PY_PYTHON}" -m pip install --upgrade pip setuptools wheel
     COMMAND "${MIM_PY_PYTHON}" -m pip install pytest

--- a/py/CMakeLists.txt
+++ b/py/CMakeLists.txt
@@ -26,7 +26,7 @@ set(MIM_PY_VENV_STAMP "${MIM_PY_VENV}/.mim-stamp")
 add_custom_command(
     OUTPUT "${MIM_PY_VENV_STAMP}"
     COMMAND "${CMAKE_COMMAND}" -E rm -rf "${MIM_PY_VENV}"
-    COMMAND "${MIM_PY_BOOTSTRAP_PYTHON}" -m ensurepip --upgrade
+    COMMAND $<$<PLATFORM_ID:Windows>:"${MIM_PY_BOOTSTRAP_PYTHON}"> $<$<PLATFORM_ID:Windows>:-m> $<$<PLATFORM_ID:Windows>:ensurepip> $<$<PLATFORM_ID:Windows>:--upgrade>
     COMMAND "${MIM_PY_BOOTSTRAP_PYTHON}" -m venv "${MIM_PY_VENV}"
     COMMAND "${MIM_PY_PYTHON}" -m pip install --upgrade pip setuptools wheel
     COMMAND "${MIM_PY_PYTHON}" -m pip install pytest

--- a/py/CMakeLists.txt
+++ b/py/CMakeLists.txt
@@ -26,9 +26,10 @@ set(MIM_PY_VENV_STAMP "${MIM_PY_VENV}/.mim-stamp")
 add_custom_command(
     OUTPUT "${MIM_PY_VENV_STAMP}"
     COMMAND "${CMAKE_COMMAND}" -E rm -rf "${MIM_PY_VENV}"
+    COMMAND "${MIM_PY_BOOTSTRAP_PYTHON}" -m ensurepip --upgrade
     COMMAND "${MIM_PY_BOOTSTRAP_PYTHON}" -m venv "${MIM_PY_VENV}"
-    COMMAND "${MIM_PY_PYTHON}" -m pip install --quiet --upgrade pip setuptools wheel
-    COMMAND "${MIM_PY_PYTHON}" -m pip install --quiet pytest
+    COMMAND "${MIM_PY_PYTHON}" -m pip install --upgrade pip setuptools wheel
+    COMMAND "${MIM_PY_PYTHON}" -m pip install pytest
     COMMAND "${CMAKE_COMMAND}" -E touch "${MIM_PY_VENV_STAMP}"
     COMMENT "mim_py: creating venv at ${MIM_PY_VENV}"
     VERBATIM

--- a/src/mim/world.cpp
+++ b/src/mim/world.cpp
@@ -390,11 +390,16 @@ const Def* World::extract(const Def* d, const Def* index) {
         }
     }
 
-    if (auto pack = d->isa_imm<Pack>()) return pack->body();
-
     if (size && !Checker::alpha<Checker::Check>(type->arity(), size))
         error(index->loc(), "index '{}' does not fit within arity '{}'", index, type->arity());
     // TODO if we have indices we need to check as well that this is compatible with `d`
+
+    if (auto pack = d->isa<Pack>()) {
+        if (pack->has_var())
+            return pack->reduce(index);
+        else
+            return pack->body();
+    }
 
     // extract(insert(x, index, val), index) -> val
     if (auto insert = d->isa<Insert>()) {


### PR DESCRIPTION
This normalizes extracts where the tuple is a Pack the its body reduces with the extract index. In particular, this resolves a type checking issue I was having where `‹i1: n; ‹i2: n; foo#i2›#i1›` could not be unified with `‹i1: n; foo#i1›`. With this change, the first expression is reduces to the second immediately.