### PR TITLE
Add memoization to alpha checks.

### DIFF
--- a/include/mim/check.h
+++ b/include/mim/check.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <absl/container/flat_hash_set.h>
+
 #include "mim/def.h"
 
 namespace mim {
@@ -125,6 +127,8 @@ private:
     template<Mode>
     [[nodiscard]] bool alpha_(const Def* d1, const Def* d2);
     template<Mode>
+    [[nodiscard]] bool alpha_impl_(const Def* d1, const Def* d2);
+    template<Mode>
     [[nodiscard]] bool check(const Prod*, const Def*);
     template<Mode>
     [[nodiscard]] bool check(const Seq*, const Def*);
@@ -132,9 +136,20 @@ private:
     [[nodiscard]] bool check(Seq*, const Seq*);
     [[nodiscard]] bool check(const UMax*, const Def*);
 
-    auto bind(Def* mut, const Def* d) { return mut ? binders_.emplace(mut, d) : std::pair(binders_.end(), true); }
+    auto bind(Def* mut, const Def* d) {
+        if (!mut) return std::pair(binders_.end(), true);
+        auto res = binders_.emplace(mut, d);
+        // A new binding may change how bound Var%s compare, so positive memo entries may become invalid.
+        if (res.second) {
+            memo_[Check].clear();
+            memo_[Test].clear();
+        }
+        return res;
+    }
+
     World& world_;
     MutMap<const Def*> binders_;
+    std::array<absl::flat_hash_set<std::pair<const Def*, const Def*>>, 2> memo_;
 };
 
 } // namespace mim

--- a/src/mim/check.cpp
+++ b/src/mim/check.cpp
@@ -148,6 +148,15 @@ const Def* Checker::assignable_(const Def* type, const Def* val) {
 
 template<Checker::Mode mode>
 bool Checker::alpha_(const Def* d1, const Def* d2) {
+    auto& memo = memo_[mode];
+    if (memo.contains({d1, d2}) || memo.contains({d2, d1})) return true;
+    if (!alpha_impl_<mode>(d1, d2)) return false;
+    memo.emplace(d1, d2);
+    return true;
+}
+
+template<Checker::Mode mode>
+bool Checker::alpha_impl_(const Def* d1, const Def* d2) {
     for (bool todo = true; todo;) {
         // below we check type and arity which may in turn open up more opportunities for zonking
         todo = false;


### PR DESCRIPTION
Right now, a chain of the following pattern would lead to exponential runtime of the alpha equiv checks... we can avoid this by memoization. b = app (a#0, (a#2, a#1)); c = app (b#0, (b#2, b#1)); ... c...

As far as I can tell, the only state we carry around in the checker otherwise is the binders -> we just invalidate the memoization once any binder changes occur -> semantics should be un-touched.

In the discussed LSTM example, this brings the debug compiletime down from >20min to 70s.