### PR TITLE
Add axioms to inspect closedness of expressions to refly

### DIFF
--- a/src/mim/plug/refly/normalizers.cpp
+++ b/src/mim/plug/refly/normalizers.cpp
@@ -95,6 +95,25 @@ const Def* normalize_check(const Def* type, const Def*, const Def* arg) {
     return nullptr;
 }
 
+template<vars id>
+const Def* normalize_vars(const Def* type, const Def* callee, const Def* arg) {
+    auto& world = type->world();
+
+    if constexpr (id == vars::is_closed) return arg->is_closed() ? world.lit_tt() : world.lit_ff();
+
+    if constexpr (id == vars::await_closed) {
+        // Curried: (await_closed T U) t u — fires on inner app where `callee` is the outer app applied to `t`.
+        if (auto outer = callee->isa<App>()) {
+            if (Axm::isa(vars::await_closed, outer->callee())) {
+                auto t = outer->arg();
+                if (t->is_closed()) return arg;
+            }
+        }
+    }
+
+    return {};
+}
+
 MIM_refly_NORMALIZER_IMPL
 
 } // namespace mim::plug::refly

--- a/src/mim/plug/refly/normalizers.cpp
+++ b/src/mim/plug/refly/normalizers.cpp
@@ -102,13 +102,7 @@ const Def* normalize_vars(const Def* type, const Def* callee, const Def* arg) {
     if constexpr (id == vars::is_closed) return arg->is_closed() ? world.lit_tt() : world.lit_ff();
 
     if constexpr (id == vars::await_closed) {
-        // Curried: (await_closed T U) t u — fires on inner app where `callee` is the outer app applied to `t`.
-        if (auto outer = callee->isa<App>()) {
-            if (Axm::isa(vars::await_closed, outer->callee())) {
-                auto t = outer->arg();
-                if (t->is_closed()) return arg;
-            }
-        }
+        if (callee->as<App>()->is_closed()) return arg;
     }
 
     return {};

--- a/src/mim/plug/refly/refly.mim
+++ b/src/mim/plug/refly/refly.mim
@@ -83,6 +83,15 @@ axm %refly.equiv(ae = struc_ne, aE = struc_eq,
 ///
 axm %refly.check: {T: *} → {n: Nat} → [Bool, T, «n; I8»] → T, normalize_check;
 ///
+/// ### %%refly.vars
+///
+/// Inspect free-variable closedness of a Mim expression.
+/// * `is_closed`: Normalizes immediately to `tt` if the argument has no free vars, otherwise `ff`.
+/// * `await_closed`: Waits until the first argument is closed; then normalizes to the second argument.
+///
+axm %refly.vars(is_closed): {T: *} → T → Bool, normalize_vars;
+axm %refly.vars(await_closed): {T U: *} → T → U → U, normalize_vars;
+///
 /// ## Manipulate
 ///
 /// ### %%refly.refine


### PR DESCRIPTION
This PR introduces two new axioms to refly that allow to inspect expression closed-ness:
`%refly.vars.is_closed e`: Checks whether the expression `e` is closed. In contrast to `%core.pe.is_closed`, this always normalizes immediately upon construction to either `tt` or `ff`.
`%refly.vars.await_closed guard e`: Normalizes to expression `e` once expression `guard` is closed. This allows precise control over when other normalers are fired depending on other expressions becoming constant. Combined with `%refly.vars.is_closed`, it allows for example to check whether some expression is still not closed once a different expression is, which can be used to delay checking closed-ness inside a lam body until it gets reduced/partially evaluated.

Notably, `%core.pe.is_closed e` could now be rewritten as `%core.refly.await_closed e tt`, if that is desired.