### PR TITLE
Refactor/sexpr

### DIFF
--- a/src/mim/sexpr.cpp
+++ b/src/mim/sexpr.cpp
@@ -348,10 +348,7 @@ void Emitter::emit_decl(BB& bb, const Def* def) {
 
             if (typed()) std::print(decls_, "(@ {}\n", emit_type(bb, axm->type()));
 
-            if (slotted())
-                std::print(decls_, "(axm {}", id(axm));
-            else
-                std::print(decls_, "(axm {} {}", id(axm), emit_type(bb, axm->type()));
+            std::print(decls_, "(axm {}", id(axm));
 
             if (typed()) std::print(decls_, ")");
             std::print(decls_, ")\n\n");
@@ -453,13 +450,11 @@ void Emitter::emit_lam(Lam* parent, Lam* curr, LamSet& rec_lams) {
 
         } else if (NESTED) {
             --tab;
-            --tab;
             // Close 'lam'
             std::print(func_impls_, ")");
             // Close the 'let' at the end of the parent lambdas' definition.
             parent_bb.tail(")");
         } else {
-            --tab;
             --tab;
             // Close 'root' and 'lam'
             std::print(func_impls_, "))\n\n");
@@ -573,7 +568,6 @@ std::string Emitter::emit_head(BB& bb, Lam* lam, bool nested) {
         ++tab;
     } else {
         std::print(os, "{}", emit_bb(bb, lam->filter()));
-        ++tab;
     }
 
     return os.str();
@@ -678,7 +672,7 @@ std::string Emitter::emit_type(BB& bb, const Def* type, bool in_term /* = false*
             auto var_val = id(var);
             std::print(os, "(sigma {} {})", var_val, scope_wrap(op_vals.str()));
         } else {
-            auto dummy_var = slotted() ? "dummy" : "dummy";
+            auto dummy_var = slotted() ? "$dummy" : "dummy";
             std::print(os, "(sigma {} {})", dummy_var, scope_wrap(op_vals.str()));
         }
 

--- a/src/mim/sexpr.cpp
+++ b/src/mim/sexpr.cpp
@@ -472,7 +472,7 @@ std::string Emitter::emit_var(BB& bb, const Def* var, const Def* type, bool meta
             toggle_slots();
             auto projs = var->projs();
             if (projs.size() == 1 || std::ranges::all_of(projs, [](auto proj) { return proj->sym().empty(); }))
-                std::print(os, "\n{}(cons (metavar {} {}) nil)", tab, id(var), emit_type(bb, type));
+                std::print(os, "\n{}(cons (metavar {}) nil)", tab, id(var));
             else {
                 std::vector<std::string> meta_vars;
                 for (auto proj : projs) {

--- a/src/mim/sexpr.cpp
+++ b/src/mim/sexpr.cpp
@@ -682,7 +682,10 @@ std::string Emitter::emit_type(BB& bb, const Def* type, bool in_term /* = false*
         std::print(os, "{}", id(axm));
         emit_decl(bb, axm);
     } else if (auto var = type->isa<Var>()) {
-        std::print(os, "{}", id(var, true));
+        if (var->mut()->isa<Rule>())
+            std::print(os, "\n{}{}", tab, id(var));
+        else
+            std::print(os, "{}", id(var, true));
     } else if (auto hole = type->isa<Hole>()) {
         std::print(os, "(hole {})", emit_type(bb, hole->type(), in_term));
     } else if (auto extract = type->isa<Extract>()) {
@@ -898,7 +901,10 @@ std::string Emitter::emit_bb(BB& bb, const Def* def) {
     } else if (auto insert = def->isa<Insert>()) {
         std::print(os, "{}", emit_node(bb, insert, "insert"));
     } else if (auto var = def->isa<Var>()) {
-        std::print(os, "\n{}{}", tab, id(var, true));
+        if (var->mut()->isa<Rule>())
+            std::print(os, "\n{}{}", tab, id(var));
+        else
+            std::print(os, "\n{}{}", tab, id(var, true));
     } else if (auto app = def->isa<App>()) {
         std::print(os, "{}", emit_node(bb, app, "app"));
     } else if (auto axm = def->isa<Axm>()) {

--- a/src/mim/sexpr.cpp
+++ b/src/mim/sexpr.cpp
@@ -554,7 +554,7 @@ std::string Emitter::emit_head(BB& bb, Lam* lam, bool nested) {
     } else {
         std::print(os, "(root {} {}", ext, id(lam));
         ++tab;
-        if (types_enabled()) std::print(os, "\n{}(@ {}\n", tab, emit_type(bb, lam->type()));
+        if (types_enabled()) std::print(os, "\n{}(@ {}", tab, emit_type(bb, lam->type()));
         std::print(os, "\n{}({}", tab, lam_kind);
     }
 
@@ -649,10 +649,10 @@ std::string Emitter::emit_type(BB& bb, const Def* type, bool in_term /* = false*
         std::string arr_val = arity_val + " " + emit_type(bb, arr->body(), in_term);
 
         if (auto var = arr->has_var()) {
-            auto var_val = slotted() ? id(var) : "(var " + id(var) + " nil)";
+            auto var_val = id(var);
             std::print(os, "(arr {} {})", var_val, scope_wrap(arr_val));
         } else {
-            auto dummy_var = slotted() ? "$dummy" : "(var dummy)";
+            auto dummy_var = slotted() ? "$dummy" : "dummy";
             std::print(os, "(arr {} {})", dummy_var, scope_wrap(arr_val));
         }
 
@@ -661,10 +661,10 @@ std::string Emitter::emit_type(BB& bb, const Def* type, bool in_term /* = false*
         std::string doms    = emit_type(bb, pi->dom(), in_term) + " " + emit_type(bb, pi->codom(), in_term);
 
         if (auto var = pi->has_var()) {
-            auto var_val = slotted() ? id(var) : "(var " + id(var) + " nil)";
+            auto var_val = id(var);
             std::print(os, "({} {} {})", pi_kind, var_val, scope_wrap(doms));
         } else {
-            auto dummy_var = slotted() ? "$dummy" : "(var dummy)";
+            auto dummy_var = slotted() ? "$dummy" : "dummy";
             std::print(os, "({} {} {})", pi_kind, dummy_var, scope_wrap(doms));
         }
 
@@ -675,10 +675,10 @@ std::string Emitter::emit_type(BB& bb, const Def* type, bool in_term /* = false*
                         sigma->ops() | std::views::transform([&](auto op) { return emit_type(bb, op, in_term); }), " ");
 
         if (auto var = sigma->has_var()) {
-            auto var_val = slotted() ? id(var) : "(var " + id(var) + " nil)";
+            auto var_val = id(var);
             std::print(os, "(sigma {} {})", var_val, scope_wrap(op_vals.str()));
         } else {
-            auto dummy_var = slotted() ? "$dummy" : "(var dummy)";
+            auto dummy_var = slotted() ? "dummy" : "dummy";
             std::print(os, "(sigma {} {})", dummy_var, scope_wrap(op_vals.str()));
         }
 
@@ -786,10 +786,10 @@ std::string Emitter::emit_node(BB& bb, const Def* def, std::string node_name, bo
 
     if (auto pack = def->isa<Pack>()) {
         if (auto var = pack->has_var()) {
-            std::string var_val = " " + (slotted() ? id(var) + " (scope" : "(var " + id(var) + " nil)");
+            std::string var_val = " " + (slotted() ? id(var) + " (scope" : id(var));
             op_vals.push_back(var_val);
         } else {
-            std::string var_val = slotted() ? " $dummy (scope" : " (var dummy)";
+            std::string var_val = slotted() ? " $dummy (scope" : "dummy";
             op_vals.push_back(var_val);
         }
         if (auto arity_val = emit_bb(bb, pack->arity()); !arity_val.empty()) op_vals.push_back(arity_val);

--- a/src/mim/sexpr.cpp
+++ b/src/mim/sexpr.cpp
@@ -116,7 +116,6 @@ public:
     void finalize();
 
     LamSet next_lams(Lam* lam);
-    bool isa_nested_proj(const Extract* extract);
 
     void emit_decl(BB& bb, const Def* def);
     void emit_lam(Lam* parent, Lam* curr, LamSet& rec_lams);
@@ -294,13 +293,14 @@ void Emitter::emit_imported(Lam* lam) {
         --tab;
 
     } else {
+        std::print(func_decls_, "(root {} {}", ext, id(lam));
+        ++tab;
         if (types_enabled()) std::print(func_decls_, "\n{}(@ {}", tab, emit_type(bb, lam->type()));
-        std::print(func_decls_, "({} {} {}", lam_kind, ext, id(lam));
+        std::print(func_decls_, "\n{}({}", tab, lam_kind);
         std::print(func_decls_, "{}", emit_var(bb, lam->var(), lam->type()->dom()));
-        std::print(func_decls_, "\n{}{}", tab, emit_type(bb, lam->dom()));
-        std::print(func_decls_, "\n{}{}", tab, emit_type(bb, lam->codom()));
         if (types_enabled()) std::print(func_decls_, ")");
-        std::print(func_decls_, ")\n\n");
+        std::print(func_decls_, "))\n\n");
+        --tab;
     }
 }
 
@@ -336,32 +336,6 @@ LamSet Emitter::next_lams(Lam* lam) {
             }
     }
     return next_lams;
-}
-
-bool Emitter::isa_nested_proj(const Extract* extract) {
-    // 'tuple' is another extract if we have for example two nested, sigma-typed variables
-    // and we are trying to print a named projection of the inner variable. ('baz' in the example below)
-    // ex.:  (var foo (sigma (var bar (sigma (var baz Nat)))))
-    // In this example, we have an extract where the tuple: 'bar' is another extract from 'foo'.
-    auto tuple           = extract->tuple();
-    auto index           = extract->index();
-    auto isa_nested_proj = false;
-    if (tuple->isa<Extract>() && Lit::isa(index)) {
-        auto curr_tuple = tuple;
-        auto curr_index = index;
-        while (curr_tuple && curr_index) {
-            if (curr_tuple->isa<Extract>() && Lit::isa(curr_index)) {
-                auto extract = curr_tuple->as<Extract>();
-                curr_tuple   = extract->tuple();
-                curr_index   = extract->index();
-                continue;
-            } else if (curr_tuple->isa<Var>() && Lit::isa(curr_index)) {
-                isa_nested_proj = true;
-            }
-            break;
-        }
-    }
-    return isa_nested_proj;
 }
 
 void Emitter::emit_decl(BB& bb, const Def* def) {
@@ -465,6 +439,7 @@ void Emitter::emit_lam(Lam* parent, Lam* curr, LamSet& rec_lams) {
         if (slotted()) {
             --tab;
             --tab;
+            --tab;
             if (NESTED) {
                 --tab;
                 // Close 'lam' and lam var 'scope'
@@ -478,13 +453,16 @@ void Emitter::emit_lam(Lam* parent, Lam* curr, LamSet& rec_lams) {
 
         } else if (NESTED) {
             --tab;
+            --tab;
             // Close 'lam'
             std::print(func_impls_, ")");
             // Close the 'let' at the end of the parent lambdas' definition.
             parent_bb.tail(")");
         } else {
-            // Close 'lam'
-            std::print(func_impls_, ")\n\n");
+            --tab;
+            --tab;
+            // Close 'root' and 'lam'
+            std::print(func_impls_, "))\n\n");
         }
     }
 }
@@ -523,7 +501,7 @@ std::string Emitter::emit_var(BB& bb, const Def* var, const Def* type, bool meta
         }
     }
 
-    else {
+    else if (meta_var) {
         auto projs = var->projs();
         if (projs.size() == 1 || std::ranges::all_of(projs, [](auto proj) { return proj->sym().empty(); }))
             std::print(os, "\n{}(var {})", tab, id(var));
@@ -534,6 +512,8 @@ std::string Emitter::emit_var(BB& bb, const Def* var, const Def* type, bool meta
                 std::print(os, "{}", emit_var(bb, proj, type->proj(i++)));
             std::print(os, ")");
         }
+    } else {
+        std::print(os, "\n{}{}", tab, id(var));
     }
     --tab;
 
@@ -570,18 +550,15 @@ std::string Emitter::emit_head(BB& bb, Lam* lam, bool nested) {
         ++tab;
         std::print(os, "\n{}{}", tab, id(lam));
         if (types_enabled()) std::print(os, "\n{}(@ {}", tab, emit_type(bb, lam->type()));
-        std::print(os, "\n{}({} {} {}", tab, lam_kind, ext, id(lam));
+        std::print(os, "\n{}({}", tab, lam_kind);
     } else {
+        std::print(os, "(root {} {}", ext, id(lam));
+        ++tab;
         if (types_enabled()) std::print(os, "\n{}(@ {}\n", tab, emit_type(bb, lam->type()));
-        std::print(os, "({} {} {}", lam_kind, ext, id(lam));
+        std::print(os, "\n{}({}", tab, lam_kind);
     }
 
     std::print(os, "{}", emit_var(bb, lam->var(), lam->type()->dom()));
-
-    if (!slotted()) {
-        std::print(os, "\n{}{}", tab, emit_type(bb, lam->dom()));
-        std::print(os, "\n{}{}", tab, emit_type(bb, lam->codom()));
-    }
 
     if (slotted()) {
         ++tab;
@@ -593,8 +570,10 @@ std::string Emitter::emit_head(BB& bb, Lam* lam, bool nested) {
         toggle_bindings();
         std::print(os, "{}", emit_bb(bb, lam->filter()));
         toggle_bindings();
+        ++tab;
     } else {
         std::print(os, "{}", emit_bb(bb, lam->filter()));
+        ++tab;
     }
 
     return os.str();
@@ -930,10 +909,8 @@ std::string Emitter::emit_bb(BB& bb, const Def* def) {
     } else if (auto pack = def->isa<Pack>()) {
         std::print(os, "{}", emit_node(bb, pack, "pack"));
     } else if (auto extract = def->isa<Extract>()) {
-        if (!slotted() && ((Lit::isa(extract->index()) && extract->tuple()->isa<Var>()) || isa_nested_proj(extract)))
-            std::print(os, "\n{}{}", tab, id(extract));
         // Projections of rule variables are meta vars and should just be printed by name
-        else if (auto var = extract->tuple()->isa<Var>(); var && var->mut()->isa<Rule>())
+        if (auto var = extract->tuple()->isa<Var>(); var && var->mut()->isa<Rule>())
             std::print(os, "\n{}{}", tab, id(extract));
         else
             std::print(os, "{}", emit_node(bb, extract, "extract"));

--- a/src/mim/sexpr.cpp
+++ b/src/mim/sexpr.cpp
@@ -436,7 +436,6 @@ void Emitter::emit_lam(Lam* parent, Lam* curr, LamSet& rec_lams) {
         if (slotted()) {
             --tab;
             --tab;
-            --tab;
             if (NESTED) {
                 --tab;
                 // Close 'lam' and lam var 'scope'
@@ -565,7 +564,6 @@ std::string Emitter::emit_head(BB& bb, Lam* lam, bool nested) {
         toggle_bindings();
         std::print(os, "{}", emit_bb(bb, lam->filter()));
         toggle_bindings();
-        ++tab;
     } else {
         std::print(os, "{}", emit_bb(bb, lam->filter()));
     }

--- a/src/mim/sexpr.cpp
+++ b/src/mim/sexpr.cpp
@@ -183,10 +183,10 @@ std::string Emitter::id(const Def* def, bool is_var_use) const {
     std::string prefix = slots_enabled() ? "$" : "";
     std::string id;
 
-    // In slotted-egraphs variable-uses need to be explicitly wrapped in a var node i.e. in λx.x (lam $x (var
-    // $x))
     auto var_wrap = [&](std::string id) {
-        return slots_enabled() && is_var_use && id.starts_with(prefix) ? "(var " + id + ")" : id;
+        auto cond_slotted = slots_enabled() && is_var_use && id.starts_with(prefix);
+        auto cond_regular = !slotted() && is_var_use;
+        return cond_slotted || cond_regular ? std::format("(var {})", id) : id;
     };
 
     // Axioms, rules, unset lambdas(imports) and externals need to be emitted without a uid
@@ -474,18 +474,12 @@ std::string Emitter::emit_var(BB& bb, const Def* var, const Def* type, bool meta
             if (projs.size() == 1 || std::ranges::all_of(projs, [](auto proj) { return proj->sym().empty(); }))
                 std::print(os, "\n{}(cons (metavar {} {}) nil)", tab, id(var), emit_type(bb, type));
             else {
-                size_t i = 0;
                 std::vector<std::string> meta_vars;
                 for (auto proj : projs) {
-                    std::ostringstream meta_var;
                     ++tab;
-                    std::print(meta_var, "\n{}(metavar", tab);
-                    std::print(meta_var, "{}", emit_bb(bb, proj));
-                    ++tab;
-                    std::print(meta_var, "\n{}{})", tab, emit_type(bb, type->proj(i++)));
+                    auto meta_var = std::format("\n{}(metavar {})", tab, id(proj));
                     --tab;
-                    --tab;
-                    meta_vars.push_back(meta_var.str());
+                    meta_vars.push_back(meta_var);
                 }
                 std::print(os, "{}", emit_cons(meta_vars));
             }
@@ -498,12 +492,12 @@ std::string Emitter::emit_var(BB& bb, const Def* var, const Def* type, bool meta
     else if (meta_var) {
         auto projs = var->projs();
         if (projs.size() == 1 || std::ranges::all_of(projs, [](auto proj) { return proj->sym().empty(); }))
-            std::print(os, "\n{}(var {})", tab, id(var));
+            std::print(os, "\n{}(metavar {})", tab, id(var));
         else {
-            std::print(os, "\n{}(var {}", tab, id(var));
+            std::print(os, "\n{}(metavar {}", tab, id(var));
             size_t i = 0;
             for (auto proj : projs)
-                std::print(os, "{}", emit_var(bb, proj, type->proj(i++)));
+                std::print(os, "{}", emit_var(bb, proj, type->proj(i++), meta_var));
             std::print(os, ")");
         }
     } else {
@@ -781,7 +775,7 @@ std::string Emitter::emit_node(BB& bb, const Def* def, std::string node_name, bo
             std::string var_val = " " + (slotted() ? id(var) + " (scope" : id(var));
             op_vals.push_back(var_val);
         } else {
-            std::string var_val = slotted() ? " $dummy (scope" : "dummy";
+            std::string var_val = slotted() ? " $dummy (scope" : " dummy";
             op_vals.push_back(var_val);
         }
         if (auto arity_val = emit_bb(bb, pack->arity()); !arity_val.empty()) op_vals.push_back(arity_val);

--- a/src/mim/sexpr.cpp
+++ b/src/mim/sexpr.cpp
@@ -876,15 +876,10 @@ std::string Emitter::emit_bb(BB& bb, const Def* def) {
                 --tab;
                 std::print(os, "))");
             } else {
-                auto ext = lam->is_external() ? "extern" : "intern";
-                std::print(os, "\n{}({} {} {}", tab, lam_kind, ext, id(lam));
-                ++tab;
+                std::print(os, "\n{}({}", tab, lam_kind);
                 std::print(os, "\n{}{}", tab, emit_var(bb, lam->var(), lam->var()->type()));
-                std::print(os, "\n{}{}", tab, emit_type(bb, lam->dom()));
-                std::print(os, "\n{}{}", tab, emit_type(bb, lam->codom()));
                 std::print(os, "{}", emit_bb(bb, lam->filter()));
                 std::print(os, "{}", emit_bb(bb, lam->body()));
-                --tab;
                 std::print(os, ")");
             }
         }


### PR DESCRIPTION
Adjusts the output of the regular `sexpr` backend to resemble the output of the `slotted-sexpr` backend more closely.

- Variable projections are always explicitly let-bound
- Types are only emitted in the annotated version
- `extern` is emitted as part of a root-level binder instead of the lambda