### PR TITLE
Add profiling capabilities with summary, tree, and trace outputs

### DIFF
--- a/include/mim/driver.h
+++ b/include/mim/driver.h
@@ -11,6 +11,7 @@
 
 #include "mim/ast/tok.h"
 #include "mim/util/log.h"
+#include "mim/util/profile.h"
 
 namespace mim {
 
@@ -34,6 +35,8 @@ public:
     Flags& flags() { return flags_; }
     const Flags& flags() const { return flags_; }
     Log& log() const { return log_; }
+    Profiler& profiler() { return profiler_; }
+    const Profiler& profiler() const { return profiler_; }
     World& world() { return world_; }
     const Version& version() const { return version_; } ///< MimIR Version.
     ///@}
@@ -129,6 +132,7 @@ private:
     Version version_;
     Flags flags_;
     mutable Log log_;
+    Profiler profiler_;
     World world_;
     std::list<fs::path> search_paths_;
     std::list<fs::path>::iterator insert_ = search_paths_.end();

--- a/include/mim/flags.h
+++ b/include/mim/flags.h
@@ -9,12 +9,21 @@ namespace mim {
 /// Compiler switches that must be saved and looked up in later phases of compilation.
 /// @see @ref cli
 struct Flags {
+    /// How (if at all) to report Phase runtimes; @see Profiler.
+    enum class Profile {
+        None,    ///< No profiling.
+        Summary, ///< Flat table aggregated by Phase name.
+        Tree,    ///< Indented tree preserving the order in which Phase%es ran.
+        Trace,   ///< chrome://tracing compatible output.
+    };
+
     uint64_t scalarize_threshold = 32;
     bool ascii                   = false;
     bool dump_recursive          = false;
     bool bootstrap               = false;
     bool force_load              = false;
-    bool aggressive_lam_spec     = false; // HACK makes LamSpec more agressive but potentially non-terminating
+    Profile profile              = Profile::None; // how to report Phase runtimes
+    bool aggressive_lam_spec     = false;         // HACK makes LamSpec more agressive but potentially non-terminating
 #ifdef MIM_ENABLE_CHECKS
     bool reeval_breakpoints = false;
     bool trace_gids         = false;

--- a/include/mim/phase.h
+++ b/include/mim/phase.h
@@ -334,10 +334,12 @@ public:
     /// @name Construction
     ///@{
     PassManPhase(World& world, std::unique_ptr<PassMan>&& man)
-        : Phase(world, "pass_man_phase")
+        : Phase(world, build_name("pass_man_phase", *man))
+        , base_name_("pass_man_phase")
         , man_(std::move(man)) {}
     PassManPhase(World& world, flags_t annex)
-        : Phase(world, annex) {}
+        : Phase(world, annex)
+        , base_name_(world.annex(annex)->sym()) {}
 
     void apply(const App*) final;
     void apply(Stage&) final;
@@ -348,6 +350,9 @@ public:
 private:
     void start() final { man_->run(); }
 
+    std::string build_name(const std::string& base, PassMan& pm) const;
+    std::string base_name_;
+    
     std::unique_ptr<PassMan> man_;
 };
 

--- a/include/mim/util/profile.h
+++ b/include/mim/util/profile.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <chrono>
+#include <limits>
+#include <ostream>
+#include <string>
+#include <string_view>
+
+#include "mim/util/vector.h"
+
+namespace mim {
+
+/// Records wall-clock timings for (possibly nested) Phase runs and reports them in various formats.
+/// Phase%es nest: a PhaseMan runs sub-Phase%es, so each run is recorded as a Profiler::Span that remembers its parent.
+/// From these Span%s the Profiler can derive
+/// - a flat Profiler::summary aggregated by Phase name,
+/// - a hierarchical Profiler::tree that shows the runtimes in context, and
+/// - a [Chrome Trace Event](https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU)
+///   JSON dump (Profiler::chrome_trace) that can be loaded into `chrome://tracing`, Perfetto, or speedscope.
+/// @see Profiler::start, Profiler::stop
+class Profiler {
+public:
+    using Clock    = std::chrono::steady_clock;
+    using Duration = Clock::duration;
+
+    static constexpr size_t No_Parent = std::numeric_limits<size_t>::max();
+
+    /// A single Phase run.
+    struct Span {
+        std::string name;
+        Clock::time_point start;
+        Clock::time_point stop;
+        size_t depth;  ///< Nesting level; a root Phase has depth 0.
+        size_t parent; ///< Index of the enclosing Span in Profiler::spans, or Profiler::No_Parent for a root.
+
+        Duration elapsed() const { return stop - start; }
+    };
+
+    /// @name Getters
+    ///@{
+    bool empty() const { return spans_.empty(); }
+    const auto& spans() const { return spans_; }
+    ///@}
+
+    /// @name Recording
+    /// Bracket a Phase run with Profiler::start / Profiler::stop; the calls must nest like a stack.
+    ///@{
+    /// Marks the start of a Phase run named @p name.
+    void start(std::string_view name) {
+        auto parent = stack_.empty() ? No_Parent : stack_.back();
+        stack_.emplace_back(spans_.size());
+        spans_.emplace_back(std::string(name), Clock::now(), Clock::time_point{}, stack_.size() - 1, parent);
+    }
+
+    /// Marks the end of the most recently started Phase run.
+    void stop() {
+        auto id = stack_.back();
+        stack_.pop_back();
+        spans_[id].stop = Clock::now();
+    }
+    ///@}
+
+    /// @name Reporting
+    ///@{
+    /// Prints a flat table aggregated by Phase name, sorted by total time, descending.
+    void summary(std::ostream&) const;
+    /// Prints the Span%s as an indented tree, preserving the order in which Phase%es ran.
+    void tree(std::ostream&) const;
+    /// Dumps all Span%s as Chrome Trace Event Format JSON.
+    void chrome_trace(std::ostream&) const;
+    ///@}
+
+private:
+    /// Per-Span time spent in *direct* children; `self = elapsed - children`.
+    Vector<Duration> children_durations() const;
+
+    Vector<size_t> stack_;
+    Vector<Span> spans_;
+};
+
+} // namespace mim

--- a/lit/profile.mim
+++ b/lit/profile.mim
@@ -1,0 +1,20 @@
+// RUN: %mim -p opt %s --profile summary                 | %FileCheck %s --check-prefix=FLAT
+// RUN: %mim -p opt %s --output-profile - --profile tree | %FileCheck %s --check-prefix=TREE
+// RUN: %mim -p opt %s --output-profile %t.json
+// RUN: %FileCheck %s --check-prefix=TRACE < %t.json
+plugin core;
+
+lam extern f(): «3; Nat» = ‹i: 3; %core.nat.add (1, %core.bitcast Nat i)›;
+
+// FLAT:      Phase profile (flat):
+// FLAT-NEXT: {{.*}}total{{.*}}self{{.*}}phase
+// FLAT:      {{.*}}cleanup
+// FLAT:      {{.*}}TOTAL
+
+// TREE:      Phase profile (tree):
+// TREE-NEXT: {{.*}}total{{.*}}self{{.*}}phase
+// TREE:      {{.*}}cleanup
+// TREE:      {{.*}}TOTAL
+
+// TRACE:      {{.*}}"traceEvents"
+// TRACE:      {{.*}}"ph":"X"{{.*}}"dur":

--- a/src/mim/CMakeLists.txt
+++ b/src/mim/CMakeLists.txt
@@ -43,6 +43,7 @@ target_sources(libmim
         util/dbg.cpp
         util/dl.cpp
         util/log.cpp
+        util/profile.cpp
         util/sys.cpp
 )
 

--- a/src/mim/cli/main.cpp
+++ b/src/mim/cli/main.cpp
@@ -8,6 +8,7 @@
 
 #include "mim/config.h"
 #include "mim/driver.h"
+#include "mim/flags.h"
 #include "mim/phase.h"
 #include "mim/sexpr.h"
 
@@ -19,7 +20,7 @@ using namespace mim;
 using namespace std::literals;
 
 int main(int argc, char** argv) {
-    enum Backends { AST, Dot, H, PY, Md, Mim, Nest, SExpr, SlottedSExpr, Num_Backends };
+    enum Backends { AST, Dot, H, PY, Md, Mim, Nest, SExpr, SlottedSExpr, ProfileTrace, Num_Backends };
 
     try {
         Driver driver;
@@ -41,6 +42,23 @@ int main(int argc, char** argv) {
         auto inc_verbose = [&](bool) { ++verbose; };
         auto& flags      = driver.flags();
 
+        auto profile = [&](const std::string& t) {
+            if (t == "tree")
+                flags.profile = Flags::Profile::Tree;
+            else if (t == "trace")
+                flags.profile = Flags::Profile::Trace;
+            else
+                flags.profile = Flags::Profile::Summary;
+            if (output[ProfileTrace].empty()) output[ProfileTrace] = "-";
+        };
+        auto profile_path = [&](const std::string& t) {
+            if (t == "-" && flags.profile == mim::Flags::Profile::None)
+                flags.profile = Flags::Profile::Summary;
+            else
+                flags.profile = Flags::Profile::Trace;
+            output[ProfileTrace] = t;
+        };
+
         // clang-format off
         auto cli = lyra::cli()
             | lyra::help(show_help)
@@ -53,13 +71,15 @@ int main(int argc, char** argv) {
             | lyra::opt(output[AST],  "file"               )      ["--output-ast"           ]("Directly emits AST representation of input.")
             | lyra::opt(output[Dot],  "file"               )      ["--output-dot"           ]("Emits the Mim program as a MimIR graph using Graphviz' DOT language.")
             | lyra::opt(output[H  ],  "file"               )      ["--output-h"             ]("Emits a header file to be used to interface with a plugin in C++.")
-            | lyra::opt(output[PY ],  "file"               )      ["--output-py"             ]("Emits a Python enum to be used to interface with a plugin in Python.")
+            | lyra::opt(output[PY ],  "file"               )      ["--output-py"            ]("Emits a Python enum to be used to interface with a plugin in Python.")
             | lyra::opt(output[Md ],  "file"               )      ["--output-md"            ]("Emits the input formatted as Markdown.")
             | lyra::opt(output[Mim],  "file"               )["-o"]["--output-mim"           ]("Emits the Mim program again.")
             | lyra::opt(output[Nest], "file"               )      ["--output-nest"          ]("Emits program nesting tree as Dot.")
             | lyra::opt(output[SExpr],"file"               )      ["--output-sexpr"         ]("Emits the program as symbolic expression.")
             | lyra::opt(output[SlottedSExpr],"file"        )      ["--output-sexpr-slotted" ]("Emits the program as symbolic expression that follows the format required by slotted-egraphs.")
             | lyra::opt(flags.force_load                   )      ["--force-load"           ]("Load plugins even on version mismatch.")
+            | lyra::opt(profile, "|summary|tree|trace"     )      ["--profile"              ]("Measure how long each phase takes and write a summary, tree or chrome://tracing compatible output to the output-profile provided destination.")
+            | lyra::opt(profile_path, "file"               )      ["--output-profile"       ]("The output path (or '-' for stdout) for the profiling information.")
             | lyra::opt(flags.ascii                        )["-a"]["--ascii"                ]("Use ASCII alternatives in output instead of UTF-8.")
             | lyra::opt(flags.bootstrap                    )      ["--bootstrap"            ]("Puts mim into \"bootstrap mode\". This means a 'plugin' directive has the same effect as an 'import' and will not load a library. In addition, no standard plugins will be loaded.")
             | lyra::opt(sexpr_include_types                )      ["--sexpr-include-types"  ]("Wraps symbolic expression terms in a type annotation. Types will not be wrapped in type annotations.")
@@ -175,6 +195,14 @@ int main(int argc, char** argv) {
                         sexpr::emit_slotted_typed(world, *s);
                     else
                         sexpr::emit_slotted(world, *s);
+                }
+                if (auto s = os[ProfileTrace]) {
+                    switch (flags.profile) {
+                        case Flags::Profile::Summary: driver.profiler().summary(*s); break;
+                        case Flags::Profile::Tree: driver.profiler().tree(*s); break;
+                        case Flags::Profile::Trace: driver.profiler().chrome_trace(*s); break;
+                        case Flags::Profile::None: break;
+                    }
                 }
             } else {
                 error("couldn't read file '{}'", input);

--- a/src/mim/phase.cpp
+++ b/src/mim/phase.cpp
@@ -3,6 +3,7 @@
 #include <memory>
 
 #include "mim/driver.h"
+#include "mim/flags.h"
 
 namespace mim {
 
@@ -11,9 +12,12 @@ namespace mim {
  */
 
 void Phase::run() {
+    auto profiling = driver().flags().profile != Flags::Profile::None;
+    if (profiling) driver().profiler().start(name());
     world().verify().ILOG("🚀 Phase launch: `{}`", name());
     start();
     world().verify().ILOG("🏁 Phase finish: `{}`", name());
+    if (profiling) driver().profiler().stop();
 }
 
 /*
@@ -224,6 +228,15 @@ void PhaseMan::start() {
  * PassManPhase
  */
 
+std::string PassManPhase::build_name(const std::string& base, PassMan& pm) const {
+    std::string join;
+    for (const auto& pass : pm.passes()) {
+        if (!join.empty()) join += ",";
+        join += pass->name();
+    }
+    return base + "(" + join + ")";
+}
+
 void PassManPhase::apply(const App* app) {
     man_        = std::make_unique<PassMan>(world(), annex());
     auto passes = Passes();
@@ -232,11 +245,15 @@ void PassManPhase::apply(const App* app) {
             passes.emplace_back(std::unique_ptr<Pass>(static_cast<Pass*>(stage.release())));
 
     man_->apply(std::move(passes));
+
+    name_ = build_name(base_name_, *man_);
 }
 
 void PassManPhase::apply(Stage& stage) {
     auto& pmp = static_cast<PassManPhase&>(stage);
     swap(man_, pmp.man_);
+
+    name_ = build_name(base_name_, *man_);
 }
 
 } // namespace mim

--- a/src/mim/util/profile.cpp
+++ b/src/mim/util/profile.cpp
@@ -1,0 +1,106 @@
+#include "mim/util/profile.h"
+
+#include <algorithm>
+#include <print>
+
+#include <absl/container/flat_hash_map.h>
+
+namespace mim {
+
+namespace {
+double ms(Profiler::Duration d) {
+    return std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(d).count();
+}
+
+double us(Profiler::Duration d) {
+    return std::chrono::duration_cast<std::chrono::duration<double, std::micro>>(d).count();
+}
+
+/// Escapes @p str for inclusion in a JSON string literal.
+std::string json_escape(std::string_view str) {
+    std::string res;
+    for (auto c : str) {
+        switch (c) {
+            case '"': res += "\\\""; break;
+            case '\\': res += "\\\\"; break;
+            case '\n': res += "\\n"; break;
+            case '\t': res += "\\t"; break;
+            case '\r': res += "\\r"; break;
+            default: res += c;
+        }
+    }
+    return res;
+}
+} // namespace
+
+Vector<Profiler::Duration> Profiler::children_durations() const {
+    auto children = Vector<Duration>(spans_.size(), Duration::zero());
+    for (const auto& span : spans_)
+        if (span.parent != No_Parent) children[span.parent] += span.elapsed();
+    return children;
+}
+
+void Profiler::summary(std::ostream& os) const {
+    struct Agg {
+        Duration total = Duration::zero();
+        Duration self  = Duration::zero();
+        size_t count   = 0;
+    };
+
+    auto children = children_durations();
+    auto by_name  = absl::flat_hash_map<std::string_view, Agg>();
+    auto total    = Duration::zero();
+
+    for (size_t i = 0, e = spans_.size(); i != e; ++i) {
+        auto self = spans_[i].elapsed() - children[i];
+        auto& agg = by_name[spans_[i].name];
+        agg.total += spans_[i].elapsed();
+        agg.self += self;
+        ++agg.count;
+        total += self;
+    }
+
+    auto ordered = Vector<std::pair<std::string_view, Agg>>(by_name.begin(), by_name.end());
+    std::ranges::sort(ordered, [](const auto& a, const auto& b) { return a.second.total > b.second.total; });
+
+    std::println(os, "Phase profile (flat):");
+    std::println(os, "{:>12}  {:>12}  {:>7}  {:>6}  {}", "total[ms]", "self[ms]", "self[%]", "#runs", "phase");
+    for (const auto& [name, agg] : ordered) {
+        auto percent = total > Duration::zero() ? 100.0 * ms(agg.self) / ms(total) : 0.0;
+        std::println(os, "{:>12.3f}  {:>12.3f}  {:>6.1f}%  {:>6}  {}", ms(agg.total), ms(agg.self), percent, agg.count,
+                     name);
+    }
+    std::println(os, "{:>12.3f}  {:>12.3f}  {:>6.1f}%  {:>6}  {}", ms(total), ms(total), 100.0, spans_.size(), "TOTAL");
+}
+
+void Profiler::tree(std::ostream& os) const {
+    auto children = children_durations();
+    auto total    = Duration::zero();
+    for (const auto& span : spans_)
+        if (span.parent == No_Parent) total += span.elapsed();
+
+    std::println(os, "Phase profile (tree):");
+    std::println(os, "{:>12}  {:>12}  {:>7}  {}", "total[ms]", "self[ms]", "tot[%]", "phase");
+    for (size_t i = 0, e = spans_.size(); i != e; ++i) {
+        const auto& span = spans_[i];
+        auto self        = span.elapsed() - children[i];
+        auto percent     = total > Duration::zero() ? 100.0 * ms(span.elapsed()) / ms(total) : 0.0;
+        std::println(os, "{:>12.3f}  {:>12.3f}  {:>6.1f}%  {:>{}}{}", ms(span.elapsed()), ms(self), percent, "",
+                     span.depth * 2, span.name);
+    }
+    std::println(os, "{:>12.3f}  {:>12}  {:>6.1f}%  {}", ms(total), "", 100.0, "TOTAL");
+}
+
+void Profiler::chrome_trace(std::ostream& os) const {
+    auto origin = spans_.empty() ? Clock::time_point{} : spans_.front().start;
+
+    std::println(os, "{{\"displayTimeUnit\":\"ms\",\"traceEvents\":[");
+    for (size_t i = 0, e = spans_.size(); i != e; ++i) {
+        const auto& span = spans_[i];
+        std::println(os, "{{\"name\":\"{}\",\"cat\":\"phase\",\"ph\":\"X\",\"pid\":1,\"tid\":1,\"ts\":{:.3f},\"dur\":{:.3f}}}{}",
+                     json_escape(span.name), us(span.start - origin), us(span.elapsed()), i + 1 == e ? "" : ",");
+    }
+    std::println(os, "]}}");
+}
+
+} // namespace mim


### PR DESCRIPTION
You can either get a very quick overview, like:
```
Phase profile (flat):
   total[ms]      self[ms]  self[%]   #runs  phase
    2895.475         2.169     0.1%       1  %compile.phases ff
     839.835       839.835    29.0%       2  %compile.prefix_cleanup_phase "internal_ "
     818.841       818.841    28.3%       1  %tensor.lower_map_reduce
     716.927       716.927    24.8%       1  %tensor.lower_tensor
     517.703       517.703    17.9%       1  %tensor.fuse_tensor
    2895.475      2895.475   100.0%       6  TOTAL
```
a tree:

```
Phase profile (tree):
   total[ms]      self[ms]   tot[%]  phase
    2910.327         2.244   100.0%  %compile.phases ff
     333.253       333.253    11.5%    %compile.prefix_cleanup_phase "internal_ "
     737.194       737.194    25.3%    %tensor.lower_tensor
     499.540       499.540    17.2%    %tensor.fuse_tensor
     815.898       815.898    28.0%    %tensor.lower_map_reduce
     522.198       522.198    17.9%    %compile.prefix_cleanup_phase "internal_ "
    2910.327                 100.0%  TOTAL
```

or a chrome://tracing compatible file to get a nice rendering:
<img width="886" height="351" alt="image" src="https://github.com/user-attachments/assets/f1f0dab7-cf75-4c18-ad28-ad20741afdb9" />

The examples are for the following pipeline:
```rust
lam extern _compile (): %compile.Phase =
    %compile.phases ff (
        %compile.internal_cleanup_phase,
        %tensor.lower_tensor,
        %tensor.fuse_tensor,
        %tensor.lower_map_reduce,
        %compile.internal_cleanup_phase,
    );
```