### PR TITLE
plugin args. fixes #487

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -15,6 +15,30 @@ Mim looks for plugins in this order:
 4. `path/to/mim.exe/../../lib/mim`
 5. `CMAKE_INSTALL_PREFIX/lib/mim`
 
+## Passing Arguments to Plugins & Phases {#clipluginargs}
+
+Plugins - and in particular backends - often need to be configured from the command line.
+For example, a backend that invokes an external tool may want to forward optimization levels, a target triple for cross-compilation, or library paths.
+Use `-X` / `--plugin-arg` for this:
+
+```
+mim foo.mim -p ll -X ll:o=out.ll -X compile:aggr=on
+```
+
+The syntax is `-X <plugin>:<arg>`:
+
+- The option is repeatable; each occurrence contributes one argument.
+- Only the *first* `:` separates `<plugin>` from `<arg>`, so `<arg>` may itself contain `:` or `=` (e.g. Windows paths or `key=value` pairs).
+- Arguments are keyed by plugin name and collected on the [`mim::Driver`](@ref mim::Driver).
+  A [`mim::Phase`](@ref mim::Phase) reads the arguments addressed to its own plugin via [`mim::Phase::args`](@ref mim::Phase::args); the interpretation of each `<arg>` is up to the plugin.
+
+### Known Arguments
+
+| Plugin              | Argument      | Effect                                                                                                                   |
+|---------------------|---------------|--------------------------------------------------------------------------------------------------------------------------|
+| [compile](@ref compile) | `aggr=<bool>` | Value of `%%compile.aggr`; toggles fixed-point iteration of the `opt` pipeline's `optimize` stage (default off). `<bool>` is `on`/`tt`/`true` or `off`/`ff`/`false`; a bare `aggr` means `on`. See @ref compile_cli_args. |
+| [ll](@ref ll)           | `o=<file>`    | Write the LLVM IR to `<file>` instead of the default `<world>.ll`/`a.ll`. See @ref ll_cli_args.                          |
+
 ## Debugging Features {#clidebug}
 
 - The breakpoint-oriented flags below are developer options that are only available when MimIR is built with `MIM_ENABLE_CHECKS`.

--- a/include/mim/driver.h
+++ b/include/mim/driver.h
@@ -126,6 +126,14 @@ public:
     auto normalizer(plugin_t d, tag_t t, sub_t s) const { return normalizer(Annex::flags(d, t, s)); }
     ///@}
 
+    /// @name Plugin/Phase Arguments
+    /// Freeform command-line arguments addressed to a plugin/phase (`-X <plugin>:<arg>`).
+    /// A Phase reads its own arguments via Phase::args().
+    ///@{
+    void add_arg(Sym plugin, std::string arg) { plugin_args_[plugin].emplace_back(std::move(arg)); }
+    const Vector<std::string>& args(Sym plugin) const; ///< Yields an empty Vector if @p plugin has none.
+    ///@}
+
 private:
     // This must go *first* so plugins will be unloaded *last* in the d'tor; otherwise funny things might happen ...
     absl::node_hash_map<Sym, Plugin::Handle> plugins_;
@@ -138,6 +146,7 @@ private:
     std::list<fs::path>::iterator insert_ = search_paths_.end();
     Flags2Phases phases_;
     Normalizers normalizers_;
+    fe::SymMap<Vector<std::string>> plugin_args_;
     Imports imports_;
 };
 

--- a/include/mim/phase.h
+++ b/include/mim/phase.h
@@ -79,6 +79,10 @@ public:
     Log& log() const { return world_.log(); }
     std::string_view name() const { return name_; }
     flags_t annex() const { return annex_; }
+
+    /// Command-line arguments passed to this Phase's plugin via `-X <plugin>:<arg>`.
+    /// Derived from Phase::annex; yields an empty Vector for name-constructed Phase%s.
+    const Vector<std::string>& args();
     ///@}
 
     /// @name Fixed-Point Handling

--- a/lit/plugin_arg.mim
+++ b/lit/plugin_arg.mim
@@ -1,0 +1,13 @@
+// RUN: rm -f %{s:stem}.ll %t.ll
+// Route a CLI argument to the `ll` backend via `-X`; `o=<file>` overrides its output path.
+// RUN: %mim -p opt %s -p ll -X ll:o=%t.ll
+// RUN: cat %t.ll | FileCheck %s
+// The default `<world>.ll` path must NOT be produced when the output path is overridden.
+// RUN: test ! -f %{s:stem}.ll
+plugin core;
+
+fun extern test(cond: Bool, a: «3; I32», b: «3; I32», i: Idx 3): «3; I32» =
+    con nx(phi: «3; I32») = return ins(phi, i, 23I32);
+    (cn () = nx a, cn () = nx b)#cond ();
+
+// CHECK: define

--- a/lit/plugin_arg.mim
+++ b/lit/plugin_arg.mim
@@ -1,7 +1,7 @@
 // RUN: rm -f %{s:stem}.ll %t.ll
 // Route a CLI argument to the `ll` backend via `-X`; `o=<file>` overrides its output path.
 // RUN: %mim -p opt %s -p ll -X ll:o=%t.ll
-// RUN: cat %t.ll | FileCheck %s
+// RUN: %FileCheck %s < %t.ll
 // The default `<world>.ll` path must NOT be produced when the output path is overridden.
 // RUN: test ! -f %{s:stem}.ll
 plugin core;

--- a/src/mim/cli/main.cpp
+++ b/src/mim/cli/main.cpp
@@ -35,7 +35,7 @@ int main(int argc, char** argv) {
         DotConfig dot;
         std::string input, prefix;
         std::string clang = sys::find_cmd("clang");
-        std::vector<std::string> plugins, search_paths;
+        std::vector<std::string> plugins, search_paths, plugin_args;
 #ifdef MIM_ENABLE_CHECKS
         std::vector<uint32_t> breakpoints;
         std::vector<uint32_t> watchpoints;
@@ -70,6 +70,7 @@ int main(int argc, char** argv) {
             | lyra::opt(clang,        "clang"              )["-c"]["--clang"                ]("Path to clang executable (default: '" MIM_WHICH " clang').")
             | lyra::opt(plugins,      "plugin"             )["-p"]["--plugin"               ]("Dynamically load plugin.")
             | lyra::opt(search_paths, "path"               )["-P"]["--plugin-path"          ]("Path to search for plugins.")
+            | lyra::opt(plugin_args,  "plugin:arg"         )["-X"]["--plugin-arg"           ]("Pass <arg> to plugin/phase <plugin>, e.g. -X ll:--target=sm_80. Repeatable.")
             | lyra::opt(inc_verbose                        )["-V"]["--verbose"              ]("Verbose mode. Multiple -V options increase the verbosity. The maximum is 4.").cardinality(0, 5)
             | lyra::opt(output[AST],  "file"               )      ["--output-ast"           ]("Directly emits AST representation of input.")
             | lyra::opt(output[Dot],  "file"               )      ["--output-dot"           ]("Emits the Mim program as a MimIR graph using Graphviz' DOT language.")
@@ -126,6 +127,13 @@ int main(int argc, char** argv) {
 
         for (auto&& path : search_paths)
             driver.add_search_path(path);
+
+        for (auto&& pa : plugin_args) {
+            auto pos = pa.find(':');
+            if (pos == std::string::npos)
+                throw std::invalid_argument("error: --plugin-arg expects <plugin>:<arg>, got '" + pa + "'");
+            driver.add_arg(driver.sym(pa.substr(0, pos)), pa.substr(pos + 1));
+        }
 
         if (list_search_paths) {
             for (auto&& path : driver.search_paths() | std::views::drop(1)) // skip first empty path

--- a/src/mim/driver.cpp
+++ b/src/mim/driver.cpp
@@ -124,4 +124,10 @@ void* Driver::get_fun_ptr(Sym plugin, const char* name) {
     return nullptr;
 }
 
+const Vector<std::string>& Driver::args(Sym plugin) const {
+    static const Vector<std::string> empty;
+    if (auto i = plugin_args_.find(plugin); i != plugin_args_.end()) return i->second;
+    return empty;
+}
+
 } // namespace mim

--- a/src/mim/phase.cpp
+++ b/src/mim/phase.cpp
@@ -20,6 +20,10 @@ Phase::Phase(World& world, flags_t annex)
     , annex_(annex)
     , name_(world.annex(annex)->sym()) {}
 
+const Vector<std::string>& Phase::args() {
+    return driver().args(Annex::demangle(driver(), Annex::flags2plugin(annex_)));
+}
+
 std::unique_ptr<Phase> Phase::recreate() {
     auto ctor = driver().phase(annex());
     auto ptr  = (*ctor)(world());

--- a/src/mim/plug/compile/compile.mim
+++ b/src/mim/plug/compile/compile.mim
@@ -9,6 +9,14 @@
 /// Invoke the optimization pipeline by defining a function `_compile: [] → %%compile.Phase`
 /// (or rely on a plugin-provided `_default_compile` such as the one in the `opt` plugin).
 ///
+/// ## Command-Line Arguments {#compile_cli_args}
+///
+/// This plugin reads the following [plugin arguments](@ref clipluginargs) (`-X compile:<arg>`):
+///
+/// | Argument         | Effect                                                                                        |
+/// |------------------|-----------------------------------------------------------------------------------------------|
+/// | `aggr=<bool>`    | Sets the value of `%%compile.aggr` (see above). `<bool>` is one of `on`/`tt`/`true` or `off`/`ff`/`false`; a bare `aggr` is equivalent to `aggr=on`. Used by the `opt` pipeline to switch fixed-point iteration on/off. |
+///
 /// ## Types
 ///
 /// ### %%compile.Phase
@@ -41,6 +49,15 @@ axm %compile.named: {n: Nat} → «n; I8» → %compile.Phase;
 /// Used to gate whole sub-pipelines on a plugin without importing it.
 ///
 axm %compile.cond: {n: Nat} → «n; I8» → %compile.Phase → %compile.Phase, normalize_cond;
+///
+/// ### %%compile.aggr
+///
+/// Makes a fixed-point flag switchable from the command line.
+/// `%%compile.aggr fallback` yields `tt` if `-X compile:aggr=on` (also `=true` or a bare `aggr`) was passed,
+/// `ff` if `-X compile:aggr=off` (also `=false`), and otherwise the given `fallback`.
+/// Use it as the Bool of a `%%compile.phases` to make that pipeline's fixed-point iteration switchable via the CLI.
+///
+axm %compile.aggr: Bool → Bool, normalize_aggr;
 ///
 /// ## Constructors
 ///

--- a/src/mim/plug/compile/normalizers.cpp
+++ b/src/mim/plug/compile/normalizers.cpp
@@ -13,6 +13,19 @@ const Def* normalize_is_loaded(const Def*, const Def*, const Def* arg) {
     return {};
 }
 
+/// `%compile.aggr fallback` ↦ `tt`/`ff` if `-X compile:aggr=on`/`=off` was passed, else `fallback`.
+const Def* normalize_aggr(const Def*, const Def*, const Def* arg) {
+    auto& world  = arg->world();
+    auto& driver = world.driver();
+    for (const auto& a : driver.args(driver.sym("compile"))) {
+        // clang-format off
+        if (a == "aggr=tt" || a == "aggr=on"  || a == "aggr=true" || a == "aggr") return world.lit_tt();
+        if (a == "aggr=ff" || a == "aggr=off" || a == "aggr=false")               return world.lit_ff();
+        // clang-format on
+    }
+    return arg;
+}
+
 /// `%compile.cond name phase` ↦ `phase` if `name`'s plugin is loaded, else `%compile.null`.
 const Def* normalize_cond(const Def*, const Def* callee, const Def* phase) {
     auto& world  = phase->world();

--- a/src/mim/plug/ll/ll.cpp
+++ b/src/mim/plug/ll/ll.cpp
@@ -14,15 +14,21 @@ namespace mim::plug::ll {
 using namespace std::string_literals;
 
 /// Pipeline phase for `%ll.emit`.
-/// Writes the LLVM IR of the fully lowered world to `<world>.ll` or `a.ll`.
+/// Writes the LLVM IR of the fully lowered world to `<world>.ll` (or `a.ll` if the world is unnamed).
+/// The output path can be overridden on the command line via `-X ll:o=<file>`.
 class Emit : public Phase {
 public:
     Emit(World& world, flags_t annex)
         : Phase(world, annex) {}
 
     void start() override {
-        auto name    = world().name() ? std::string(world().name().view()) : "a"s;
-        auto ofs     = std::ofstream(name + ".ll"s);
+        auto name = world().name() ? std::string(world().name().view()) : "a"s;
+        auto path = name + ".ll"s;
+        for (const auto& arg : args()) {
+            world().DLOG("ll backend arg: `{}`", arg);
+            if (arg.starts_with("o=")) path = arg.substr(2);
+        }
+        auto ofs     = std::ofstream(path);
         auto emitter = Emitter(world(), ofs);
         emitter.run();
     }

--- a/src/mim/plug/ll/ll.mim
+++ b/src/mim/plug/ll/ll.mim
@@ -6,16 +6,25 @@
 ///
 /// The LLVM backend.
 /// Loading this plugin (`mim foo.mim -p ll`) appends an emission phase to the compilation pipeline that writes the LLVM IR of the fully lowered program to `<world>.ll`.
+/// The output path can be overridden via the `-X ll:o=<file>` command-line argument; see @ref ll_cli_args.
 ///
 /// ## Dependencies
 ///
 plugin opt;
 ///
+/// ## Command-Line Arguments {#ll_cli_args}
+///
+/// This plugin reads the following [plugin arguments](@ref clipluginargs) (`-X ll:<arg>`):
+///
+/// | Argument   | Effect                                                                      |
+/// |------------|-----------------------------------------------------------------------------|
+/// | `o=<file>` | Write the LLVM IR to `<file>` instead of the default `<world>.ll`/`a.ll`.   |
+///
 /// ## Phases
 ///
 /// ### %%ll.emit
 ///
-/// Emits the LLVM IR of the current world to `<world>.ll`.
+/// Emits the LLVM IR of the current world to `<world>.ll` (or to the path given via `-X ll:o=<file>`).
 /// This phase is spliced into the default pipeline (see `opt`) whenever the `ll` plugin is loaded.
 ///
 axm %ll.emit: %compile.Phase;

--- a/src/mim/plug/opt/opt.mim
+++ b/src/mim/plug/opt/opt.mim
@@ -19,7 +19,8 @@ plugin compile;
 ///
 lam extern _default_compile (): %compile.Phase =
     let optimize =
-        %compile.phases tt (
+        // fixed-point iteration off by default; enable with `-X compile:aggr=on`
+        %compile.phases (%compile.aggr ff) (
             %compile.scalarize,
             %compile.phases tt (
                 %compile.beta_red,


### PR DESCRIPTION
adds plug-in args via cli. this PR already ships two:

- `-X ll:o=foo.ll` to change the standard output file name of the emitted ll file
- `-X compile:aggr=on` switches the optimize pipeline to a fp loop which by default in this PR now is not looped anymore