### PR TITLE
Dont transform pack/arr to tuple/sigma in immutabilize

### DIFF
--- a/src/mim/def.cpp
+++ b/src/mim/def.cpp
@@ -204,18 +204,12 @@ const Def* Arr::immutabilize() {
     auto& w = world();
     if (is_immutabilizable()) return w.arr(arity(), body());
 
-    if (auto n = Lit::isa(arity()); n && *n < w.flags().scalarize_threshold)
-        return w.sigma(DefVec(*n, [&](size_t i) { return reduce(w.lit_idx(*n, i)); }));
-
     return nullptr;
 }
 
 const Def* Pack::immutabilize() {
     auto& w = world();
     if (is_immutabilizable()) return w.pack(arity(), body());
-
-    if (auto n = Lit::isa(arity()); n && *n < w.flags().scalarize_threshold)
-        return w.tuple(DefVec(*n, [&](size_t i) { return reduce(w.lit_idx(*n, i)); }));
 
     return nullptr;
 }


### PR DESCRIPTION
fixes #436 

While transforming arrays and packs into tuples and sigmas by reducing their body with the range of indices allows more of them to be immutabilized, it changes the type of extracts with an unknown index from such arrays/tuple when their type is not uniform. This PR removes this transformation.