### PR TITLE
[core] Implement identity normalization for double conversion in normalize_conv

### DIFF
--- a/lit/core/fold.mim
+++ b/lit/core/fold.mim
@@ -102,6 +102,14 @@ let _ = %refly.equiv.struc_eq (%core.conv.u 3 4_5, 1_3);
 let _ = %refly.equiv.struc_eq (%core.conv.s 3 4_5, 2_3);
 let _ = %refly.equiv.struc_eq (%core.conv.s 3 3_5, 1_3);
 
+/// conv(conv(x)) -> x: widening then narrowing back to the original size is the identity.
+/// Symbolic operands are required here since literal chains already fold via the literal path above.
+lam conv_uu_widen   (x: I8):    I8    = %refly.equiv.struc_eq (%core.conv.u i8 (%core.conv.u i16 x), x);
+lam conv_ss_widen   (x: I8):    I8    = %refly.equiv.struc_eq (%core.conv.s i8 (%core.conv.s i16 x), x);
+lam conv_uu_to_i64  (x: I8):    I8    = %refly.equiv.struc_eq (%core.conv.u i8 (%core.conv.u i64 x), x);
+lam conv_uu_idx5    (x: Idx 5): Idx 5 = %refly.equiv.struc_eq (%core.conv.u 5 (%core.conv.u i16 x), x);
+lam conv_ss_idx5    (x: Idx 5): Idx 5 = %refly.equiv.struc_eq (%core.conv.s 5 (%core.conv.s i16 x), x);
+
 /// word-domain icmp basic
 let _ = %refly.equiv.struc_eq (%core.icmp.e  (42I8, 42I8), tt);
 let _ = %refly.equiv.struc_eq (%core.icmp.ne (42I8, 43I8), tt);

--- a/src/mim/plug/core/normalizers.cpp
+++ b/src/mim/plug/core/normalizers.cpp
@@ -873,6 +873,14 @@ const Def* normalize_conv(const Def* dst_t, const Def*, const Def* x) {
         return world.lit(d_t, idx_from_signed_mod(*ld, idx_sext(*ls, *l)));
     }
 
+    if (ls && ld)
+        if (auto c1 = Axm::isa(id, x)) {
+            auto x1 = c1->arg();
+            if (auto ls1 = Lit::isa(x1->type()->as<App>()->arg()))
+                if (*ls > *ls1 || *ls == 0)     // the intermediate conv is widening
+                    if (*ld == *ls1) return x1; // conv(conv(x)) -> x
+        }
+
     return {};
 }
 


### PR DESCRIPTION
This only applies if the first conv is a widening conversion and the second conversion converts back to the initial size. Furthermore it also only is applied when using the same conv type (u/s).

sample that I encontered:
```rust
                let _85816: Idx 4 = %core.conv.u 0 4 _85783;
                let _85817: I64 = %core.conv.u 4 0 _85816;
                let _85818: Idx 4 = %core.conv.u 0 4 _85817;
-> 
                let _85816: Idx 4 = %core.conv.u 0 4 _85783;
```