### PR TITLE
Add %tuple.head and %tuple.tail

### DIFF
--- a/lit/tuple/head_tail.mim
+++ b/lit/tuple/head_tail.mim
@@ -1,0 +1,25 @@
+// RUN: %mim %s
+plugin tuple;
+plugin refly;
+
+let tup = (1, tt, ff, 23, 42);
+
+let h = %tuple.head tup;
+let t = %tuple.tail tup;
+
+let _ = %refly.equiv.struc_eq (h, (1,));
+let _ = %refly.equiv.struc_eq (t, (tt, ff, 23, 42));
+
+/// uniform array
+let arr = ‹3; 7›;
+let ha  = %tuple.head arr;
+let ta  = %tuple.tail arr;
+
+let _ = %refly.equiv.struc_eq (ha, (7,));
+let _ = %refly.equiv.struc_eq (ta, ‹2; 7›);
+
+/// type-level
+lam f (a: [Nat, Bool, Nat]): [Nat]         = %tuple.head a;
+lam g (a: [Nat, Bool, Nat]): [Bool, Nat]   = %tuple.tail a;
+lam h_arr (a: «3; Nat»): [Nat]             = %tuple.head a;
+lam t_arr (a: «3; Nat»): «2; Nat»          = %tuple.tail a;

--- a/lit/tuple/head_tail.mim
+++ b/lit/tuple/head_tail.mim
@@ -1,4 +1,4 @@
-// RUN: %mim %s
+// RUN: %mim %s -O 1
 plugin tuple;
 plugin refly;
 

--- a/src/mim/plug/tuple/tuple.mim
+++ b/src/mim/plug/tuple/tuple.mim
@@ -9,6 +9,7 @@
 /// ## Dependencies
 ///
 plugin core;
+plugin refly;
 ///
 /// ## Operations
 ///
@@ -44,6 +45,15 @@ lam %tuple.prepend  {m: Nat}
                     (a: T, b: «i: m; Us#i»)
                   : %tuple.typecat T Us
                   = %tuple.cat (a, b);
+
+lam %tuple.pop {n: Nat}
+    {Ts: «n; ★»}
+    [values: «i: n; Ts#i»]
+  : [Ts#(%core.idx n %core.mode.US 0), «i: %core.nat.sub (n, 1); Ts#(%core.bitcast (Idx n) (%core.nat.add (%core.bitcast Nat i, 1)))»]
+  = %refly.check (%core.ncmp.ne (n, 0),
+    (values#(%core.idx n %core.mode.US 0), ‹i: %core.nat.sub (n, 1); values#(%core.bitcast (Idx n) (%core.nat.add (%core.bitcast Nat i, 1)))›),
+    "cannot pop from empty tuple");
+
 ///
 /// ### %%tuple.contains
 ///

--- a/src/mim/plug/tuple/tuple.mim
+++ b/src/mim/plug/tuple/tuple.mim
@@ -46,12 +46,20 @@ lam %tuple.prepend  {m: Nat}
                   : %tuple.typecat T Us
                   = %tuple.cat (a, b);
 
-lam %tuple.pop {n: Nat}
+lam %tuple.head {n: Nat}
     {Ts: «n; ★»}
     [values: «i: n; Ts#i»]
-  : [Ts#(%core.idx n %core.mode.US 0), «i: %core.nat.sub (n, 1); Ts#(%core.bitcast (Idx n) (%core.nat.add (%core.bitcast Nat i, 1)))»]
+  : [Ts#(%core.idx n %core.mode.US 0)]
   = %refly.check (%core.ncmp.ne (n, 0),
-    (values#(%core.idx n %core.mode.US 0), ‹i: %core.nat.sub (n, 1); values#(%core.bitcast (Idx n) (%core.nat.add (%core.bitcast Nat i, 1)))›),
+    values#(%core.idx n %core.mode.US 0),
+    "cannot pop from empty tuple");
+
+lam %tuple.tail {n: Nat}
+    {Ts: «n; ★»}
+    [values: «i: n; Ts#i»]
+  : «i: %core.nat.sub (n, 1); Ts#(%core.bitcast (Idx n) (%core.nat.add (%core.bitcast Nat i, 1)))»
+  = %refly.check (%core.ncmp.ne (n, 0),
+    ‹i: %core.nat.sub (n, 1); values#(%core.bitcast (Idx n) (%core.nat.add (%core.bitcast Nat i, 1)))›,
     "cannot pop from empty tuple");
 
 ///

--- a/src/mim/plug/tuple/tuple.mim
+++ b/src/mim/plug/tuple/tuple.mim
@@ -9,7 +9,6 @@
 /// ## Dependencies
 ///
 plugin core;
-plugin refly;
 ///
 /// ## Operations
 ///

--- a/src/mim/plug/tuple/tuple.mim
+++ b/src/mim/plug/tuple/tuple.mim
@@ -50,17 +50,13 @@ lam %tuple.head {n: Nat}
     {Ts: «n; ★»}
     [values: «i: n; Ts#i»]
   : [Ts#(%core.idx n %core.mode.US 0)]
-  = %refly.check (%core.ncmp.ne (n, 0),
-    values#(%core.idx n %core.mode.US 0),
-    "cannot pop from empty tuple");
+  = values#(%core.idx n %core.mode.US 0);
 
 lam %tuple.tail {n: Nat}
     {Ts: «n; ★»}
     [values: «i: n; Ts#i»]
   : «i: %core.nat.sub (n, 1); Ts#(%core.bitcast (Idx n) (%core.nat.add (%core.bitcast Nat i, 1)))»
-  = %refly.check (%core.ncmp.ne (n, 0),
-    ‹i: %core.nat.sub (n, 1); values#(%core.bitcast (Idx n) (%core.nat.add (%core.bitcast Nat i, 1)))›,
-    "cannot pop from empty tuple");
+  = ‹i: %core.nat.sub (n, 1); values#(%core.bitcast (Idx n) (%core.nat.add (%core.bitcast Nat i, 1)))›;
 
 ///
 /// ### %%tuple.contains

--- a/src/mim/plug/tuple/tuple.mim
+++ b/src/mim/plug/tuple/tuple.mim
@@ -46,13 +46,13 @@ lam %tuple.prepend  {m: Nat}
                   = %tuple.cat (a, b);
 
 lam %tuple.head {n: Nat}
-    {Ts: «n; ★»}
+    {Ts: «n; *»}
     [values: «i: n; Ts#i»]
   : [Ts#(%core.idx n %core.mode.US 0)]
   = values#(%core.idx n %core.mode.US 0);
 
 lam %tuple.tail {n: Nat}
-    {Ts: «n; ★»}
+    {Ts: «n; *»}
     [values: «i: n; Ts#i»]
   : «i: %core.nat.sub (n, 1); Ts#(%core.bitcast (Idx n) (%core.nat.add (%core.bitcast Nat i, 1)))»
   = ‹i: %core.nat.sub (n, 1); values#(%core.bitcast (Idx n) (%core.nat.add (%core.bitcast Nat i, 1)))›;


### PR DESCRIPTION
This PR adds the lams %tuple.head and %tuple.tail, which are frequently useful when implementing recursive functions consuming tuples. It does currently not check that the tuple is not empty, as that broke type checking in some of my use cases, so the error messages for n=0 are not great. 

Depends on #425