### PR TITLE
Revert "Add axioms to inspect closedness of expressions to refly"

### DIFF
--- a/src/mim/plug/refly/normalizers.cpp
+++ b/src/mim/plug/refly/normalizers.cpp
@@ -100,19 +100,6 @@ const Def* normalize_check(const Def* type, const Def*, const Def* arg) {
     return nullptr;
 }
 
-template<vars id>
-const Def* normalize_vars(const Def* type, const Def* callee, const Def* arg) {
-    auto& world = type->world();
-
-    if constexpr (id == vars::is_closed) return arg->is_closed() ? world.lit_tt() : world.lit_ff();
-
-    if constexpr (id == vars::await_closed) {
-        if (callee->as<App>()->is_closed()) return arg;
-    }
-
-    return {};
-}
-
 MIM_refly_NORMALIZER_IMPL
 
 } // namespace mim::plug::refly

--- a/src/mim/plug/refly/refly.mim
+++ b/src/mim/plug/refly/refly.mim
@@ -89,15 +89,6 @@ axm %refly.check_bot: {T: *} → T → T, normalize_check_bot;
 ///
 axm %refly.check: {T: *} → {n: Nat} → [Bool, T, «n; I8»] → T, normalize_check;
 ///
-/// ### %%refly.vars
-///
-/// Inspect free-variable closedness of a Mim expression.
-/// * `is_closed`: Normalizes immediately to `tt` if the argument has no free vars, otherwise `ff`.
-/// * `await_closed`: Waits until the first argument is closed; then normalizes to the second argument.
-///
-axm %refly.vars(is_closed): {T: *} → T → Bool, normalize_vars;
-axm %refly.vars(await_closed): {T U: *} → T → U → U, normalize_vars;
-///
 /// ## Manipulate
 ///
 /// ### %%refly.refine


### PR DESCRIPTION
Reverts mimir/mimir#428

After further consideration, those are actually a horrible idea that only leads to pain and suffering. Remove before anyone else tries.