### PR TITLE
ci: pin FileCheck release; fix stale comment

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           owner: fodinabor
           repo: FileCheckBuild
-          tag: latest
+          tag: llvmorg-22.1.8
           file: FileCheck-x86_64-win.exe
           path: ${{github.workspace}}/bin
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/lit/CMakeLists.txt
+++ b/lit/CMakeLists.txt
@@ -19,7 +19,7 @@ find_program(MIM_FILECHECK_DEFAULT
 )
 set(MIM_FILECHECK "${MIM_FILECHECK_DEFAULT}" CACHE STRING "FileCheck command used by lit tests.")
 mark_as_advanced(MIM_FILECHECK_DEFAULT)
-# Normalize to forward slashes; lit runs tests through bash, which chokes on backslash paths.
+# Normalize to forward slashes so the path embedded into lit.site.cfg.py is shell-agnostic.
 file(TO_CMAKE_PATH "${MIM_FILECHECK}" MIM_FILECHECK)
 
 if(NOT MIM_FILECHECK)


### PR DESCRIPTION
Pins `fodinabor/FileCheckBuild` to `llvmorg-22.1.8` instead of `latest` so the FileCheck binary cannot change underneath CI again (the asset silently jumped from LLVM 20 to 22 while debugging #476). Also rewords the `MIM_FILECHECK` normalization comment in `lit/CMakeLists.txt` — backslash paths were not the actual cause of the exit-127 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)