### PR TITLE
[Py] Add bindings for the profiler CLI args.

### DIFF
--- a/py/bindings/driver.cpp
+++ b/py/bindings/driver.cpp
@@ -1,3 +1,5 @@
+#include <sstream>
+
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/filesystem.h>
 #include <nanobind/stl/pair.h>
@@ -16,6 +18,14 @@ namespace nb = nanobind;
 namespace mim {
 
 void init_driver(nb::module_& m) {
+    nb::class_<Profiler>(m, "Profiler")
+        .def("empty", &Profiler::empty)
+        // clang-format off
+        .def("summary",      [](const Profiler& p) { std::ostringstream os; p.summary(os);      return os.str(); })
+        .def("tree",         [](const Profiler& p) { std::ostringstream os; p.tree(os);         return os.str(); })
+        .def("chrome_trace", [](const Profiler& p) { std::ostringstream os; p.chrome_trace(os); return os.str(); });
+    // clang-format on
+
     nb::class_<Driver, fe::SymPool>(m, "Driver")
         .def(nb::init<>())
         .def(nb::init<std::string>())
@@ -24,6 +34,8 @@ void init_driver(nb::module_& m) {
         .def("add_import", [](Driver& driver, std::string path, std::string str) { return driver.imports().add(fs::path(path), driver.sym(str), ast::Tok::Tag::K_import); }, nb::rv_policy::reference_internal)
         .def("add_plugin", [](Driver& driver, std::string path, std::string str) { return driver.imports().add(fs::path(path), driver.sym(str), ast::Tok::Tag::K_plugin); }, nb::rv_policy::reference_internal)
         .def("add_search_path", &Driver::add_search_path)
+        .def("flags", [](Driver& driver) -> Flags& { return driver.flags(); }, nb::rv_policy::reference_internal)
+        .def("profiler", [](Driver& driver) -> Profiler& { return driver.profiler(); }, nb::rv_policy::reference_internal)
         .def("log", &Driver::log, nb::rv_policy::reference_internal)
         .def("load_plugin",  [](Driver& d,             std::string  plugin ) { ast::load_plugin (d.world(), plugin ); })
         .def("load_plugins", [](Driver& d, std::vector<std::string> plugins) { ast::load_plugins(d.world(), plugins); });

--- a/py/bindings/flags.cpp
+++ b/py/bindings/flags.cpp
@@ -7,6 +7,16 @@ namespace nb = nanobind;
 namespace mim {
 
 void init_flags(nb::module_& m) {
-    nb::class_<Flags>(m, "Flags").def(nb::init<>()).def_rw("scalarize_threshold", &Flags::scalarize_threshold);
+    auto flags = nb::class_<Flags>(m, "Flags")
+                     .def(nb::init<>())
+                     .def_rw("scalarize_threshold", &Flags::scalarize_threshold);
+
+    nb::enum_<Flags::Profile>(flags, "Profile")
+        .value("None_", Flags::Profile::None)
+        .value("Summary", Flags::Profile::Summary)
+        .value("Tree", Flags::Profile::Tree)
+        .value("Trace", Flags::Profile::Trace);
+    
+    flags.def_rw("profile", &Flags::profile);
 }
 } // namespace mim


### PR DESCRIPTION
This allows enabling the profiler in downstream python projects.