### PR TITLE
don't optimize type level lam applications

### DIFF
--- a/include/mim/lam.h
+++ b/include/mim/lam.h
@@ -348,9 +348,14 @@ inline const App* isa_callee(const Def* def, size_t i) { return i == 0 ? def->is
 /// * neither `nullptr`,
 /// * nor Lam::is_external,
 /// * nor Lam::is_annex,
-/// * nor Lam::is_unset.
+/// * nor Lam::is_unset,
+/// * nor type-level.
+/// Type-level Lam%s (the body is a type, not a term) must stay representation-stable:
+/// their filter is the normalization strategy, and unfolding or eta-manipulating their applications
+/// desyncs types in rewritten positions from Var types, which alpha-equivalence cannot reconcile.
 inline Lam* isa_optimizable(Lam* lam) {
     if (!lam || lam->is_external() || lam->is_annex() || !lam->is_set()) return nullptr;
+    if (!lam->body()->is_term()) return nullptr;
     return lam;
 }
 

--- a/lit/bug/beta_red_proxy_leaks_into_type.mim
+++ b/lit/bug/beta_red_proxy_leaks_into_type.mim
@@ -1,0 +1,27 @@
+// RUN: %mim -O2 %s -o - | FileCheck %s
+
+// BetaRed wraps the second-encountered application of an already-inlined mut
+// lam into a pass-internal `.proxy` (beta_red.cpp: `proxy(app->type(),
+// {lam, app->arg()}, 0)`). Inside G's body the two solved implicits of %X.k
+// are two distinct stuck applications of the filtered type-level lam F:
+// BetaRed unfolds one (filter `@(ff)` ignored) and proxy-wraps the other.
+// The enclosing app is rebuilt and re-typechecked before PassMan::analyze
+// gets the chance to undo the proxy: the rebuilt callee carries the
+// pass-internal `.proxy` embedded in its *type* and the recheck fails with
+// "cannot apply argument to callee" (unfolded dom vs stuck `F n` argument
+// type), with the proxy leaked into the type term / error.
+//
+// Mirrors the corrupted implicits `T = «…» (unfolded), U = .proxy#0#0
+// make_Ts …` of %admit.extract.k in the spirv access_chain axm type.
+
+plugin core;
+
+lam F (n: Nat)@(ff): □ = «n; ★»;
+
+axm %X.k: {T U: □} → T → U;
+
+lam G (n: Nat, Ts: F n)@(ff): F (%core.nat.sub (n, 1)) = %X.k @(F n, F (%core.nat.sub (n, 1))) Ts;
+
+lam extern keep () = G;
+
+// CHECK-NOT: .proxy

--- a/lit/bug/beta_red_unfolds_filtered_type_lam.mim
+++ b/lit/bug/beta_red_unfolds_filtered_type_lam.mim
@@ -1,0 +1,25 @@
+// RUN: %mim -O2 %s -o -
+
+// BetaRed inlines applications of mut lams without consulting their filter
+// (beta_red.cpp: `lam->reduce_body(app->arg())`). For a *type-level* lam the
+// filter is the normalization strategy: `@(ff)` means "keep applications
+// stuck". Unfolding such an app inside a type desyncs it from Var types:
+// PassMan rewrites a mut lam's ops (filter, body) but never its *type*, so
+// G's binder type `x: F n` keeps the stuck App while the solved implicit
+// `T = F n` inside `%X.k @(F n) x` in G's body is unfolded to `«n; Nat»`.
+// Rebuilding the app re-runs `Checker::assignable`; alpha has no
+// beta-conversion, so `«n; Nat»` vs `F n` fails with
+// "cannot apply argument to callee".
+//
+// Mirrors the spirv access_chain failure (make_Ts ~ F, make_Compound ~ G,
+// %admit.extract.k ~ %X.k).
+
+plugin core;
+
+lam F (n: Nat)@(ff): ★ = «n; Nat»;
+
+axm %X.k: {T: ★} → T → ★;
+
+lam G (n: Nat, x: F n)@(ff): ★ = %X.k @(F n) x;
+
+lam extern keep () = G;


### PR DESCRIPTION
fixes #445 

This changes filters out type level lams in lam.h:isa_optimizable to prevent them from being inconsistently β-reduced (or similar) within lam bodies but not in lam var types. The change was written by Claude Fable 5 but is rather straightforward and looks good to me.