### PR TITLE
Add affine maps to model affine expressions and showcase in map_reduce_aff

### DIFF
--- a/include/mim/plug/affine/phase/lower_index.h
+++ b/include/mim/plug/affine/phase/lower_index.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <mim/phase.h>
+
+namespace mim::plug::affine::phase {
+
+/// Lowers the affine index algebra to %core arithmetic.
+///
+/// The opaque %affine.index type is rewritten to the wide `Idx 0` (i64) carrier, and the index operations are computed with
+/// wrap-around (`%core.Mode::none`) arithmetic, so negation/subtraction are correct via two's complement:
+/// * `%affine.constant n`           ↦ `n` reinterpreted as an `Idx 0`,
+/// * `%affine.op.add (a, b)`        ↦ `%core.wrap.add none (a, b)`,
+/// * `%affine.op.sub (a, b)`        ↦ `%core.wrap.sub none (a, b)`,
+/// * `%affine.op.neg a`             ↦ `%core.wrap.sub none (0, a)`,
+/// * `%affine.semiop.mul (a, c)`    ↦ `%core.wrap.mul none (a, c)`.
+///
+/// The `%affine.map f idxs` bridge lowers to: widen each runtime `idxs#i : Idx (sin#i)` to `Idx 0` via `%core.conv.u`, apply
+/// the (now core-arithmetic) function `f`, and narrow each result back to its target `Idx (sout#j)` via `%core.conv.u`.
+///
+/// The division-based semiops (`ceildiv`, `floordiv`, `mod`) are not yet lowered (they require `%core.div`, which threads
+/// a `%mem.M`); they currently raise an error.
+class LowerIndex : public RWPhase {
+public:
+    LowerIndex(World& world, flags_t annex)
+        : RWPhase(world, annex) {}
+
+    const Def* rewrite(const Def*) final;
+    const Def* rewrite_imm_App(const App*) final;
+};
+
+} // namespace mim::plug::affine::phase

--- a/include/mim/plug/tensor/phase/lower_map_reduce.h
+++ b/include/mim/plug/tensor/phase/lower_map_reduce.h
@@ -20,6 +20,7 @@ private:
     const Def* lower_set(const App*);
     const Def* lower_broadcast(const App*);
     const Def* lower_map_reduce(const App*);
+    const Def* lower_map_reduce_aff(const App*);
 
     const Def* rec_broadcast(const Def* s_in, const Def* s_out, const Def* input, u64 r, u64 i);
 };

--- a/lit/affine/affine_index.mim
+++ b/lit/affine/affine_index.mim
@@ -1,0 +1,37 @@
+// RUN: rm -f %t.ll
+// RUN: %mim %s --output-ll %t.ll -o - | %FileCheck %s
+// RUN: clang %t.ll -o %t -Wno-override-module
+// RUN: %t       ; test $? -eq 9
+// RUN: %t 1 2 3 ; test $? -eq 21
+
+plugin core;
+plugin affine;
+plugin mem;
+
+// f exercises the affine index algebra over two input indices `a`, `b`:
+//   out0 = (a + b) - b = a   (op.add + op.sub)
+//   out1 = a * 3             (semiop.mul)
+//   out2 = 5                 (constant)
+lam f (idx: «2; %affine.index»): «3; %affine.index» =
+    ( %affine.op.sub (%affine.op.add (idx#0_2, idx#1_2), idx#1_2)
+    , %affine.semiop.mul (idx#0_2, 3)
+    , %affine.constant 5
+    );
+
+// The moduli `sin`/`sout` cannot be inferred from `f` (which is %affine.index-valued),
+// so they are passed explicitly: here both inputs and all outputs are `I32` (modulus 2^32).
+con extern main [mem : %mem.M 0, argc : I32, argv : %mem.Ptr (%mem.Ptr (I32, 0), 0), return : Cn [%mem.M 0, I32]] =
+    let a = argc;
+    let b = 4I32;
+    let r = %affine.map @(3, 2) @((i32, i32), (i32, i32, i32)) f (a, b);
+    // sum = a + 3*a + 5 = 4*a + 5
+    let s0 = %core.wrap.add 0 (r#0_3, r#1_3);
+    let s  = %core.wrap.add 0 (s0, r#2_3);
+    return (mem, s);
+
+// The whole affine index algebra must be gone after %affine.lower_index_phase.
+// CHECK-NOT: %affine.index
+// CHECK-NOT: %affine.constant
+// CHECK-NOT: %affine.op
+// CHECK-NOT: %affine.semiop
+// CHECK-NOT: %affine.map

--- a/lit/affine/affine_index_symbolic.mim
+++ b/lit/affine/affine_index_symbolic.mim
@@ -1,0 +1,26 @@
+// RUN: %mim %s -o - | %FileCheck %s --implicit-check-not=affine.
+
+// The input/output bounds are only symbolically known (the `Nat` parameters `m` and `n`), so the lowering must thread the
+// symbolic moduli through `%core.conv.u` rather than baking in a concrete `Idx` size. `g` stays polymorphic (hence this is a
+// pipeline/FileCheck test, not an executable one) so the symbolic bound survives to `%affine.lower_index_phase`.
+
+plugin core;
+plugin affine;
+plugin mem;
+
+lam f (idx: «2; %affine.index»): «2; %affine.index» =
+    ( %affine.op.add (idx#0_2, idx#1_2)
+    , %affine.semiop.mul (idx#1_2, 2)
+    );
+
+// `a` and `b` carry distinct, symbolically-known bounds `m` and `n`; the outputs are `Idx m` and `Idx n` respectively.
+fun extern g {m n: Nat} (a: Idx m, b: Idx n): «i: 2; Idx ((m, n)#i)» =
+    return (%affine.map f (a, b));
+
+// CHECK: fun extern g {m{{.*}}: Nat, n{{.*}}: Nat}
+// Inputs are widened from their symbolic moduli `Idx m` / `Idx n` to the `Idx 0` carrier ...
+// CHECK-DAG: %core.conv.u m{{[0-9_]*}} 0
+// CHECK-DAG: %core.conv.u n{{[0-9_]*}} 0
+// ... and the results are narrowed back to the symbolic `Idx m` / `Idx n`.
+// CHECK-DAG: %core.conv.u 0 m{{[0-9_]*}}
+// CHECK-DAG: %core.conv.u 0 n{{[0-9_]*}}

--- a/lit/tensor/map_reduce_aff.mim
+++ b/lit/tensor/map_reduce_aff.mim
@@ -1,0 +1,42 @@
+// RUN: %mim %s -o - | %FileCheck %s
+// RUN: %mim %s -o - | %FileCheck %s --check-prefix=GONE
+
+// Exercises %tensor.map_reduce_aff, the affine-indexed generalisation of %tensor.map_reduce.
+// The inputs are taken as extern array arguments (as in hlo.mim) so the lowering is realistic; the
+// test checks the lowered Mim IR (no codegen). The GONE prefix asserts the axiom is fully lowered
+// away in every function.
+// GONE-NOT: %tensor.map_reduce_aff
+
+plugin core;
+plugin tensor;
+plugin affine;
+plugin mem;
+
+fun add  (x: I32, y: «1; I32»)@tt = return (%core.wrap.add 0 (x, y#0_1));
+fun copy (x: I32, y: «1; I32»)@tt = return (y#0_1);
+lam id1 (i  : %affine.index): «1; %affine.index» = i;
+lam id1i(i,j: %affine.index): «1; %affine.index» = i;
+lam id2 (i,j: %affine.index): «2; %affine.index» = (i, j);
+lam tr  (i,j: %affine.index): «2; %affine.index» = (j, i);
+lam sl  (i  : %affine.index): «1; %affine.index» = (%affine.op.add (%affine.semiop.mul (i, 3), %affine.constant 2),);
+
+// A reduction (`Ro = Rr = 1`): out[i] = sum_j input[i][j], with a projection input access and the identity output map.
+// CHECK-DAG: fun extern row_sum
+fun extern row_sum (input: «3, 4; I32»): «3; I32» =
+    return (%tensor.map_reduce_aff @1 @(I32, 1, 1) (3, (3, 4))
+                @(I32, 2, (3, 4)) (add, 0I32) id1i id2 input);
+
+// Transpose via the output map `acc_out` (`Rr = 0`): out[j][i] = input[i][j].
+// CHECK-DAG: fun extern transpose
+fun extern transpose (input: «2, 3; I32»): «3, 2; I32» =
+    return (%tensor.map_reduce_aff @1 @(I32, 2, 0) ((3,2), (2, 3))
+                @(‹1; I32›, ‹1; 2›, ‹1; (2, 3)›) (copy, ⊥:I32) tr id2 input);
+
+// A strided slice via the affine input map: out[i] = input[3*i + 2].
+// CHECK-DAG: fun extern strided
+// The affine read index `3*i + 2` lowers to %core arithmetic:
+// CHECK-DAG: %core.wrap.mul {{.*}}(3I64
+// CHECK-DAG: %core.wrap.add {{.*}}(2I64
+fun extern strided (input: «8; I32»): «2; I32» =
+    return (%tensor.map_reduce_aff @1 @(I32, 1, 0) (‹1; 2›, ‹1; 2›)
+                @(‹1; I32›, ‹1; 1›, ‹1; ‹1; 8››) (copy, ⊥:I32) id1 sl input);

--- a/src/mim/plug/affine/CMakeLists.txt
+++ b/src/mim/plug/affine/CMakeLists.txt
@@ -2,5 +2,6 @@ add_mim_plugin(affine
     SOURCES
         affine.cpp
         phase/lower_for.cpp
+        phase/lower_index.cpp
     INSTALL
 )

--- a/src/mim/plug/affine/affine.cpp
+++ b/src/mim/plug/affine/affine.cpp
@@ -4,10 +4,14 @@
 #include <mim/pass.h>
 
 #include "mim/plug/affine/phase/lower_for.h"
+#include "mim/plug/affine/phase/lower_index.h"
 
 using namespace mim;
 using namespace mim::plug;
 
-void reg_stages(Flags2Stages& stages) { Stage::hook<affine::lower_for_phase, affine::phase::LowerFor>(stages); }
+void reg_stages(Flags2Stages& stages) {
+    Stage::hook<affine::lower_for_phase, affine::phase::LowerFor>(stages);
+    Stage::hook<affine::lower_index_phase, affine::phase::LowerIndex>(stages);
+}
 
 extern "C" MIM_EXPORT Plugin mim_get_plugin() { return {"affine", MIM_VERSION, nullptr, reg_stages, nullptr}; }

--- a/src/mim/plug/affine/affine.mim
+++ b/src/mim/plug/affine/affine.mim
@@ -7,6 +7,8 @@
 /// ## Dependencies
 ///
 import mem;
+import core;
+import refly;
 ///
 /// ## Operations
 ///
@@ -25,6 +27,54 @@ axm %affine.For: {m n: Nat, Ts: «n; *»}
                → [Cn «i: n; Ts#i»]                                             // exit
                → Cn [begin _end step: Idx m, init: «i: n; Ts#i»];
 ///
+/// ## Affine Index Operations
+///
+/// ### %%affine.index
+/// The affine index type is an opaque type that can only be manipulated through the following operations.
+///
+axm %affine.index: *;
+///
+/// ### %%affine.constant
+/// Constructs an affine index from a constant natural number.
+///
+axm %affine.constant: Nat → %affine.index;
+///
+/// ### %%affine.op(add,sub)
+/// Performs addition and subtraction on affine indices.
+///
+axm %affine.op(add,sub): [%affine.index, %affine.index] → %affine.index;
+///
+/// ### %%affine.op(neg)
+/// Negates an affine index.
+///
+axm %affine.op(neg): %affine.index → %affine.index;
+///
+/// ### %%affine.semiop(mul,ceildiv,floordiv,mod)
+/// Performs semi-linear operations on affine indices.
+/// The second argument must be a constant natural number with regards to the indices.
+///
+axm %affine.semiop(mul,ceildiv,floordiv,mod): [%affine.index, Nat] → %affine.index;
+///
+/// ### %%affine.op(mul)
+/// Performs multiplication of an affine index with a constant natural number.
+/// The second argument must be a constant natural number (which is a stronger argument than the semiop).
+///
+lam %affine.op.mul (d : %affine.index, c : Nat): %affine.index = 
+    %affine.semiop.mul(d, %refly.check (%core.pe.is_closed(c), c, "The second argument of %affine.op.mul must be a constant."));
+
+///
+/// ### %%affine.map
+/// Maps a function over a list of affine indices.
+/// Any captured variables of the function must be closed over the entire list of indices, i.e. they must not depend on the iteration index.
+/// The moduli are per-element: each input index `i` carries its own modulus `sin#i` and each output index `j` its own `sout#j`.
+///
+axm %affine.map: {m n: Nat}
+               → {sin: «n; Nat», sout: «m; Nat»}
+               → ([«n; %affine.index»] → «m; %affine.index»)
+               → «i: n; Idx (sin#i)»
+               → «i: m; Idx (sout#i)»;
+
+///
 /// ## Passes and Phases
 ///
 /// ### %%affine.lower_for_pass
@@ -32,3 +82,9 @@ axm %affine.For: {m n: Nat, Ts: «n; *»}
 /// Loweres the %%%affine.For operation to recursive function calls.
 ///
 axm %affine.lower_for_phase: %compile.Phase;
+///
+/// ### %%affine.lower_index_phase
+///
+/// Lowers the affine index algebra (%%%affine.index, %%%affine.constant, %%%affine.op, %%%affine.semiop, %%%affine.map) to %%core arithmetic.
+///
+axm %affine.lower_index_phase: %compile.Phase;

--- a/src/mim/plug/affine/phase/lower_index.cpp
+++ b/src/mim/plug/affine/phase/lower_index.cpp
@@ -1,0 +1,86 @@
+#include "mim/plug/affine/phase/lower_index.h"
+
+#include <mim/def.h>
+#include <mim/lam.h>
+#include <mim/tuple.h>
+
+#include <mim/plug/core/core.h>
+
+#include "mim/plug/affine/affine.h"
+
+namespace mim::plug::affine::phase {
+
+const Def* LowerIndex::rewrite(const Def* def) {
+    // The opaque affine index type lowers to the wide `Idx 0` (i64) carrier.
+    if (Axm::isa<affine::index>(def)) return new_world().type_i64();
+    return RWPhase::rewrite(def);
+}
+
+const Def* LowerIndex::rewrite_imm_App(const App* app) {
+    if (is_bootstrapping()) return RWPhase::rewrite_imm_App(app);
+
+    auto& w = new_world();
+
+    // The affine index algebra is computed on the wide `Idx 0` carrier with wrap-around (`Mode::none`) arithmetic, so that
+    // negation/subtraction are correct via two's complement; the boundary `%affine.map` casts in/out with `%core.conv.u`.
+
+    // %affine.constant n ↦ the `Nat` n reinterpreted as an `Idx 0`.
+    if (Axm::isa<affine::constant>(app)) return w.call<core::bitcast>(w.type_i64(), rewrite(app->arg()));
+
+    if (auto op = Axm::isa<affine::op>(app)) {
+        switch (op.id()) {
+            case affine::op::add: {
+                auto [a, b] = rewrite(app->arg())->projs<2>();
+                return w.call(core::wrap::add, core::Mode::none, Defs{a, b});
+            }
+            case affine::op::sub: {
+                auto [a, b] = rewrite(app->arg())->projs<2>();
+                return w.call(core::wrap::sub, core::Mode::none, Defs{a, b});
+            }
+            case affine::op::neg: {
+                auto a = rewrite(app->arg());
+                return w.call(core::wrap::sub, core::Mode::none, Defs{w.lit(w.type_i64(), 0), a});
+            }
+            case affine::op::mul: {
+                error("affine.op.mul should have been rewritten to affine.semiop.mul and then to core.mul");
+            }
+        }
+    }
+
+    if (auto semiop = Axm::isa<affine::semiop>(app)) {
+        switch (semiop.id()) {
+            case affine::semiop::mul: {
+                auto [a, c] = rewrite(app->arg())->projs<2>();
+                // `c` is a `Nat` constant; reinterpret it on the `Idx 0` carrier.
+                return w.call(core::wrap::mul, core::Mode::none, Defs{a, w.call<core::bitcast>(w.type_i64(), c)});
+            }
+            case affine::semiop::ceildiv:
+            case affine::semiop::floordiv:
+            case affine::semiop::mod:
+                error("affine: lowering of semiop `{}` is not yet implemented (needs %core.div with a %mem.M token)",
+                      app);
+        }
+    }
+
+    // %affine.map f idxs ↦ widen idxs to `Idx 0`, apply f, narrow each result back to its target `Idx (sout#j)`.
+    if (Axm::isa<affine::map>(app)) {
+        auto f      = rewrite(app->callee()->as<App>()->arg()); // «n; Idx 0» → «m; Idx 0»
+        auto idxs   = rewrite(app->arg());                      // «n; Idx (sin#i)»
+        auto res_ty = rewrite(app->type());                     // «m; Idx (sout#j)»
+
+        auto ins    = idxs->projs();
+        auto lifted = w.tuple(
+            DefVec(ins.size(), [&](size_t i) { return w.call(core::conv::u, w.lit_i64(), ins[i]); }));
+
+        auto outs = w.app(f, lifted)->projs(); // «m; Idx 0»
+        return w.tuple(DefVec(outs.size(), [&](size_t j) {
+            // `res_ty#j` is `Idx (sout#j)`, i.e. `%Idx sout#j`; recover the destination size for `%core.conv.u`.
+            auto sout_j = res_ty->proj(outs.size(), j)->as<App>()->arg();
+            return w.call(core::conv::u, sout_j, outs[j]);
+        }));
+    }
+
+    return RWPhase::rewrite_imm_App(app);
+}
+
+} // namespace mim::plug::affine::phase

--- a/src/mim/plug/opt/opt.mim
+++ b/src/mim/plug/opt/opt.mim
@@ -48,6 +48,7 @@ lam extern _default_compile (): %compile.Phase =
                 %tensor.lower_map_reduce,
             )
         ),
+        cond_phase "affine" %affine.lower_index_phase,
         cond_phase "affine" %affine.lower_for_phase,
         %compile.pass2phase (
             %compile.passes (

--- a/src/mim/plug/tensor/normalizers.cpp
+++ b/src/mim/plug/tensor/normalizers.cpp
@@ -177,6 +177,11 @@ const Def* normalize_map_reduce(const Def*, const Def*, const Def*) {
     return nullptr;
 }
 
+const Def* normalize_map_reduce_aff(const Def*, const Def*, const Def*) {
+    // TODO: fold size-1 loop dimensions / identity access maps.
+    return nullptr;
+}
+
 MIM_tensor_NORMALIZER_IMPL
 
 } // namespace mim::plug::tensor

--- a/src/mim/plug/tensor/phase/lower_map_reduce.cpp
+++ b/src/mim/plug/tensor/phase/lower_map_reduce.cpp
@@ -170,8 +170,8 @@ const Def* LowerMapReduce::lower_broadcast(const App* app) {
 static std::pair<Lam*, const Def*> counting_for(const Def* bound, const Def* acc, const Def* exit, Sym name) {
     auto& w       = bound->world();
     auto acc_ty   = acc->type();
-    auto body     = w.mut_con({/* iter */ w.type_i32(), /* acc */ acc_ty, /* return */ w.cn(acc_ty)})->set(name);
-    auto for_loop = w.call<affine::For>(body, exit, Defs{w.lit_i32(0), bound, w.lit_i32(1), acc});
+    auto body     = w.mut_con({/* iter */ w.type_i64(), /* acc */ acc_ty, /* return */ w.cn(acc_ty)})->set(name);
+    auto for_loop = w.call<affine::For>(body, exit, Defs{w.lit_i64(0), bound, w.lit_i64(1), acc});
     return {body, for_loop};
 }
 
@@ -287,7 +287,7 @@ create_outer_loop(Lam* fun, const Vector<u64>& out_indices, const absl::flat_has
     for (auto idx : out_indices) {
         auto for_name    = w.sym("forIn_" + std::to_string(idx));
         auto dim_nat_def = dims.at(idx);
-        auto dim         = w.call<core::bitcast>(w.type_i32(), dim_nat_def);
+        auto dim         = w.call<core::bitcast>(w.type_i64(), dim_nat_def);
         w.DLOG("out_cont {} : {}", cont, cont->type());
 
         auto [body, for_call]       = counting_for(dim, acc, cont, for_name);
@@ -465,7 +465,7 @@ const Def* LowerMapReduce::lower_map_reduce(const App* app) {
         for (auto idx : in_indices) {
             auto for_name    = w.sym("forIn_" + std::to_string(idx));
             auto dim_nat_def = dims[idx];
-            auto dim         = w.call<core::bitcast>(w.type_i32(), dim_nat_def);
+            auto dim         = w.call<core::bitcast>(w.type_i64(), dim_nat_def);
             DLOG("in_cont {} : {}", cont, cont->type());
 
             auto [body, for_call]       = counting_for(dim, acc, cont, for_name);
@@ -519,6 +519,157 @@ const Def* LowerMapReduce::lower_map_reduce(const App* app) {
     }
 }
 
+const Def* LowerMapReduce::lower_map_reduce_aff(const App* app) {
+    // meta arguments:
+    // * nis = in-count (nat)
+    // * To = out-type (*), Ro = #output loops = result rank, Rr = #reduction loops
+    // * So = result shape (Ro*nat)
+    // * Sr = the full loop bounds (Ro+Rr)*nat: the leading Ro are the output-loop bounds, the trailing Rr the
+    // reductions
+    // * Tis/Ris/Sis = input types/ranks/shapes
+    // arguments:
+    // * f = combination function (CPS), init = accumulator init
+    // * acc_out = affine map from the (Ro+Rr) loop vector to the Ro write coordinates in the result «So» (the reduction
+    //             part is not in scope at write-back, so acc_out must depend only on the leading Ro output indices)
+    // * accs = per-input affine map from the (Ro+Rr) loop vector to the input's read coordinates
+    // * is = input tensors
+    auto& w     = new_world();
+    auto c      = rewrite(app->callee())->as<App>();
+    auto inputs = rewrite(app->arg());
+    auto type   = rewrite(app->type());
+
+    auto [nis, meta, shapes, TisRisSis, comb_init, acc_out, accs] = c->uncurry_args<7>();
+    auto [To, Ro, Rr]                                             = meta->projs<3>();
+    auto [So, Sr]                                                 = shapes->projs<2>();
+    auto [Tis, Ris, Sis]                                          = TisRisSis->projs<3>();
+    auto [comb, init]                                             = comb_init->projs<2>();
+
+    auto nis_l = Lit::isa<u64>(nis);
+    auto ro_l = Lit::isa<u64>(Ro), rr_l = Lit::isa<u64>(Rr);
+    if (!nis_l || !ro_l || !rr_l) {
+        WLOG("{} doesn't have lowering-time known rank counts (nis/Ro/Rr)", app);
+        return nullptr;
+    }
+    auto nis_nat = *nis_l;
+    auto ro = *ro_l, rr = *rr_l;
+    auto nloops = ro + rr;           // length of the full loop vector (= length of Sr)
+    auto n      = w.lit_nat(nloops); // passed as the affine maps' domain length
+
+    // ranks of each input must be literal so that we know how many `extract`s to emit
+    Vector<u64> ris_nat(nis_nat);
+    for (u64 i = 0; i < nis_nat; ++i) {
+        auto l = Lit::isa<u64>(Ris->proj(nis_nat, i));
+        if (!l) {
+            WLOG("input {} of {} has a non-literal rank", i, app);
+            return nullptr;
+        }
+        ris_nat[i] = *l;
+    }
+
+    // Builds `%affine.map @(m, n) @(sin, sout) f idxs`. The emitted `%affine.map` is lowered to %core arithmetic by the
+    // subsequent %affine.lower_index_phase.
+    auto affine_map = [&](const Def* f, const Def* m, const Def* n, const Def* sin, const Def* sout, const Def* idxs) {
+        auto a = w.app(w.annex<affine::map>(), w.tuple({m, n}));
+        a      = w.app(a, w.tuple({sin, sout}));
+        a      = w.app(a, f);
+        return w.app(a, idxs);
+    };
+    auto nested_extract = [&](const Def* matrix, const Def* coords, u64 r) {
+        auto cur = matrix;
+        for (u64 k = 0; k < r; ++k)
+            cur = w.extract(cur, coords->proj(r, k));
+        return cur;
+    };
+    auto nested_insert = [&](const Def* matrix, const Def* coords, u64 r, const Def* elem) -> const Def* {
+        if (r == 0) return elem;
+        DefVec subs(r);
+        subs[0] = matrix;
+        for (u64 k = 0; k + 1 < r; ++k)
+            subs[k + 1] = w.extract(subs[k], coords->proj(r, k));
+        auto cur = elem;
+        for (auto k = static_cast<s64>(r) - 1; k >= 0; --k)
+            cur = w.insert(subs[k], coords->proj(r, k), cur);
+        return cur;
+    };
+
+    try {
+        auto fun    = w.mut_fun(inputs->type(), type)->set("mapRedAff");
+        auto ds_fun = direct::op_cps2ds_dep(fun)->set("dsFun");
+        auto call   = w.app(ds_fun, inputs)->set("call");
+
+        auto new_inputs = fun->var(0)->set("is");
+
+        // Outer (parallel) loops over the leading Ro bounds of `Sr`, collecting the output iteration indices.
+        auto cont        = fun->var(1);
+        auto init_mat    = w.bot(cont->type()->as<Pi>()->dom());
+        auto acc         = init_mat;
+        auto current_mut = fun;
+        DefVec out_iters;
+        out_iters.reserve(ro);
+        for (u64 i = 0; i < ro; ++i) {
+            auto dim                    = Sr->proj(nloops, i);
+            auto bound                  = w.call<core::bitcast>(w.type_i64(), dim);
+            auto [body, for_call]       = counting_for(bound, acc, cont, w.sym("forOut_" + std::to_string(i)));
+            auto [iter, new_acc, yield] = body->vars<3>();
+            cont                        = yield;
+            out_iters.push_back(w.call(core::conv::u, dim, iter));
+            acc = new_acc;
+            current_mut->set(true, for_call);
+            current_mut = body;
+        }
+        auto wb_matrix = acc;
+
+        // Write-back: narrow the accumulated element into the result at the affine write coordinates `acc_out`.
+        // acc_out takes the full (Ro+Rr) loop vector, but the reduction loops have already been folded away here, so we
+        // pass 0 for those slots; acc_out must depend only on the leading Ro output indices.
+        auto write_back    = w.mut_con(To)->set("writeBack");
+        auto element_final = write_back->var(0);
+        DefVec wb_iters    = out_iters;
+        for (u64 j = 0; j < rr; ++j)
+            wb_iters.push_back(w.call(core::conv::u, Sr->proj(nloops, ro + j), w.lit(w.type_i64(), 0)));
+        auto write_coords = affine_map(acc_out, Ro, n, Sr, So, w.tuple(wb_iters)); // «Ro; Idx (So#k)»
+        write_back->app(true, cont, nested_insert(wb_matrix, write_coords, ro, element_final));
+
+        // Inner (reduction) loops over the trailing Rr bounds of `Sr`, collecting the reduction iteration indices.
+        acc  = init;
+        cont = write_back;
+        DefVec red_iters;
+        red_iters.reserve(rr);
+        for (u64 j = 0; j < rr; ++j) {
+            auto dim                    = Sr->proj(nloops, ro + j);
+            auto bound                  = w.call<core::bitcast>(w.type_i64(), dim);
+            auto [body, for_call]       = counting_for(bound, acc, cont, w.sym("forIn_" + std::to_string(j)));
+            auto [iter, new_acc, yield] = body->vars<3>();
+            cont                        = yield;
+            red_iters.push_back(w.call(core::conv::u, dim, iter));
+            acc = new_acc;
+            current_mut->set(true, for_call);
+            current_mut = body;
+        }
+        auto element_acc = acc;
+
+        // The full loop iteration vector `(o…, r…)`; its moduli are exactly `Sr`.
+        DefVec iters_v = out_iters;
+        iters_v.insert(iters_v.end(), red_iters.begin(), red_iters.end());
+        auto iters = w.tuple(iters_v);
+
+        // Read one element from each input at its affine read coordinates.
+        DefVec input_elements(nis_nat);
+        for (u64 i = 0; i < nis_nat; ++i) {
+            auto input_matrix = new_inputs->proj(nis_nat, i);
+            auto coords
+                = affine_map(accs->proj(nis_nat, i), Ris->proj(nis_nat, i), n, Sr, Sis->proj(nis_nat, i), iters);
+            input_elements[i] = nested_extract(input_matrix, coords, ris_nat[i]);
+        }
+
+        comb->set("comb");
+        current_mut->app(true, comb, {w.tuple({element_acc, w.tuple(input_elements)}), cont});
+        return call;
+    } catch (const std::exception& e) {
+        error("error during lowering map_reduce_aff: {}", e.what());
+    }
+}
+
 const Def* LowerMapReduce::rewrite_imm_App(const App* app) {
     if (auto get = Axm::isa<tensor::get>(app)) {
         if (auto res = lower_get(get)) return res;
@@ -528,6 +679,8 @@ const Def* LowerMapReduce::rewrite_imm_App(const App* app) {
         if (auto res = lower_broadcast(bc)) return res;
     } else if (auto mr = Axm::isa<tensor::map_reduce>(app)) {
         if (auto res = lower_map_reduce(mr)) return res;
+    } else if (auto mra = Axm::isa<tensor::map_reduce_aff>(app)) {
+        if (auto res = lower_map_reduce_aff(mra)) return res;
     }
     return RWPhase::rewrite_imm_App(app);
 }

--- a/src/mim/plug/tensor/tensor.mim
+++ b/src/mim/plug/tensor/tensor.mim
@@ -9,6 +9,7 @@
 plugin tuple;
 plugin refly;
 plugin vec;
+import affine;
 ///
 /// A tensor plugin
 ///
@@ -85,6 +86,32 @@ lam %tensor.map_reduce_ds_impl {nis: Nat}
                                  : «So; To»
                                  = fun f_ (x: To, y: «i: nis; Tis#i»)@tt = return (f (x, y));
                                    %tensor.map_reduce @nis @(To, Ro) So @(Tis, Ris, Sis) (f_, init) subs is;
+///
+/// ### %%tensor.map_reduce_aff
+///
+/// Generalisation of %tensor.map_reduce where the per-input subscripts are replaced by affine access functions.
+///
+/// The iteration domain and the result shape are stated explicitly:
+/// * `Sr`: the bounds of the full loop nest of length `Ro + Rr`. Its leading `Ro` dimensions are the parallel output loops; the trailing `Rr` dimensions are the reduction loops that are folded away.
+/// * `So`: the shape of the result tensor (rank `Ro`). It may differ from the leading `Ro` bounds of `Sr`, which is what lets `acc_out` write to a re-shaped output (e.g. a transpose).
+///
+/// The full loop iteration vector `(o…, r…)` has length `Ro + Rr`.
+/// * `acc_out` maps the full loop vector to the `Ro` write coordinates in the result `«So»`. As the reduction is folded away before the write, it must depend only on the leading `Ro` output indices.
+/// * `accs#i` maps the full loop vector to the `Ris#i` read coordinates of input `i`. Transposes, slices and broadcasts are expressed here, by reading the inputs accordingly.
+///
+/// The literal subscript `subs#i#j = k` of %tensor.map_reduce corresponds to the projection access map `λ iters. iters#k`, with `acc_out` the identity and the leading `Ro` bounds of `Sr` equal to `So`.
+///
+/// `nis`, `Ro`, `Rr` and the `Ris` must be literals before entering the `tensor::Lower` phase for the lowering to succeed; the bounds `So` and `Sr` may be symbolic.
+///
+axm %tensor.map_reduce_aff: {nis: Nat}
+                          → {To: *, Ro Rr: Nat}
+                          → [So: «Ro; Nat», Sr: «%core.nat.add (Ro, Rr); Nat»]
+                          → {Tis: «nis; *», Ris: «i: nis; Nat», Sis: «i: nis; «Ris#i; Nat»»}
+                          → [f: Fn [To, «i: nis; Tis#i»] → To, init: To]
+                          → [acc_out: [«%core.nat.add (Ro, Rr); %affine.index»] → «Ro; %affine.index»]
+                          → [accs: «i: nis; ([«%core.nat.add (Ro, Rr); %affine.index»] → «Ris#i; %affine.index»)»]
+                          → [is: «i: nis; «Sis#i; Tis#i»»]
+                          → «So; To», normalize_map_reduce_aff;
 ///
 /// ### %%tensor.dot_product
 ///


### PR DESCRIPTION
This adds the `%affine.index` / `%affine.map` infrastructure that we discussed a while ago.
It now comes with lowering support as well, no normalizers, yet.
However, as everything is lowered to `Idx`, those normalizers should be able to clean up once lowered.
If we were to implement an analysis of the affine maps, we should probably normalize beforehands, to make that easier (collapse to a single query).

The showcase is a new axiom `%tensor.map_reduce_aff` that could subsumes `%tensor.map_reduce`.
This is a bit more versatile concerning what operations / views can be represented directly (e.g. gather, scatter, tiling, ...).
I can't quite discern what the impact on code gen will be (i.e. is the map evaluation pretty much just fold away, if there's nothing special going on? from what I observed on the test case, yes).

We still generate a few too many `%core.conv.u`s imo, but I believe we can get rid of that with #437.

One thing that I am not sure about, yet, is whether we could actually emit the index calculations in the output's arity? but that would break for things like `(a * b) % c`.

CC @hsqStephenZhang - I believe this should bring us closer to being able to represent a lot of PyTorch operations/views using the `tensor` plugin