### PR TITLE
Add support for encoding decimal float literals with correct bit width.

### DIFF
--- a/lit/CMakeLists.txt
+++ b/lit/CMakeLists.txt
@@ -74,6 +74,23 @@ foreach(MIM_LIT_STAGE_FILE IN LISTS MIM_LIT_STAGE_FILES)
     string(APPEND MIM_LIT_STAGE_FILES_SCRIPT "    \"${MIM_LIT_STAGE_FILE}\"\n")
 endforeach()
 
+# Detect 16-bit floating-point support once at configure time; mim's fp16 path needs `std::float16_t`.
+# Exposed to lit as the `fp16` feature so tests emitting %math.F16 literals can gate via `// REQUIRES: fp16`.
+include(CheckCXXSourceCompiles)
+check_cxx_source_compiles(
+    "#include <stdfloat>
+     #if !defined(__STDCPP_FLOAT16_T__)
+     #    error no std::float16_t
+     #endif
+     int main() { std::float16_t f = 1.0f16; return int(f); }"
+    MIM_HAS_FLOAT16
+)
+if(MIM_HAS_FLOAT16)
+    set(MIM_FP16_SUPPORTED True)
+else()
+    set(MIM_FP16_SUPPORTED False)
+endif()
+
 configure_file(lit.site.cfg.py.in lit.site.cfg.py @ONLY)
 configure_file("${PROJECT_SOURCE_DIR}/cmake/stage-lit-tests.cmake.in" "${CMAKE_CURRENT_BINARY_DIR}/stage-lit-tests.cmake" @ONLY)
 

--- a/lit/lit.cfg.py
+++ b/lit/lit.cfg.py
@@ -18,3 +18,8 @@ config.substitutions.append(('%FileCheck', '"{}"'.format(config.filecheck)))
 config.environment = os.environ
 
 config.available_features.add("always")
+
+# 16-bit floating-point support (needs std::float16_t) is detected once by CMake and passed in via
+# lit.site.cfg.py. Tests emitting %math.F16 literals gate on this via `// REQUIRES: fp16`.
+if getattr(config, 'fp16', False):
+    config.available_features.add("fp16")

--- a/lit/lit.site.cfg.py.in
+++ b/lit/lit.site.cfg.py.in
@@ -5,6 +5,7 @@ config.my_src_root = r'@CMAKE_SOURCE_DIR@'
 config.my_obj_root = r'@CMAKE_BINARY_DIR@'
 config.test_source_root = r'@CMAKE_CURRENT_BINARY_DIR@/tests'
 config.filecheck = r'@MIM_FILECHECK@'
+config.fp16 = @MIM_FP16_SUPPORTED@
 lit_config.maxIndividualTestTime = @MIM_LIT_TIMEOUT@
 if sys.platform == "win32":
     config.mim = r'@CMAKE_BINARY_DIR@/bin/mim.exe'

--- a/lit/math/lit_float.mim
+++ b/lit/math/lit_float.mim
@@ -1,5 +1,5 @@
 // RUN: %mim %s -o - -p ll | %FileCheck %s
-// RUN: cat %{s:stem}.ll | %FileCheck %s --check-prefix=LLVM
+// RUN: %FileCheck %s --check-prefix=LLVM < %{s:stem}.ll
 plugin math;
 
 // Decimal float literals must be encoded with the bit width of their annotated type.

--- a/lit/math/lit_float.mim
+++ b/lit/math/lit_float.mim
@@ -1,5 +1,5 @@
 // RUN: %mim %s -o - -p ll | %FileCheck %s
-// RUN: cat %{s:stem}.ll | FileCheck %s --check-prefix=LLVM
+// RUN: cat %{s:stem}.ll | %FileCheck %s --check-prefix=LLVM
 plugin math;
 
 // Decimal float literals must be encoded with the bit width of their annotated type.

--- a/lit/math/lit_float.mim
+++ b/lit/math/lit_float.mim
@@ -1,0 +1,27 @@
+// RUN: %mim %s -o - -p ll | %FileCheck %s
+// RUN: cat %{s:stem}.ll | FileCheck %s --check-prefix=LLVM
+plugin math;
+
+// Decimal float literals must be encoded with the bit width of their annotated type.
+// The Tok stores the value as f64 bits; re-encoding these for %math.F32 used to be forgotten,
+// so the low 32 bits of the f64 pattern ended up in the Lit (0 for most values).
+
+// CHECK-DAG: fun extern f32_one (): %math.F (23, 8) =
+// CHECK-DAG: return_{{[0-9_]+}} 1065353216:(%math.F (23, 8))
+// LLVM-DAG: ret float 0x3ff0000000000000
+con extern f32_one(return: Cn %math.F32) = return 1.0:(%math.F32);
+
+// CHECK-DAG: fun extern f32_em3 (): %math.F (23, 8) =
+// CHECK-DAG: return_{{[0-9_]+}} 981668463:(%math.F (23, 8))
+// LLVM-DAG: ret float 0x3f50624de0000000
+con extern f32_em3(return: Cn %math.F32) = return 1e-3:(%math.F32);
+
+// CHECK-DAG: fun extern f32_pe (): %math.F (23, 8) =
+// CHECK-DAG: return_{{[0-9_]+}} 1124073472:(%math.F (23, 8))
+// LLVM-DAG: ret float 0x4060000000000000
+con extern f32_pe(return: Cn (%math.F (23, 8))) = return 128.0:(%math.F (23, 8));
+
+// CHECK-DAG: fun extern f64_one (): %math.F (52, 11) =
+// CHECK-DAG: return_{{[0-9_]+}} 4607182418800017408:(%math.F (52, 11))
+// LLVM-DAG: ret double 0x3ff0000000000000
+con extern f64_one(return: Cn %math.F64) = return 1.0:(%math.F64);

--- a/lit/math/lit_float_fp16.mim
+++ b/lit/math/lit_float_fp16.mim
@@ -1,6 +1,6 @@
 // REQUIRES: fp16
 // RUN: %mim %s -o - -p ll | %FileCheck %s
-// RUN: cat %{s:stem}.ll | FileCheck %s --check-prefix=LLVM
+// RUN: cat %{s:stem}.ll | %FileCheck %s --check-prefix=LLVM
 plugin math;
 
 // Companion to lit_float.mim for the 16-bit path; only run where std::float16_t is available.

--- a/lit/math/lit_float_fp16.mim
+++ b/lit/math/lit_float_fp16.mim
@@ -1,6 +1,6 @@
 // REQUIRES: fp16
 // RUN: %mim %s -o - -p ll | %FileCheck %s
-// RUN: cat %{s:stem}.ll | %FileCheck %s --check-prefix=LLVM
+// RUN: %FileCheck %s --check-prefix=LLVM < %{s:stem}.ll
 plugin math;
 
 // Companion to lit_float.mim for the 16-bit path; only run where std::float16_t is available.

--- a/lit/math/lit_float_fp16.mim
+++ b/lit/math/lit_float_fp16.mim
@@ -1,0 +1,17 @@
+// REQUIRES: fp16
+// RUN: %mim %s -o - -p ll | %FileCheck %s
+// RUN: cat %{s:stem}.ll | FileCheck %s --check-prefix=LLVM
+plugin math;
+
+// Companion to lit_float.mim for the 16-bit path; only run where std::float16_t is available.
+// A decimal literal must be encoded with the bit width of its annotated %math.F16 type.
+
+// CHECK-DAG: fun extern f16_one (): %math.F (10, 5) =
+// CHECK-DAG: return_{{[0-9_]+}} 15360:(%math.F (10, 5))
+// LLVM-DAG: ret half 0xH3c00
+con extern f16_one(return: Cn %math.F16) = return 1.0:(%math.F16);
+
+// CHECK-DAG: fun extern f16_half (): %math.F (10, 5) =
+// CHECK-DAG: return_{{[0-9_]+}} 14336:(%math.F (10, 5))
+// LLVM-DAG: ret half 0xH3800
+con extern f16_half(return: Cn %math.F16) = return 0.5:(%math.F16);

--- a/src/mim/ast/emit.cpp
+++ b/src/mim/ast/emit.cpp
@@ -176,11 +176,42 @@ const Def* PrimaryExpr ::emit_(Emitter& e) const {
     // clang-format on
 }
 
+/// If @p type is a `%math.F` type of known precision/exponent, yields its bit width.
+/// Note that libmim must not depend on the generated math plugin header, so lookup the Axm at runtime instead.
+static std::optional<nat_t> isa_math_f(Emitter& e, const Def* type) {
+    auto math_f = e.world().annex(e.world().sym("%math.F"));
+    if (auto app = type->zonk()->isa<App>(); math_f && app && app->callee() == math_f) {
+        if (auto [p, ex] = app->arg()->projs<2>([](auto op) { return Lit::isa(op); }); p && ex) {
+            if (*p == 10 && *ex == 5) return 16;
+            if (*p == 23 && *ex == 8) return 32;
+            if (*p == 52 && *ex == 11) return 64;
+        }
+    }
+    return {};
+}
+
+/// A float Tok stores its value as mim::f64 bits; re-encode them for the width of the annotated type @p t.
+static u64 encode_f(Emitter& e, [[maybe_unused]] Loc loc, const Def* t, u64 bits) {
+    if (auto width = isa_math_f(e, t)) {
+        auto val = std::bit_cast<f64>(bits);
+        switch (*width) {
+#if defined(__STDCPP_FLOAT16_T__)
+            case 16: return std::bit_cast<u16>(f16(val));
+#else
+            case 16: error(loc, "16-bit floating-point literals are not supported on this platform");
+#endif
+            case 32: return std::bit_cast<u32>(f32(val));
+            default: break;
+        }
+    }
+    return bits;
+}
+
 const Def* LitExpr::emit_(Emitter& e) const {
     auto t = type() ? type()->emit(e) : nullptr;
     // clang-format off
     switch (tag()) {
-        case Tag::L_f:
+        case Tag::L_f:   return t ? e.world().lit(t, encode_f(e, loc(), t, tok().lit_u())) : e.world().lit_nat(tok().lit_u());
         case Tag::L_s:
         case Tag::L_u:   return t ? e.world().lit(t, tok().lit_u()) : e.world().lit_nat(tok().lit_u());
         case Tag::L_i:   return tok().lit_i();


### PR DESCRIPTION
I ended up running into a bunch of nan errors - which seem to stem from encoding 32-bit floats as a bit representation of a double.
The normalizers (and maybe also backend) seem to be confused by this, and thus did invalid math -> nan...