### PR TITLE
Add assertion to check if all ops of a Def are in the current world.

### DIFF
--- a/include/mim/world.h
+++ b/include/mim/world.h
@@ -693,6 +693,7 @@ private:
 #ifdef MIM_ENABLE_CHECKS
         if (flags().trace_gids) std::println("{}: {} - {}", def->node_name(), def->gid(), def->flags());
         if (flags().reeval_breakpoints && breakpoints().contains(def->gid())) fe::breakpoint();
+        for (auto op : def->ops()) assert(&op->world() == this && "op of new Def belongs to a different World");
 #endif
 
         if (is_frozen()) {

--- a/include/mim/world.h
+++ b/include/mim/world.h
@@ -693,7 +693,9 @@ private:
 #ifdef MIM_ENABLE_CHECKS
         if (flags().trace_gids) std::println("{}: {} - {}", def->node_name(), def->gid(), def->flags());
         if (flags().reeval_breakpoints && breakpoints().contains(def->gid())) fe::breakpoint();
-        for (auto op : def->ops()) assert(&op->world() == this && "op of new Def belongs to a different World");
+        for (auto op : def->ops())
+            assert(&op->world() == this && "op of new Def belongs to a different World");
+        assert(!def->type() || &def->type()->world() == this && "type of new Def belongs to a different World");
 #endif
 
         if (is_frozen()) {


### PR DESCRIPTION
As brought up in #312 

For most tests that I tried to fabricate, it crashed somewhere earlier already (due to e.g. Zonk-ing), however this should still capture otherwise silent issues.