### PR TITLE
feat: core.nat.div

### DIFF
--- a/include/mim/plug/ll/ll.h
+++ b/include/mim/plug/ll/ll.h
@@ -721,12 +721,25 @@ inline std::string Emitter::emit_bb(BB& bb, const Def* def) {
         auto [a, b] = nat->args<2>([this](auto def) { return emit(def); });
 
         switch (nat.id()) {
-            case core::nat::add: op = "add"; break;
-            case core::nat::sub: op = "sub"; break;
-            case core::nat::mul: op = "mul"; break;
+            case core::nat::add: return bb.assign(name, "add nsw nuw i64 {}, {}", a, b);
+            case core::nat::sub: return bb.assign(name, "sub nsw nuw i64 {}, {}", a, b);
+            case core::nat::mul: return bb.assign(name, "mul nsw nuw i64 {}, {}", a, b);
+            // %core.nat.div/mod define division/modulo by zero as `a / 0 = 0` and `a % 0 = a`.
+            // replace a zero divisor by 1 to keep udiv/urem well-defined, then select the
+            // defined result for the zero case (0 for div, a for mod).
+            case core::nat::div: {
+                auto bz   = bb.assign(name + ".bz", "icmp eq i64 {}, 0", b);
+                auto bsaf = bb.assign(name + ".bsafe", "select i1 {}, i64 1, i64 {}", bz, b);
+                auto q    = bb.assign(name + ".q", "udiv i64 {}, {}", a, bsaf);
+                return bb.assign(name, "select i1 {}, i64 0, i64 {}", bz, q);
+            }
+            case core::nat::mod: {
+                auto bz   = bb.assign(name + ".bz", "icmp eq i64 {}, 0", b);
+                auto bsaf = bb.assign(name + ".bsafe", "select i1 {}, i64 1, i64 {}", bz, b);
+                auto r    = bb.assign(name + ".r", "urem i64 {}, {}", a, bsaf);
+                return bb.assign(name, "select i1 {}, i64 {}, i64 {}", bz, a, r);
+            }
         }
-
-        return bb.assign(name, "{} nsw nuw i64 {}, {}", op, a, b);
     } else if (auto ncmp = Axm::isa<core::ncmp>(def)) {
         auto [a, b] = ncmp->args<2>([this](auto def) { return emit(def); });
         op          = "icmp ";
@@ -1174,6 +1187,8 @@ inline std::string Emitter::emit_bb(BB& bb, const Def* def) {
                 case core::nat::add: op = "add nuw nsw"; break;
                 case core::nat::sub: op = "sub nuw nsw"; break;
                 case core::nat::mul: op = "mul nuw nsw"; break;
+                case core::nat::div: op = "udiv"; break;
+                case core::nat::mod: op = "urem"; break;
             }
         } else if (auto arith_op = Axm::isa<math::arith, 1>(f)) {
             auto lmode = static_cast<math::Mode>(Lit::as(f->as<App>()->arg()));

--- a/lit/core/nat_div_mod.mim
+++ b/lit/core/nat_div_mod.mim
@@ -1,0 +1,53 @@
+// RUN: %mim -p opt %s -o - | %FileCheck %s --check-prefix=OPT
+// RUN: rm -f %{s:stem}.ll
+// RUN: %mim -p opt %s -p ll
+// RUN: clang %{s:stem}.ll -c -o %t -Wno-override-module
+// RUN: %FileCheck %s --check-prefix=DIV < %{s:stem}.ll
+// RUN: %FileCheck %s --check-prefix=MOD < %{s:stem}.ll
+
+plugin core;
+plugin mem;
+import compile;
+
+// %core.nat.div/mod fold the partial/degenerate cases at normalization time:
+//   a / 0 = 0,   a % 0 = a,   a % a = 0,   plus ordinary constant folding.
+// `x` is a runtime value, so `x / 0` and `x % x` exercise the symbolic rules;
+// everything must still collapse to literals, i.e. no `%core.nat` may remain.
+//
+// OPT-LABEL: fun extern test_fold
+// OPT-NOT: %core.nat
+// OPT: (0, 7, 3, 1, 0)
+fun extern test_fold(x: Nat) : [Nat, Nat, Nat, Nat, Nat] =
+    let a = %core.nat.div (x, 0); // -> 0 (symbolic a / 0 = 0)
+    let b = %core.nat.mod (7, 0); // -> 7 (a % 0 = a)
+    let c = %core.nat.div (10, 3); // -> 3
+    let d = %core.nat.mod (10, 3); // -> 1
+    let e = %core.nat.mod (x, x); // -> 0 (symbolic a % a = 0)
+    return (a, b, c, d, e);
+
+// For a runtime (non-literal) divisor the axiom survives normalization and must
+// be lowered by the `ll` backend. A bare `udiv`/`urem` would make division by
+// zero immediate UB, so the backend guards the divisor (replace 0 by 1) and
+// selects the defined result for the zero case: `a / 0 = 0`, `a % 0 = a`.
+//
+// The `mem` keeps the domain a heterogeneous sigma so the two `Nat`s stay scalar
+// `i64`s instead of folding into a `«2; Nat»` SIMD vector. DIV and MOD use
+// independent prefixes because the two functions' emission order is not stable.
+
+// MOD-LABEL: define{{.*}}@test_mod
+// MOD: icmp eq i64
+// MOD: select i1
+// MOD: urem i64
+// MOD: select i1
+fun extern test_mod(mem: %mem.M 0, x: Nat, y: Nat): [%mem.M 0, Nat] =
+    let r = %core.nat.mod (x, y);
+    return (mem, r);
+
+// DIV-LABEL: define{{.*}}@test_div
+// DIV: icmp eq i64
+// DIV: select i1
+// DIV: udiv i64
+// DIV: select i1
+fun extern test_div(mem: %mem.M 0, x: Nat, y: Nat): [%mem.M 0, Nat] =
+    let q = %core.nat.div (x, y);
+    return (mem, q);

--- a/src/mim/plug/core/core.mim
+++ b/src/mim/plug/core/core.mim
@@ -13,9 +13,12 @@ plugin mem;
 /// ### %%core.nat
 ///
 /// Standard arithmetic operations on `Nat`s. <br>
-/// `%%core.nat.sub (a, b)` yields `0`, if `a` < `b`.
+/// `%%core.nat.sub (a, b)` yields `0`, if `a` < `b`. <br>
+/// `%%core.nat.div (a, b)` yields `0`, if `b` is `0`. <br>
+/// `%%core.nat.mod (a, b)` yields `a`, if `b` is `0`. <br>
+/// This holds both statically (literal folding) and dynamically (runtime lowering).
 ///
-axm %core.nat(add, sub, mul): «2; Nat» → Nat, normalize_nat;
+axm %core.nat(add, sub, mul, div, mod): «2; Nat» → Nat, normalize_nat;
 ///
 /// ### %%core.ncmp
 ///

--- a/src/mim/plug/core/normalizers.cpp
+++ b/src/mim/plug/core/normalizers.cpp
@@ -496,6 +496,8 @@ const Def* normalize_nat(const Def* type, const Def* callee, const Def* arg) {
                 case nat::add: return world.lit_nat(*la + *lb);
                 case nat::sub: return *la < *lb ? world.lit_nat_0() : world.lit_nat(*la - *lb);
                 case nat::mul: return world.lit_nat(*la * *lb);
+                case nat::div: return *lb == 0 ? world.lit_nat_0() : world.lit_nat(*la / *lb);
+                case nat::mod: return *lb == 0 ? a : world.lit_nat(*la % *lb);
             }
         }
 
@@ -504,19 +506,39 @@ const Def* normalize_nat(const Def* type, const Def* callee, const Def* arg) {
                 case nat::add: return b;
                 case nat::sub: return a; // 0 - b = 0
                 case nat::mul: return a; // 0 * b = 0
+                case nat::div: return world.lit_nat_0(); // 0 / b = 0
+                case nat::mod: return world.lit_nat_0(); // 0 % b = 0
             }
         }
 
         if (*la == 1 && id == nat::mul) return b; // 1 * b = b
     }
 
-    if (lb && *lb == 0 && id == nat::sub) return a; // a - 0 = a
+    if (lb) {
+        if (*lb == 0) {
+            switch (id) {
+                case nat::sub: return a; // a - 0 = a
+                case nat::div: return world.lit_nat_0(); // a / 0 = 0
+                case nat::mod: return a; // a % 0 = a
+                default: break;
+            }
+        }
+        if (*lb == 1) {
+            switch (id) {
+                case nat::div: return a; // a / 1 = a
+                case nat::mod: return world.lit_nat_0(); // a % 1 = 0
+                default: break;
+            }
+        }
+    }
 
     if (a == b) {
         switch (id) {
             case nat::add: return world.call(nat::mul, Defs{world.lit_nat(2), a}); // a + a = 2 * a
             case nat::sub: return world.lit_nat(0);                                // a - a = 0
             case nat::mul: break;
+            case nat::div: break; // 0 / 0 = 0, so we cannot fold a / a = 1 symbolically
+            case nat::mod: return world.lit_nat_0(); // a % a = 0 (even for a = 0, since 0 % 0 = 0)
         }
     }
 


### PR DESCRIPTION
## Background

tensor plugin needs nat's div to calculate the shape of output tensor for operations like convolution by formula: Lout = ⌊ (Lin + 2 * padding - dilation * (kernel - 1) - 1) / stride + 1 ⌋

for tensor's shape, each dim is a nat, so we need `div` support for `%core.nat`

## Solution

Add static and dynamic lowering for core.nat.div/mod, will return 0 if the divisor is 0. 

see https://leanprover-community.github.io/mathlib4_docs/Init/Data/Nat/Div/Basic.html for detailed definition.