### PR TITLE
fix(tensor): calculate output tensor's shape for %tensor.conv

### DIFF
--- a/lit/tensor/conv_dilated.mim
+++ b/lit/tensor/conv_dilated.mim
@@ -25,3 +25,16 @@ lam nat_ring (): %tensor.Ring = (Nat, 0, %core.nat.add, %core.nat.mul);
 // CHECK-DAG: fun extern conv_dilate
 fun extern conv_dilate (input: «2, 2, 7, 7; Nat», weight: «3, 2, 3, 3; Nat»): «2, 3, 3, 3; Nat» =
     return (%tensor.conv (nat_ring ()) ((1, 1), (2, 2), (0, 0)) (input, weight));
+
+// Custom pipeline that stops before %tensor.lower_get_set: the get/set unrolling is expensive and the
+// remaining %tensor.get / %tensor.set are irrelevant to the checks below, so skipping it keeps the test fast.
+lam extern _compile (): %compile.Phase =
+    %compile.phases ff (
+        %compile.internal_cleanup,
+        %tensor.lower_tensor,
+        %tensor.fuse_tensor,
+        %tensor.lower_map_reduce,
+        %affine.lower_index,
+        %affine.lower_for,
+        %compile.internal_cleanup,
+    );

--- a/lit/tensor/conv_dilated.mim
+++ b/lit/tensor/conv_dilated.mim
@@ -24,4 +24,4 @@ lam nat_ring (): %tensor.Ring = (Nat, 0, %core.nat.add, %core.nat.mul);
 // dilated, no padding: 7x7 input, 3x3 kernel, dilation 2 (effective kernel 5x5), stride 1 -> 3x3 output.
 // CHECK-DAG: fun extern conv_dilate
 fun extern conv_dilate (input: «2, 2, 7, 7; Nat», weight: «3, 2, 3, 3; Nat»): «2, 3, 3, 3; Nat» =
-    return (%tensor.conv (nat_ring ()) ((1, 1), (2, 2), (0, 0), (3, 3)) (input, weight));
+    return (%tensor.conv (nat_ring ()) ((1, 1), (2, 2), (0, 0)) (input, weight));

--- a/lit/tensor/conv_dynamic.mim
+++ b/lit/tensor/conv_dynamic.mim
@@ -1,0 +1,44 @@
+// RUN: %mim %s -o - | %FileCheck %s
+
+// %tensor.conv with fully *dynamic* (symbolic) shapes: the input/weight extents are function parameters, so
+// `conv_shape` cannot fold to a literal output shape. Instead it stays as a %core.nat.div/sub/mul/add expression
+// in the result type, which the type checker accepts.
+//
+// The window formula per spatial axis is `O#d = (s#d + 2·padding#d − (dilation#d·(k#d − 1) + 1)) / stride#d + 1`.
+
+plugin core;
+plugin tensor;
+plugin affine;
+plugin mem;
+
+// A ring over Nat so the multiply-accumulate stays in %core.nat.
+lam nat_ring (): %tensor.Ring = (Nat, 0, %core.nat.add, %core.nat.mul);
+
+// Fully symbolic conv, no padding, unit stride/dilation: OH = h − kh + 1, OW = w − kw + 1.
+// CHECK-DAG: fun extern conv_dyn_valid
+fun extern conv_dyn_valid {n cin cout h w kh kw: Nat}
+                          (input: «n, cin, h, w; Nat», weight: «cout, cin, kh, kw; Nat»)
+                        : «conv_shape (n, cout, (h, w), (kh, kw), (1, 1), (1, 1), (0, 0)); Nat» =
+    return (%tensor.conv (nat_ring ()) ((1, 1), (1, 1), (0, 0)) (input, weight));
+
+// Symbolic extents with stride 2: the output dim keeps a `%core.nat.div (_, 2)`, proving the shape is *computed*
+// (not passed in) and survives symbolically.
+// CHECK-DAG: fun extern conv_dyn_strided
+// CHECK-DAG: %core.nat.div ({{.*}}, 2)
+fun extern conv_dyn_strided {n cin cout h w kh kw: Nat}
+                            (input: «n, cin, h, w; Nat», weight: «cout, cin, kh, kw; Nat»)
+                          : «conv_shape (n, cout, (h, w), (kh, kw), (2, 2), (1, 1), (0, 0)); Nat» =
+    return (%tensor.conv (nat_ring ()) ((2, 2), (1, 1), (0, 0)) (input, weight));
+
+// Custom pipeline that stops before %tensor.lower_get_set: the get/set unrolling is expensive and the
+// remaining %tensor.get / %tensor.set are irrelevant to the checks below, so skipping it keeps the test fast.
+lam extern _compile (): %compile.Phase =
+    %compile.phases ff (
+        %compile.internal_cleanup,
+        %tensor.lower_tensor,
+        %tensor.fuse_tensor,
+        %tensor.lower_map_reduce,
+        %affine.lower_index,
+        %affine.lower_for,
+        %compile.internal_cleanup,
+    );

--- a/lit/tensor/conv_same.mim
+++ b/lit/tensor/conv_same.mim
@@ -27,3 +27,16 @@ lam nat_ring (): %tensor.Ring = (Nat, 0, %core.nat.add, %core.nat.mul);
 // CHECK-DAG: %core.nat.add
 fun extern conv_same (input: «2, 2, 5, 5; Nat», weight: «3, 2, 3, 3; Nat»): «2, 3, 5, 5; Nat» =
     return (%tensor.conv (nat_ring ()) ((1, 1), (1, 1), (1, 1)) (input, weight));
+
+// Custom pipeline that stops before %tensor.lower_get_set: the get/set unrolling is expensive and the
+// remaining %tensor.get / %tensor.set are irrelevant to the checks below, so skipping it keeps the test fast.
+lam extern _compile (): %compile.Phase =
+    %compile.phases ff (
+        %compile.internal_cleanup,
+        %tensor.lower_tensor,
+        %tensor.fuse_tensor,
+        %tensor.lower_map_reduce,
+        %affine.lower_index,
+        %affine.lower_for,
+        %compile.internal_cleanup,
+    );

--- a/lit/tensor/conv_same.mim
+++ b/lit/tensor/conv_same.mim
@@ -26,4 +26,4 @@ lam nat_ring (): %tensor.Ring = (Nat, 0, %core.nat.add, %core.nat.mul);
 // CHECK-DAG: %core.nat.mul
 // CHECK-DAG: %core.nat.add
 fun extern conv_same (input: «2, 2, 5, 5; Nat», weight: «3, 2, 3, 3; Nat»): «2, 3, 5, 5; Nat» =
-    return (%tensor.conv (nat_ring ()) ((1, 1), (1, 1), (1, 1), (5, 5)) (input, weight));
+    return (%tensor.conv (nat_ring ()) ((1, 1), (1, 1), (1, 1)) (input, weight));

--- a/lit/tensor/conv_stride.mim
+++ b/lit/tensor/conv_stride.mim
@@ -25,3 +25,16 @@ lam nat_ring (): %tensor.Ring = (Nat, 0, %core.nat.add, %core.nat.mul);
 // CHECK-DAG: fun extern conv_stride
 fun extern conv_stride (input: «2, 2, 7, 7; Nat», weight: «3, 2, 3, 3; Nat»): «2, 3, 3, 3; Nat» =
     return (%tensor.conv (nat_ring ()) ((2, 2), (1, 1), (0, 0)) (input, weight));
+
+// Custom pipeline that stops before %tensor.lower_get_set: the get/set unrolling is expensive and the
+// remaining %tensor.get / %tensor.set are irrelevant to the checks below, so skipping it keeps the test fast.
+lam extern _compile (): %compile.Phase =
+    %compile.phases ff (
+        %compile.internal_cleanup,
+        %tensor.lower_tensor,
+        %tensor.fuse_tensor,
+        %tensor.lower_map_reduce,
+        %affine.lower_index,
+        %affine.lower_for,
+        %compile.internal_cleanup,
+    );

--- a/lit/tensor/conv_stride.mim
+++ b/lit/tensor/conv_stride.mim
@@ -24,4 +24,4 @@ lam nat_ring (): %tensor.Ring = (Nat, 0, %core.nat.add, %core.nat.mul);
 // strided, no padding: 7x7 input, 3x3 kernel, stride 2 -> 3x3 output.
 // CHECK-DAG: fun extern conv_stride
 fun extern conv_stride (input: «2, 2, 7, 7; Nat», weight: «3, 2, 3, 3; Nat»): «2, 3, 3, 3; Nat» =
-    return (%tensor.conv (nat_ring ()) ((2, 2), (1, 1), (0, 0), (3, 3)) (input, weight));
+    return (%tensor.conv (nat_ring ()) ((2, 2), (1, 1), (0, 0)) (input, weight));

--- a/src/mim/plug/tensor/tensor.mim
+++ b/src/mim/plug/tensor/tensor.mim
@@ -221,7 +221,21 @@ axm %tensor.concat: {T: *, nis r: Nat}
 /// `out[n,co,oh,ow] = Σ_{ci,kh,kw} padded[n, ci, stride#0·oh + dilation#0·kh, stride#1·ow + dilation#1·kw] · weight[co,ci,kh,kw]`
 ///
 /// `padding` zero-pads the spatial axes (composed via %tensor.pad) so the windowed read is a pure affine map.
-/// The output spatial size `s_out = (OH, OW)` is passed explicitly (MimIR has no `Nat` division to compute it).
+/// The output shape is deduced from the input/weight extents and the window parameters (see `conv_shape`), so it
+/// is not passed explicitly.
+
+// `(n, cout, (H, W), (KH, KW), stride, dilation, padding) ↦ (n, cout, OH, OW)`, where
+// `O#d = (s#d + 2·padding#d − (dilation#d·(k#d − 1) + 1)) / stride#d + 1`: the NCHW output shape.
+lam conv_shape (n cout: Nat, s: «2; Nat», k: «2; Nat», stride: «2; Nat», dilation: «2; Nat», padding: «2; Nat»): «4; Nat» =
+    let hw = ‹d: 2;
+        %core.nat.add (
+            %core.nat.div (
+                %core.nat.sub (
+                    %core.nat.add (s#d, %core.nat.mul (2, padding#d)),
+                    %core.nat.add (%core.nat.mul (dilation#d, %core.nat.sub (k#d, 1)), 1)),
+                stride#d),
+            1)›;
+    (n, cout, hw#0_2, hw#1_2);
 
 /// Fused multiply-add over the ring `R`; `ab#0` is the padded-input element, `ab#1` the weight.
 fun conv_fun [R: %tensor.Ring] (acc: R#T, ab: «2; R#T»)@tt: R#T = return (R#add (acc, R#mul (ab#0_2, ab#1_2)));
@@ -238,22 +252,25 @@ lam conv2d_in_map (stride: «2; Nat», dilation: «2; Nat») (o: «7; %affine.in
 
 axm %tensor.conv: [R: %tensor.Ring]
                 → {n cin cout h w kh kw: Nat}
-                → [stride: «2; Nat», dilation: «2; Nat», padding: «2; Nat», s_out: «2; Nat»]
+                → [stride: «2; Nat», dilation: «2; Nat», padding: «2; Nat»]
                 → [input: «n, cin, h, w; R#T», weight: «cout, cin, kh, kw; R#T»]
-                → «n, cout, s_out#0_2, s_out#1_2; R#T»;
+                → «conv_shape (n, cout, (h, w), (kh, kw), stride, dilation, padding); R#T»;
 
 lam %tensor.conv_impl [R: %tensor.Ring] {n cin cout h w kh kw: Nat}
-                      (stride: «2; Nat», dilation: «2; Nat», padding: «2; Nat», s_out: «2; Nat»)
+                      (stride: «2; Nat», dilation: «2; Nat», padding: «2; Nat»)
                       (input: «n, cin, h, w; R#T», weight: «cout, cin, kh, kw; R#T»)
-                    : «n, cout, s_out#0_2, s_out#1_2; R#T» =
+                    : «conv_shape (n, cout, (h, w), (kh, kw), stride, dilation, padding); R#T» =
     // Zero-pad only the spatial axes (lo = hi = (0, 0, pad_h, pad_w)); the pad value is the ring zero.
     let s_in     = (n, cin, h, w);
     let pad_lohi = (0, 0, padding#0_2, padding#1_2);
     let padded   = %tensor.pad s_in (0, pad_lohi, pad_lohi) (input, R#_0);
     let s_padded = %tensor.shape 4 padded;
+    let s_out    = conv_shape (n, cout, (h, w), (kh, kw), stride, dilation, padding);
+    let oh       = s_out#2_4;
+    let ow       = s_out#3_4;
 
     %tensor.map_reduce @2 @(R#T, 4, 3)
-        ((n, cout, s_out#0_2, s_out#1_2), (n, cout, s_out#0_2, s_out#1_2, cin, kh, kw))
+        ((n, cout, oh, ow), (n, cout, oh, ow, cin, kh, kw))
         @((R#T, R#T), (4, 4), (s_padded, (cout, cin, kh, kw)))
         (conv_fun R, R#_0)
         (%tensor.proj_map @(7, 4) (0, 1, 2, 3))


### PR DESCRIPTION
## What this PR does?

1. cherry-pick `%core.nat.div` commit(it's a pain to rebase)
2. update `%tensor.conv` signature and calculate output tensor's shape by `conv_shape`
3. update test cases

## Tests

`./lit/lit build/lit --filter "conv` passes.