### PR TITLE
cleanup

### DIFF
--- a/docs/dev.md
+++ b/docs/dev.md
@@ -240,6 +240,8 @@ Methods beginning with
 
 - `isa` behave like `dynamic_cast`: they perform a runtime check and return `nullptr` if the cast fails;
 - `as` behave more like `static_cast`: in `Debug` builds they assert, via the corresponding `isa`, that the cast is valid.
+- `expect` behave like `as`, but - instead of merely asserting in `Debug` builds and being silently unchecked in `Release` - they *always* check via the corresponding `isa` and throw a formatted exception (via mim::throwf) when the cast fails.
+  Reach for `expect` (over `as`) whenever the assumption is really a claim about the incoming IR that should surface as a proper error message rather than a `Debug`-only assertion or Release-mode undefined behavior - e.g. in backends that validate an already-lowered program.
 
 #### General Downcast
 
@@ -254,6 +256,15 @@ void foo(const Def* def) {
     // sigma has type "const Sigma*" and may be mutable or immutable
     // asserts if def is not a Sigma
     auto sigma = def->as<Sigma>();
+
+    // sigma has type "const Sigma*" and may be mutable or immutable
+    // throws an exception (via mim::throwf) like "expected a struct type, but got '<def>'" if def is not a Sigma;
+    // the argument is a description of what was expected - a plain string or a format string plus arguments
+    auto s1 = def->expect<Sigma>("a struct type");
+    auto s2 = def->expect<Sigma>("the operand of {}", parent);
+
+    // the mutable counterpart, mirroring Def::as_mut; yields "Lam*"
+    auto lam = def->expect_mut<Lam>("a mutable continuation");
 }
 ```
 
@@ -340,6 +351,10 @@ void foo(const Def* def) {
     // asserts if def is not a Lit
     auto lu64 = Lit::as(def);
     auto lf32 = Lit::as<f32>(def);
+
+    // throws an exception (via mim::throwf) like "expected an address space, but got '<def>'" if def is not a Lit
+    auto a = Lit::expect(def, "an address space");
+    auto f = Lit::expect<f32>(def, "a floating-point constant");
 }
 ```
 
@@ -347,13 +362,15 @@ void foo(const Def* def) {
 
 The following table summarizes the most important casts:
 
-| `dynamic_cast` <br> `static_cast`               | Returns                                                                                                                             | If `def` is a ...                    |
-| ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
-| `def->isa<Lam>()` <br> `def->as<Lam>()`         | `const Lam*`                                                                                                                        | [`Lam`](@ref mim::Lam)               |
-| `def->isa_imm<Lam>()` <br> `def->as_imm<Lam>()` | `const Lam*`                                                                                                                        | **immutable** [`Lam`](@ref mim::Lam) |
-| `def->isa_mut<Lam>()` <br> `def->as_mut<Lam>()` | `Lam*`                                                                                                                              | **mutable** [`Lam`](@ref mim::Lam)   |
-| `Lit::isa(def)` <br> `Lit::as(def)`             | [std::optional](https://en.cppreference.com/w/cpp/utility/optional)`<`[`nat_t`](@ref mim::nat_t)`>` <br> [`nat_t`](@ref mim::nat_t) | [`Lit`](@ref mim::Lit)               |
-| `Lit::isa<f32>(def)` <br> `Lit::as<f32>(def)`   | [std::optional](https://en.cppreference.com/w/cpp/utility/optional)`<`[`f32`](@ref mim::f32)`>` <br> [`f32`](@ref mim::f32)         | [`Lit`](@ref mim::Lit)               |
+A method beginning with `expect` behaves like the `as` in the same row, but throws a formatted exception (via mim::throwf) instead of asserting; it takes a description (a plain string or a format string plus arguments) of what was expected.
+
+| `dynamic_cast` <br> `static_cast` <br> throwing                                     | Returns                                                                                                                             | If `def` is a ...                    |
+| ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| `def->isa<Lam>()` <br> `def->as<Lam>()` <br> `def->expect<Lam>(fmt, ...)`           | `const Lam*`                                                                                                                        | [`Lam`](@ref mim::Lam)               |
+| `def->isa_imm<Lam>()` <br> `def->as_imm<Lam>()`                                     | `const Lam*`                                                                                                                        | **immutable** [`Lam`](@ref mim::Lam) |
+| `def->isa_mut<Lam>()` <br> `def->as_mut<Lam>()` <br> `def->expect_mut<Lam>(fmt, ...)` | `Lam*`                                                                                                                            | **mutable** [`Lam`](@ref mim::Lam)   |
+| `Lit::isa(def)` <br> `Lit::as(def)` <br> `Lit::expect(def, fmt, ...)`               | [std::optional](https://en.cppreference.com/w/cpp/utility/optional)`<`[`nat_t`](@ref mim::nat_t)`>` <br> [`nat_t`](@ref mim::nat_t) | [`Lit`](@ref mim::Lit)               |
+| `Lit::isa<f32>(def)` <br> `Lit::as<f32>(def)` <br> `Lit::expect<f32>(def, fmt, ...)` | [std::optional](https://en.cppreference.com/w/cpp/utility/optional)`<`[`f32`](@ref mim::f32)`>` <br> [`f32`](@ref mim::f32)         | [`Lit`](@ref mim::Lit)               |
 
 #### Further Casts
 
@@ -375,6 +392,10 @@ void foo(const Def* def) {
     if (auto pi = Pi::isa_basicblock(def)) {
         // def is a Pi whose codomain is bottom and which is not returning
     }
+
+    // yields the bit width of an Idx type, or throws a formatted exception (via mim::throwf) if it is not statically known
+    // (the throwing counterpart of the std::optional-returning Idx::size2bitwidth)
+    auto w = Idx::expect_bitwidth(def, "an index type of known width");
 }
 ```
 
@@ -382,8 +403,9 @@ void foo(const Def* def) {
 
 You can match [axioms](@ref mim::Axm) via
 
-- [`mim::Axm::isa`](@ref mim::Axm::isa), which behaves like a checked `dynamic_cast` and returns [a wrapped](@ref mim::Axm::isa) `nullptr`-like value on failure, or
-- [`mim::Axm::as`](@ref mim::Axm::as), which behaves like a checked `static_cast` and asserts in `Debug` builds if the match fails.
+- [`mim::Axm::isa`](@ref mim::Axm::isa), which behaves like a checked `dynamic_cast` and returns [a wrapped](@ref mim::Axm::isa) `nullptr`-like value on failure,
+- [`mim::Axm::as`](@ref mim::Axm::as), which behaves like a checked `static_cast` and asserts in `Debug` builds if the match fails, or
+- [`mim::Axm::expect`](@ref mim::Axm::expect), which - like the other `expect` helpers - throws a formatted exception (via mim::throwf) instead of asserting: `Axm::expect<mem::Ptr>(def, "a %mem.Ptr")`.
 
 The result is a `mim::Axm::isa<Id, D>`, which wraps a `const D*`.
 Here, `Id` is the enum corresponding to the [matched axiom tag](@ref anatomy), and `D` is usually an [`App`](@ref mim::App), because most [axioms](@ref mim::Axm) inhabit a [function type](@ref mim::Pi).
@@ -427,6 +449,9 @@ void foo(const Def* def) {
 
     // def must match mem::load - otherwise, this asserts
     auto load = Axm::as<mem::load>(def);
+
+    // def must match mem::load - otherwise, this throws a formatted exception (via mim::throwf)
+    auto ld = Axm::expect<mem::load>(def, "a %mem.load");
 }
 ```
 

--- a/include/mim/axm.h
+++ b/include/mim/axm.h
@@ -130,6 +130,15 @@ public:
     template<class Id, u8 Curry=0> static auto as(       const Def* def) { return isa<Id, Curry, false>(    def); }
     template<class Id, u8 Curry=0> static auto as(Id id, const Def* def) { return isa<Id, Curry, false>(id, def); }
     // clang-format on
+
+    /// Like Axm::as but - instead of merely asserting in `Debug` builds - throws a formatted mim::error when @p def
+    /// is not the expected axm.
+    /// @p fmt / @p args describe what was expected; a plain string works, as does a format string plus arguments.
+    template<class Id, u8 Curry = 0, class... Args>
+    static auto expect(const Def* def, std::format_string<Args...> fmt, Args&&... args) {
+        if (auto res = isa<Id, Curry>(def)) return res;
+        fe::throwf("expected {}, but got '{}'", std::format(fmt, std::forward<Args>(args)...), def);
+    }
     ///@}
 
     static constexpr u8 Trip_End    = u8(-1);

--- a/include/mim/def.h
+++ b/include/mim/def.h
@@ -540,6 +540,15 @@ public:
         else
             return const_cast<Def*>(this)->template as<T>();
     }
+
+    /// Like Def::as_mut but - instead of merely asserting in `Debug` builds - throws via fe::throwf when the cast
+    /// fails; the mutable counterpart of fe::RuntimeCast::expect (which Def inherits for the general case).
+    /// @p fmt / @p args describe what was expected; a plain string works, as does a format string plus arguments.
+    template<class T = Def, class... Args>
+    T* expect_mut(std::format_string<Args...> fmt, Args&&... args) const {
+        if (auto res = isa_mut<T>()) return res;
+        fe::throwf("expected {}, but got '{}'", std::format(fmt, std::forward<Args>(args)...), this);
+    }
     ///@}
 
     /// @name Dbg Getters
@@ -875,6 +884,12 @@ public:
     static T as(const Def* def) {
         return def->as<Lit>()->get<T>();
     }
+    /// Like Lit::as but throws a formatted mim::error instead of merely asserting in `Debug`; see Def::expect.
+    template<class T = nat_t, class... Args>
+    static T expect(const Def* def, std::format_string<Args...> fmt, Args&&... args) {
+        if (auto res = isa<T>(def)) return *res;
+        fe::throwf("expected {}, but got '{}'", std::format(fmt, std::forward<Args>(args)...), def);
+    }
     ///@}
 
     static constexpr auto Node      = mim::Node::Lit;
@@ -936,6 +951,16 @@ public:
     static constexpr nat_t size2bitwidth(nat_t n) { return n == 0 ? 64 : std::bit_width(n - 1_n); }
     // clang-format on
     static std::optional<nat_t> size2bitwidth(const Def* size);
+
+    /// Yields the bit width of the `Idx` @p type or throws a formatted mim::error - instead of yielding
+    /// std::nullopt or dereferencing an unchecked std::optional - if @p type is not an `Idx` of statically known
+    /// size; see Def::expect.
+    template<class... Args>
+    static nat_t expect_bitwidth(const Def* type, std::format_string<Args...> fmt, Args&&... args) {
+        if (auto size = isa(type))
+            if (auto w = size2bitwidth(size)) return *w;
+        fe::throwf("expected {}, but got '{}'", std::format(fmt, std::forward<Args>(args)...), type);
+    }
     ///@}
 
     static constexpr auto Node      = mim::Node::Idx;

--- a/include/mim/phase.h
+++ b/include/mim/phase.h
@@ -61,9 +61,9 @@ public:
                 }
                 return phase;
             } else
-                error("phase `{}` not found", axm->sym());
+                fe::throwf("phase `{}` not found", axm->sym());
         else
-            error("unsupported callee for a phase: `{}`", p_def);
+            fe::throwf("unsupported callee for a phase: `{}`", p_def);
     }
 
     template<class A, class P>

--- a/include/mim/plug/ll/ll.h
+++ b/include/mim/plug/ll/ll.h
@@ -123,10 +123,6 @@ public:
     void finalize();
 
     virtual inline std::optional<std::string> isa_targetspecific_intrinsic(BB&, const Def*) { return std::nullopt; }
-    inline std::string as_targetspecific_intrinsic(BB& bb, const Def* def) {
-        if (auto res = isa_targetspecific_intrinsic(bb, def)) return res.value();
-        error("target-specific intrinsic detected but not handled in LLVM backend: {} : {}", def, def->type());
-    }
 
     template<class... Args>
     void declare(std::format_string<Args...> s, Args&&... args) {
@@ -140,6 +136,23 @@ protected:
     std::string id(const Def*, bool force_bb = false) const;
     virtual std::string convert(const Def*, bool simd = true);
     std::string convert_ret_pi(const Pi*);
+
+    /// Registers @p arg as an incoming phi value for @p phi in @p callee, coming from predecessor @p pred.
+    void emit_phi(Lam* callee, const Def* phi, std::string arg, Lam* pred) {
+        lam2bb_[callee].phis[phi].emplace_back(std::move(arg), id(pred, true));
+        locals_[phi] = id(phi);
+    }
+
+    /// Wires all non-`%mem.M` arguments of @p app into @p callee's phis, coming from predecessor @p pred.
+    void emit_phi_args(Lam* callee, const App* app, Lam* pred) {
+        size_t n = callee->num_tvars();
+        for (size_t i = 0; i != n; ++i)
+            if (auto arg = emit_unsafe(app->arg(n, i)); !arg.empty()) {
+                auto phi = callee->var(n, i);
+                if (Axm::isa<mem::M>(phi->type())) continue;
+                emit_phi(callee, phi, std::move(arg), pred);
+            }
+    }
 
     absl::btree_set<std::string> decls_;
     std::ostringstream type_decls_;
@@ -163,7 +176,7 @@ inline static std::optional<std::pair<nat_t, const Def*>> is_simd(const Def* typ
     return {};
 }
 
-inline static std::optional<std::pair<nat_t, const Def*>> is_simd_aggregate(const std::vector<const Def*> types) {
+inline static std::optional<std::pair<nat_t, const Def*>> is_simd_aggregate(Defs types) {
     if (std::ranges::all_of(types, [&](auto i) { return i == types[0]; })) {
         if (types[0]->isa<Nat>() || Idx::isa(types[0]) || Axm::isa<math::F>(types[0]))
             return std::pair{types.size(), types[0]};
@@ -386,8 +399,8 @@ inline void Emitter::emit_epilogue(Lam* lam) {
     auto app = lam->body()->as<App>();
     auto& bb = lam2bb_[lam];
     if (app->callee() == root()->ret_var()) { // return
-        std::vector<std::string> values;
-        std::vector<const Def*> types;
+        Vector<std::string> values;
+        DefVec types;
         for (auto arg : app->args()) {
             if (auto val = emit_unsafe(arg); !val.empty()) {
                 values.emplace_back(val);
@@ -440,24 +453,11 @@ inline void Emitter::emit_epilogue(Lam* lam) {
         }
 
     } else if (auto dispatch = Dispatch(app)) {
-        for (auto callee : dispatch.tuple()->projs([](const Def* def) { return def->isa_mut<Lam>(); })) {
-            size_t n = callee->num_tvars();
-            if (n == 1 && is_simd(callee->var(0)->type())) {
-                auto phi = callee->var(0);
-                auto arg = emit(app->arg(n, 0));
-                lam2bb_[callee].phis[phi].emplace_back(arg, id(lam, true));
-                locals_[phi] = id(phi);
-            } else {
-                for (size_t i = 0; i != n; ++i) {
-                    if (auto arg = emit_unsafe(app->arg(n, i)); !arg.empty()) {
-                        auto phi = callee->var(n, i);
-                        if (Axm::isa<mem::M>(phi->type())) continue;
-                        lam2bb_[callee].phis[phi].emplace_back(arg, id(lam, true));
-                        locals_[phi] = id(phi);
-                    }
-                }
-            }
-        }
+        for (auto callee : dispatch.tuple()->projs([](const Def* def) { return def->isa_mut<Lam>(); }))
+            if (size_t n = callee->num_tvars(); n == 1 && is_simd(callee->var(0)->type()))
+                emit_phi(callee, callee->var(0), emit(app->arg(n, 0)), lam);
+            else
+                emit_phi_args(callee, app, lam);
 
         auto v_index = emit(dispatch.index());
         size_t n     = dispatch.num_targets();
@@ -476,27 +476,17 @@ inline void Emitter::emit_epilogue(Lam* lam) {
         return bb.tail("ret ; bottom: unreachable");
     } else if (auto callee = Lam::isa_mut_basicblock(app->callee())) { // ordinary jump
 
-        auto common_src = find_common_simd_src(app);
-        if (common_src) {
+        if (auto common_src = find_common_simd_src(app)) {
             auto v_src      = emit(common_src);
             auto callee_var = callee->var();
             if (simd_phi_.find(callee) == simd_phi_.end()) simd_phi_[callee] = callee_var;
             auto key = simd_phi_[callee];
-            lam2bb_[callee].phis[key].emplace_back(v_src, id(lam, true));
-            locals_[key] = id(key);
+            emit_phi(callee, key, v_src, lam);
             for (auto var : callee->vars())
                 locals_[var] = id(key);
             locals_[callee_var] = id(key);
         } else {
-            size_t n = callee->num_tvars();
-            for (size_t i = 0; i != n; ++i) {
-                if (auto arg = emit_unsafe(app->arg(n, i)); !arg.empty()) {
-                    auto phi = callee->var(n, i);
-                    if (Axm::isa<mem::M>(phi->type())) continue;
-                    lam2bb_[callee].phis[phi].emplace_back(arg, id(lam, true));
-                    locals_[phi] = id(phi);
-                }
-            }
+            emit_phi_args(callee, app, lam);
         }
         return bb.tail("br label {}", id(callee));
 
@@ -520,13 +510,12 @@ inline void Emitter::emit_epilogue(Lam* lam) {
         auto ptr     = ret_lam->var(2, 1);
         auto v_ptr   = "%" + app->unique_name() + ".slot";
         std::print(bb.body().emplace_back(), "{} = alloca {}", v_ptr, convert(pointee, false));
-        lam2bb_[ret_lam].phis[ptr].emplace_back(v_ptr, id(lam, true));
-        locals_[ptr] = id(ptr);
+        emit_phi(ret_lam, ptr, v_ptr, lam);
         return bb.tail("br label {}", id(ret_lam));
     } else if (Pi::isa_returning(app->callee_type())) { // function call
         auto v_callee = emit(app->callee());
 
-        std::vector<std::string> args;
+        Vector<std::string> args;
         auto app_args = app->args();
         for (auto arg : app_args.view().rsubspan(1))
             if (auto v_arg = emit_unsafe(arg); !v_arg.empty()) args.emplace_back(convert(arg->type()) + " " + v_arg);
@@ -538,17 +527,10 @@ inline void Emitter::emit_epilogue(Lam* lam) {
             return bb.tail("unreachable");
         }
 
-        auto ret_lam    = app->args().back()->as_mut<Lam>();
-        size_t num_vars = ret_lam->num_vars();
-        size_t n        = 0;
-        DefVec values(num_vars);
-        DefVec types(num_vars);
-        for (auto var : ret_lam->vars()) {
-            if (Axm::isa<mem::M>(var->type())) continue;
-            values[n] = var;
-            types[n]  = var->type();
-            ++n;
-        }
+        auto ret_lam = app->args().back()->as_mut<Lam>();
+        size_t n     = 0;
+        for (auto var : ret_lam->vars())
+            if (!Axm::isa<mem::M>(var->type())) ++n;
 
         if (n == 0) {
             bb.tail("call void {}({})", v_callee, fe::Join(args));
@@ -556,9 +538,7 @@ inline void Emitter::emit_epilogue(Lam* lam) {
             auto name  = "%" + app->unique_name() + "ret";
             auto t_ret = convert_ret_pi(ret_lam->type());
             bb.tail("{} = call {} {}({})", name, t_ret, v_callee, fe::Join(args));
-            auto phi = ret_lam->var();
-            lam2bb_[ret_lam].phis[phi].emplace_back(name, id(lam, true));
-            locals_[phi] = id(phi);
+            emit_phi(ret_lam, ret_lam->var(), name, lam);
         }
 
         return bb.tail("br label {}", id(ret_lam));

--- a/include/mim/plug/ll/ll.h
+++ b/include/mim/plug/ll/ll.h
@@ -45,7 +45,7 @@ inline const char* math_suffix(const Def* type) {
             case 64: return "";
         }
     }
-    error("unsupported floating point type '{}'", type);
+    fe::throwf("unsupported floating point type '{}'", type);
 }
 
 inline const char* llvm_suffix(const Def* type) {
@@ -56,7 +56,7 @@ inline const char* llvm_suffix(const Def* type) {
             case 64: return ".f64";
         }
     }
-    error("unsupported floating point type '{}'", type);
+    fe::throwf("unsupported floating point type '{}'", type);
 }
 
 // [%mem.M 0, T] => T

--- a/include/mim/plug/ll/ll.h
+++ b/include/mim/plug/ll/ll.h
@@ -8,16 +8,14 @@
 
 #include <absl/container/btree_set.h>
 
+#include <mim/driver.h>
+
+#include <mim/be/emitter.h>
+
 #include <mim/plug/clos/clos.h>
 #include <mim/plug/math/math.h>
 #include <mim/plug/mem/mem.h>
 #include <mim/plug/vec/vec.h>
-
-#include "mim/driver.h"
-
-#include "mim/be/emitter.h"
-
-#include "mim/plug/math/autogen.h"
 
 // Lessons learned:
 // * **Always** follow all ops - even if you actually want to ignore one.
@@ -179,6 +177,16 @@ protected:
                 if (Axm::isa<mem::M>(phi->type())) continue;
                 emit_phi(callee, phi, std::move(arg), pred);
             }
+    }
+
+    /// Emits the storage backing a `%mem.slot` of type @p pointee and yields the pointer value.
+    /// The generic backend allocates on the stack; targets may override (e.g. a global in a specific address space).
+    /// Kept inline on purpose so `Emitter` retains no vtable key function (else its vtable would live in a single
+    /// module and break derived backends loaded from a separate plugin).
+    virtual std::string emit_slot(BB& bb, const App* app, const Def* pointee, const Def* /*addr_space*/) {
+        auto v_ptr = "%" + app->unique_name() + ".slot";
+        std::print(bb.body().emplace_back(), "{} = alloca {}", v_ptr, convert(pointee, false));
+        return v_ptr;
     }
 
     absl::btree_set<std::string> decls_;

--- a/include/mim/plug/ll/ll.h
+++ b/include/mim/plug/ll/ll.h
@@ -2,10 +2,8 @@
 
 #include <deque>
 #include <format>
-#include <iomanip>
 #include <optional>
 #include <ostream>
-#include <ranges>
 #include <string>
 
 #include <absl/container/btree_set.h>
@@ -15,9 +13,10 @@
 #include <mim/plug/mem/mem.h>
 #include <mim/plug/vec/vec.h>
 
+#include "mim/driver.h"
+
 #include "mim/be/emitter.h"
 
-#include "mim/plug/core/core.h"
 #include "mim/plug/math/autogen.h"
 
 // Lessons learned:
@@ -37,11 +36,8 @@ class World;
 
 namespace plug::ll {
 
-namespace clos = mim::plug::clos;
-namespace core = mim::plug::core;
 namespace math = mim::plug::math;
 namespace mem  = mim::plug::mem;
-namespace vec  = mim::plug::vec;
 
 namespace detail {
 inline const char* math_suffix(const Def* type) {
@@ -107,20 +103,47 @@ struct BB {
     std::array<std::deque<std::ostringstream>, 3> parts;
 };
 
+class Emitter;
+
+/// The heavy, target-independent emitter methods are compiled once into `libmim_ll` (see ll.cpp).
+/// `libmim_ll_nvptx` reaches them through these `extern "C"` shims instead of recompiling the bodies;
+/// Emitter caches the pointers via `GET_FUN_PTR` in its constructor.
+extern "C" {
+MIM_EXPORT void mim_ll_convert(Emitter&, const Def*, bool simd, std::string& res);
+MIM_EXPORT void mim_ll_finalize(Emitter&);
+MIM_EXPORT void mim_ll_emit_epilogue(Emitter&, Lam*);
+MIM_EXPORT void mim_ll_emit_bb(Emitter&, BB&, const Def*, std::string& res);
+}
+
 class Emitter : public mim::Emitter<std::string, std::string, BB, Emitter> {
 public:
     using Super = mim::Emitter<std::string, std::string, BB, Emitter>;
 
     Emitter(World& world, std::string name, std::ostream& ostream)
-        : Super(world, name, ostream) {}
+        : Super(world, name, ostream) {
+        auto& driver = world.driver();
+        // Ensure libmim_ll is loaded so the shims below resolve (e.g. when a derived backend like
+        // ll_nvptx uses us). Loading merely registers %ll.emit; it does not run it.
+        if (auto ll = driver.sym("ll"); !driver.is_loaded(ll)) driver.load(ll);
+        convert_       = driver.GET_FUN_PTR("ll", mim_ll_convert);
+        finalize_      = driver.GET_FUN_PTR("ll", mim_ll_finalize);
+        emit_epilogue_ = driver.GET_FUN_PTR("ll", mim_ll_emit_epilogue);
+        emit_bb_       = driver.GET_FUN_PTR("ll", mim_ll_emit_bb);
+    }
 
     bool is_valid(std::string_view s) { return !s.empty(); }
     void start() override;
     void emit_imported(Lam*);
-    virtual void emit_epilogue(Lam*);
-    std::string emit_bb(BB&, const Def*);
     virtual std::string prepare();
-    void finalize();
+
+    // Thin forwarders into `libmim_ll`; the real bodies (`*_impl`) live in ll.cpp.
+    virtual void emit_epilogue(Lam* lam) { emit_epilogue_(*this, lam); }
+    void finalize() { finalize_(*this); }
+    std::string emit_bb(BB& bb, const Def* def) {
+        std::string res;
+        emit_bb_(*this, bb, def, res);
+        return res;
+    }
 
     virtual inline std::optional<std::string> isa_targetspecific_intrinsic(BB&, const Def*) { return std::nullopt; }
 
@@ -134,7 +157,11 @@ public:
 
 protected:
     std::string id(const Def*, bool force_bb = false) const;
-    virtual std::string convert(const Def*, bool simd = true);
+    virtual std::string convert(const Def* type, bool simd = true) {
+        std::string res;
+        convert_(*this, type, simd, res);
+        return res;
+    }
     std::string convert_ret_pi(const Pi*);
 
     /// Registers @p arg as an incoming phi value for @p phi in @p callee, coming from predecessor @p pred.
@@ -160,6 +187,23 @@ protected:
     std::ostringstream func_decls_;
     std::ostringstream func_impls_;
     LamMap<const Def*> simd_phi_;
+
+private:
+    // Real implementations; defined in ll.cpp and exported via the `mim_ll_*` shims above.
+    std::string convert_impl(const Def*, bool simd);
+    void finalize_impl();
+    void emit_epilogue_impl(Lam*);
+    std::string emit_bb_impl(BB&, const Def*);
+
+    decltype(&mim_ll_convert) convert_             = nullptr;
+    decltype(&mim_ll_finalize) finalize_           = nullptr;
+    decltype(&mim_ll_emit_epilogue) emit_epilogue_ = nullptr;
+    decltype(&mim_ll_emit_bb) emit_bb_             = nullptr;
+
+    friend void mim_ll_convert(Emitter&, const Def*, bool, std::string&);
+    friend void mim_ll_finalize(Emitter&);
+    friend void mim_ll_emit_epilogue(Emitter&, Lam*);
+    friend void mim_ll_emit_bb(Emitter&, BB&, const Def*, std::string&);
 };
 
 /*
@@ -221,78 +265,6 @@ inline std::string Emitter::id(const Def* def, bool force_bb /*= false*/) const 
     return std::string("%") + def->unique_name();
 }
 
-inline std::string Emitter::convert(const Def* type, bool simd) {
-    if (auto i = types_.find(type); i != types_.end()) return i->second;
-
-    assert(!Axm::isa<mem::M>(type));
-    std::ostringstream s;
-    std::string name;
-
-    if (type->isa<Nat>()) {
-        return types_[type] = "i64";
-    } else if (auto size = Idx::isa(type)) {
-        return types_[type] = "i" + std::to_string(*Idx::size2bitwidth(size));
-    } else if (auto w = math::isa_f(type)) {
-        switch (*w) {
-            case 16: return types_[type] = "half";
-            case 32: return types_[type] = "float";
-            case 64: return types_[type] = "double";
-            default: fe::unreachable();
-        }
-    } else if (auto ptr = Axm::isa<mem::Ptr>(type)) {
-        auto [pointee, addr_space] = ptr->args<2>();
-        std::print(s, "{} addrspace({})*", convert(pointee, false), addr_space);
-    } else if (auto arr = type->isa<Arr>()) {
-        if (auto se = is_simd(arr); se && simd) {
-            auto [size, elem] = *se;
-            std::print(s, "<{} x {}>", size, convert(elem));
-        } else {
-            u64 size = 0;
-            if (auto arity = Lit::isa(arr->arity())) size = *arity;
-            std::print(s, "[{} x {}]", size, convert(arr->body(), false));
-        }
-    } else if (auto pi = type->isa<Pi>()) {
-        assert(Pi::isa_returning(pi) && "should never have to convert type of BB");
-        std::print(s, "{} (", convert_ret_pi(pi->ret_pi()));
-
-        if (auto t = detail::isa_mem_sigma_2(pi->dom()))
-            s << convert(t);
-        else {
-            auto doms = pi->doms();
-            for (auto sep = ""; auto dom : doms.view().rsubspan(1)) {
-                if (Axm::isa<mem::M>(dom)) continue;
-                s << sep << convert(dom);
-                sep = ", ";
-            }
-        }
-        s << ")*";
-    } else if (auto t = detail::isa_mem_sigma_2(type)) {
-        return convert(t);
-    } else if (auto sigma = type->isa<Sigma>()) {
-        if (sigma->isa_mut()) {
-            name          = id(sigma);
-            types_[sigma] = name;
-            std::print(s, "{} = type", name);
-        }
-
-        std::print(s, "{{");
-        for (auto sep = ""; auto t : sigma->ops()) {
-            if (Axm::isa<mem::M>(t)) continue;
-            s << sep << convert(t);
-            sep = ", ";
-        }
-        std::print(s, "}}");
-    } else {
-        fe::unreachable();
-    }
-
-    if (name.empty()) return types_[type] = s.str();
-
-    assert(!s.str().empty());
-    type_decls_ << s.str() << '\n';
-    return types_[type] = name;
-}
-
 inline std::string Emitter::convert_ret_pi(const Pi* pi) {
     auto dom = mem::strip_mem_ty(pi->dom());
     if (dom == world().sigma()) return "void";
@@ -347,957 +319,6 @@ inline std::string Emitter::prepare() {
 
     std::print(func_impls_, ") {{\n");
     return root()->unique_name();
-}
-
-inline void Emitter::finalize() {
-    for (auto& [lam, bb] : lam2bb_) {
-        for (const auto& [phi, args] : bb.phis) {
-            std::print(bb.head().emplace_back(), "{} = phi {} ", id(phi), convert(phi->type()));
-            for (auto sep = ""; const auto& [arg, pred] : args) {
-                std::print(bb.head().back(), "{}[ {}, {} ]", sep, arg, pred);
-                sep = ", ";
-            }
-        }
-    }
-
-    for (auto mut : Scheduler::schedule(nest())) {
-        if (auto lam = mut->isa_mut<Lam>()) {
-            assert(lam2bb_.contains(lam));
-            auto& bb = lam2bb_[lam];
-            std::print(func_impls_, "{}:\n", lam->unique_name());
-
-            ++tab;
-            for (const auto& part : bb.parts)
-                for (const auto& line : part)
-                    std::println(func_impls_, "{}{}", tab, line.str());
-            --tab;
-            func_impls_ << std::endl;
-        }
-    }
-
-    std::print(func_impls_, "}}\n\n");
-}
-
-/*
- Block           type              return
-BB:
-          Cn [M, a, A]         →    2 phi
-          Cn «2;A»             →    2 phi
-          Cn [M, «2;A»]        →    1 phi
-Ret:
-          Cn[M,A,A]            →    1 phi
-          Cn «2;A»             →    1 phi
-          Cn[M, «2;A»]         →    1 phi
-
-Fun:
-          Cn[A, A, Cn R]       →    2 args + ret
-          Cn[«2; A», Cn R]     →    1 args + ret
-          Cn[M, A, A, Cn R]    →    2 args + ret
-          Cn[M, «2; A», Cn R]  →    1 args + ret
-*/
-inline void Emitter::emit_epilogue(Lam* lam) {
-    auto app = lam->body()->as<App>();
-    auto& bb = lam2bb_[lam];
-    if (app->callee() == root()->ret_var()) { // return
-        Vector<std::string> values;
-        DefVec types;
-        for (auto arg : app->args()) {
-            if (auto val = emit_unsafe(arg); !val.empty()) {
-                values.emplace_back(val);
-                types.emplace_back(arg->type());
-            }
-        }
-
-        switch (values.size()) {
-            case 0: return bb.tail("ret void");
-            case 1:
-                return Axm::isa<mem::M>(types[0]) ? bb.tail("ret void")
-                                                  : bb.tail("ret {} {}", convert(types[0]), values[0]);
-            default: {
-                std::string type;
-                std::string prev;
-
-                if (auto se = is_simd_aggregate(types)) {
-                    auto common_src = find_common_simd_src(app);
-                    if (common_src) {
-                        auto v_src = emit(common_src);
-                        auto t     = convert(common_src->type());
-                        return bb.tail("ret {} {}", t, v_src);
-                    }
-                    auto [size, elem] = *se;
-                    auto val_t        = convert(elem);
-
-                    type = std::format("<{} x {}>", size, val_t);
-                    for (auto val : values) {
-                        if (prev.empty())
-                            prev = "<";
-                        else
-                            prev += ", ";
-                        prev += std::format("{} {}", val_t, val);
-                    }
-                    prev += ">";
-                } else {
-                    prev = "undef";
-                    type = convert(world().sigma(types));
-                    for (size_t i = 0, n = values.size(); i != n; ++i) {
-                        if (auto mem = Axm::isa<mem::M>(types[i])) continue;
-                        auto v_elem = values[i];
-                        auto t_elem = convert(types[i]);
-                        auto namei  = "%ret_val." + std::to_string(i);
-                        bb.tail("{} = insertvalue {} {}, {} {}, {}", namei, type, prev, t_elem, v_elem, i);
-                        prev = namei;
-                    }
-                }
-                bb.tail("ret {} {}", type, prev);
-            }
-        }
-
-    } else if (auto dispatch = Dispatch(app)) {
-        for (auto callee : dispatch.tuple()->projs([](const Def* def) { return def->isa_mut<Lam>(); }))
-            if (size_t n = callee->num_tvars(); n == 1 && is_simd(callee->var(0)->type()))
-                emit_phi(callee, callee->var(0), emit(app->arg(n, 0)), lam);
-            else
-                emit_phi_args(callee, app, lam);
-
-        auto v_index = emit(dispatch.index());
-        size_t n     = dispatch.num_targets();
-        auto bbs     = absl::FixedArray<std::string>(n);
-        for (size_t i = 0; i != n; ++i)
-            bbs[i] = emit(dispatch.target(i));
-
-        if (auto branch = Branch(app)) return bb.tail("br i1 {}, label {}, label {}", v_index, bbs[1], bbs[0]);
-
-        auto t_index = convert(dispatch.index()->type());
-        bb.tail("switch {} {}, label {} [ ", t_index, v_index, bbs[0]);
-        for (size_t i = 1; i != n; ++i)
-            std::print(bb.tail().back(), "{} {}, label {} ", t_index, std::to_string(i), bbs[i]);
-        std::print(bb.tail().back(), "]");
-    } else if (app->callee()->isa<Bot>()) {
-        return bb.tail("ret ; bottom: unreachable");
-    } else if (auto callee = Lam::isa_mut_basicblock(app->callee())) { // ordinary jump
-
-        if (auto common_src = find_common_simd_src(app)) {
-            auto v_src      = emit(common_src);
-            auto callee_var = callee->var();
-            if (simd_phi_.find(callee) == simd_phi_.end()) simd_phi_[callee] = callee_var;
-            auto key = simd_phi_[callee];
-            emit_phi(callee, key, v_src, lam);
-            for (auto var : callee->vars())
-                locals_[var] = id(key);
-            locals_[callee_var] = id(key);
-        } else {
-            emit_phi_args(callee, app, lam);
-        }
-        return bb.tail("br label {}", id(callee));
-
-    } else if (auto longjmp = Axm::isa<clos::longjmp>(app)) {
-        declare("void @longjmp(i8*, i32) noreturn");
-
-        auto [mem, jbuf, tag] = app->args<3>();
-        emit_unsafe(mem);
-        auto v_jb  = emit(jbuf);
-        auto v_tag = emit(tag);
-        bb.tail("call void @longjmp(i8* {}, i32 {})", v_jb, v_tag);
-        return bb.tail("unreachable");
-    } else if (auto mslot = Axm::isa<mem::mslot>(app)) {
-        // Continuation-based stack slot: allocate and jump to the passed continuation with the fresh pointer.
-        auto [Ta, rest]            = mslot->uncurry_args<2>();
-        auto [pointee, addr_space] = Ta->projs<2>();
-        auto [msize, ret]          = rest->projs<2>();
-        emit_unsafe(msize->proj(0)); // mem
-        // TODO array with size
-        auto ret_lam = ret->as_mut<Lam>();
-        auto ptr     = ret_lam->var(2, 1);
-        auto v_ptr   = "%" + app->unique_name() + ".slot";
-        std::print(bb.body().emplace_back(), "{} = alloca {}", v_ptr, convert(pointee, false));
-        emit_phi(ret_lam, ptr, v_ptr, lam);
-        return bb.tail("br label {}", id(ret_lam));
-    } else if (Pi::isa_returning(app->callee_type())) { // function call
-        auto v_callee = emit(app->callee());
-
-        Vector<std::string> args;
-        auto app_args = app->args();
-        for (auto arg : app_args.view().rsubspan(1))
-            if (auto v_arg = emit_unsafe(arg); !v_arg.empty()) args.emplace_back(convert(arg->type()) + " " + v_arg);
-
-        if (app->args().back()->isa<Bot>()) {
-            // TODO: Perhaps it'd be better to simply η-wrap this prior to the BE...
-            assert(convert_ret_pi(app->callee_type()->ret_pi()) == "void");
-            bb.tail("call void {}({})", v_callee, fe::Join(args));
-            return bb.tail("unreachable");
-        }
-
-        auto ret_lam = app->args().back()->as_mut<Lam>();
-        size_t n     = 0;
-        for (auto var : ret_lam->vars())
-            if (!Axm::isa<mem::M>(var->type())) ++n;
-
-        if (n == 0) {
-            bb.tail("call void {}({})", v_callee, fe::Join(args));
-        } else {
-            auto name  = "%" + app->unique_name() + "ret";
-            auto t_ret = convert_ret_pi(ret_lam->type());
-            bb.tail("{} = call {} {}({})", name, t_ret, v_callee, fe::Join(args));
-            emit_phi(ret_lam, ret_lam->var(), name, lam);
-        }
-
-        return bb.tail("br label {}", id(ret_lam));
-    }
-}
-
-inline std::string Emitter::emit_bb(BB& bb, const Def* def) {
-    if (auto lam = def->isa<Lam>()) return id(lam);
-
-    auto name = id(def);
-    std::string op;
-
-    auto emit_tuple = [&](const Def* tuple) {
-        if (detail::isa_mem_sigma_2(tuple->type())) {
-            emit_unsafe(tuple->proj(2, 0));
-            return emit(tuple->proj(2, 1));
-        }
-
-        if (tuple->is_closed()) {
-            bool is_array   = tuple->type()->isa<Arr>();
-            auto simd_array = convert(tuple->type()).front() == '<'; // needed to respect pointer context
-            std::string s;
-            s += simd_array ? "<" : is_array ? "[" : "{";
-            auto sep = "";
-            for (size_t i = 0, n = tuple->num_projs(); i != n; ++i) {
-                auto e = tuple->proj(n, i);
-                if (auto v_elem = emit_unsafe(e); !v_elem.empty()) {
-                    auto t_elem = convert(e->type());
-                    s += sep + t_elem + " " + v_elem;
-                    sep = ", ";
-                }
-            }
-
-            return s += simd_array ? ">" : is_array ? "]" : "}";
-        }
-
-        std::string prev = "undef";
-        auto t           = convert(tuple->type());
-        for (size_t src = 0, dst = 0, n = tuple->num_projs(); src != n; ++src) {
-            auto e = tuple->proj(n, src);
-            if (auto elem = emit_unsafe(e); !elem.empty()) {
-                auto elem_t = convert(e->type());
-                // TODO: check dst vs src
-                auto namei = name + "." + std::to_string(dst);
-                if (t.front() == '<') // not using is_simd to respect the pointer context (Pointer Pointee case)
-                    prev = bb.assign(namei, "insertelement {} {}, {} {}, {} {}", t, prev, elem_t, elem, elem_t, dst);
-                else
-                    prev = bb.assign(namei, "insertvalue {} {}, {} {}, {}", t, prev, elem_t, elem, dst);
-                dst++;
-            }
-        }
-        return prev;
-    };
-
-    if (def->isa<Var>()) {
-        if (is_simd(def->type())) return id(def);
-        auto ts = def->type()->projs();
-        if (std::ranges::any_of(ts, [](auto t) { return Axm::isa<mem::M>(t); })) return {};
-        return emit_tuple(def);
-    }
-
-    auto emit_gep_index = [&](const Def* index) {
-        auto v_i = emit(index);
-        auto t_i = convert(index->type());
-
-        if (auto size = Idx::isa(index->type())) {
-            if (auto w = Idx::size2bitwidth(size); w && *w < 64) {
-                v_i = bb.assign(name + ".zext",
-                                "zext {} {} to i{} ; add one more bit for gep index as it is treated as signed value",
-                                t_i, v_i, *w + 1);
-                t_i = "i" + std::to_string(*w + 1);
-            }
-        }
-
-        return std::pair(v_i, t_i);
-    };
-
-    if (auto lit = def->isa<Lit>()) {
-        if (lit->type()->isa<Nat>() || Idx::isa(lit->type())) {
-            return std::to_string(lit->get());
-        } else if (auto w = math::isa_f(lit->type())) {
-            std::stringstream s;
-            u64 hex;
-
-            switch (*w) {
-                case 16:
-                    s << "0xH" << std::setfill('0') << std::setw(4) << std::right << std::hex << lit->get<u16>();
-                    return s.str();
-                case 32: {
-                    hex = std::bit_cast<u64>(f64(lit->get<f32>()));
-                    break;
-                }
-                case 64: hex = lit->get<u64>(); break;
-                default: fe::unreachable();
-            }
-
-            s << "0x" << std::setfill('0') << std::setw(16) << std::right << std::hex << hex;
-            return s.str();
-        }
-        fe::unreachable();
-    } else if (def->isa<Bot>()) {
-        return "undef";
-    } else if (auto top = def->isa<Top>()) {
-        if (Axm::isa<mem::M>(top->type())) return {};
-        // bail out to error below
-    } else if (auto tuple = def->isa<Tuple>()) {
-        return emit_tuple(tuple);
-    } else if (auto pack = def->isa<Pack>()) {
-        if (auto lit = Lit::isa(pack->body()); lit && *lit == 0) return "zeroinitializer";
-        return emit_tuple(pack);
-    } else if (auto sel = Select(def)) {
-        auto t                = convert(sel.extract()->type());
-        auto [elem_a, elem_b] = sel.pair()->projs<2>([&](auto e) { return emit_unsafe(e); });
-        auto cond_t           = convert(sel.cond()->type());
-        auto cond             = emit(sel.cond());
-        return bb.assign(name, "select {} {}, {} {}, {} {}", cond_t, cond, t, elem_b, t, elem_a);
-    } else if (auto extract = def->isa<Extract>()) {
-        auto tuple = extract->tuple();
-        auto index = extract->index();
-        auto v_tup = emit_unsafe(tuple);
-        if (is_simd(tuple->type()) && !Axm::isa<mem::M>(tuple->type())) return v_tup;
-
-        // this exact location is important: after emitting the tuple -> ordering of mem ops
-        // before emitting the index, as it might be a weird value for mem vars.
-        if (Axm::isa<mem::M>(extract->type())) return {};
-        if (auto sigma = extract->type()->isa<Sigma>(); sigma && sigma->num_ops() == 0) return {};
-
-        auto t_tup = convert(tuple->type());
-        if (auto li = Lit::isa(index)) {
-            if (detail::isa_mem_sigma_2(tuple->type())) return v_tup;
-            // Adjust index: convert() drops %mem.M elements from sigmas,
-            // so subtract the number of mem elements preceding the index.
-            auto v_i = *li;
-            if (auto sigma = tuple->type()->isa<Sigma>())
-                for (u64 i = 0; i < *li; ++i)
-                    if (Axm::isa<mem::M>(sigma->op(i))) --v_i;
-
-            return bb.assign(name, "extractvalue {} {}, {}", t_tup, v_tup, v_i);
-        }
-
-        auto t_elem     = convert(extract->type());
-        auto [v_i, t_i] = emit_gep_index(index);
-
-        std::print(lam2bb_[root()].body().emplace_front(),
-                   "{}.alloca = alloca {} ; copy to alloca to emulate extract with store + gep + load", name, t_tup);
-        std::print(bb.body().emplace_back(), "store {} {}, {}* {}.alloca", t_tup, v_tup, t_tup, name);
-        std::print(bb.body().emplace_back(), "{}.gep = getelementptr inbounds {}, {}* {}.alloca, i64 0, {} {}", name,
-                   t_tup, t_tup, name, t_i, v_i);
-        return bb.assign(name, "load {}, {}* {}.gep", t_elem, t_elem, name);
-    } else if (auto insert = def->isa<Insert>()) {
-        assert(!Axm::isa<mem::M>(insert->tuple()->proj(0)->type()));
-        auto t_tup = convert(insert->tuple()->type());
-        auto t_val = convert(insert->value()->type());
-        auto v_tup = emit(insert->tuple());
-        auto v_val = emit(insert->value());
-        if (auto idx = Lit::isa(insert->index())) {
-            auto v_idx = emit(insert->index());
-            if (is_simd(insert->tuple()->type()))
-
-                return bb.assign(name, "insertelement {} {}, {} {}, i32 {}", t_tup, v_tup, t_val, v_val, v_idx);
-            else
-
-                return bb.assign(name, " insertvalue {} {}, {} {}, {}", t_tup, v_tup, t_val, v_val, v_idx);
-        } else {
-            if (is_simd(insert->tuple()->type())) {
-                auto v_i = emit(insert->index());
-                auto t_i = convert(insert->index()->type());
-                if (t_i != "i32") {
-                    auto w_src = *Idx::size2bitwidth(Idx::isa(insert->index()->type()));
-                    v_i        = bb.assign(name + ".idx", "{} {} {} to i32", w_src < 32 ? "zext" : "trunc", t_i, v_i);
-                }
-                return bb.assign(name, "insertelement {} {}, {} {}, i32 {}", t_tup, v_tup, t_val, v_val, v_i);
-            }
-            auto t_elem     = convert(insert->value()->type());
-            auto [v_i, t_i] = emit_gep_index(insert->index());
-            std::print(lam2bb_[root()].body().emplace_front(),
-                       "{}.alloca = alloca {} ; copy to alloca to emulate insert with store + gep + load", name, t_tup);
-            std::print(bb.body().emplace_back(), "store {} {}, {}* {}.alloca", t_tup, v_tup, t_tup, name);
-            std::print(bb.body().emplace_back(), "{}.gep = getelementptr inbounds {}, {}* {}.alloca, i64 0, {} {}",
-                       name, t_tup, t_tup, name, t_i, v_i);
-            std::print(bb.body().emplace_back(), "store {} {}, {}* {}.gep", t_val, v_val, t_val, name);
-            return bb.assign(name, "load {}, {}* {}.alloca", t_tup, t_tup, name);
-        }
-    } else if (auto global = def->isa<Global>()) {
-        auto v_init                = emit(global->init());
-        auto [pointee, addr_space] = Axm::as<mem::Ptr>(global->type())->args<2>();
-        std::print(vars_decls_, "{} = global {} {}\n", name, convert(pointee), v_init);
-        return globals_[global] = name;
-    } else if (auto nat = Axm::isa<core::nat>(def)) {
-        auto [a, b] = nat->args<2>([this](auto def) { return emit(def); });
-
-        switch (nat.id()) {
-            case core::nat::add: return bb.assign(name, "add nsw nuw i64 {}, {}", a, b);
-            case core::nat::sub: {
-                // nat subtraction saturates at 0: cap result when b > a
-                auto ugt = bb.assign(name + ".ugt", "icmp ugt i64 {}, {}", b, a);
-                auto raw = bb.assign(name + ".raw", "sub i64 {}, {}", a, b);
-                return bb.assign(name, "select i1 {}, i64 0, i64 {}", ugt, raw);
-            }
-            case core::nat::mul: return bb.assign(name, "mul nsw nuw i64 {}, {}", a, b);
-            // %core.nat.div/mod define division/modulo by zero as `a / 0 = 0` and `a % 0 = a`.
-            // replace a zero divisor by 1 to keep udiv/urem well-defined, then select the
-            // defined result for the zero case (0 for div, a for mod).
-            case core::nat::div: {
-                auto bz   = bb.assign(name + ".bz", "icmp eq i64 {}, 0", b);
-                auto bsaf = bb.assign(name + ".bsafe", "select i1 {}, i64 1, i64 {}", bz, b);
-                auto q    = bb.assign(name + ".q", "udiv i64 {}, {}", a, bsaf);
-                return bb.assign(name, "select i1 {}, i64 0, i64 {}", bz, q);
-            }
-            case core::nat::mod: {
-                auto bz   = bb.assign(name + ".bz", "icmp eq i64 {}, 0", b);
-                auto bsaf = bb.assign(name + ".bsafe", "select i1 {}, i64 1, i64 {}", bz, b);
-                auto r    = bb.assign(name + ".r", "urem i64 {}, {}", a, bsaf);
-                return bb.assign(name, "select i1 {}, i64 {}, i64 {}", bz, a, r);
-            }
-        }
-    } else if (auto ncmp = Axm::isa<core::ncmp>(def)) {
-        auto [a, b] = ncmp->args<2>([this](auto def) { return emit(def); });
-        op          = "icmp ";
-
-        switch (ncmp.id()) {
-                // clang-format off
-            case core::ncmp::e:  op += "eq" ; break;
-            case core::ncmp::ne: op += "ne" ; break;
-            case core::ncmp::g:  op += "ugt"; break;
-            case core::ncmp::ge: op += "uge"; break;
-            case core::ncmp::l:  op += "ult"; break;
-            case core::ncmp::le: op += "ule"; break;
-            // clang-format on
-            default: fe::unreachable();
-        }
-
-        return bb.assign(name, "{} i64 {}, {}", op, a, b);
-    } else if (auto idx = Axm::isa<core::idx>(def)) {
-        auto x = emit(idx->arg());
-        auto s = *Idx::size2bitwidth(Idx::isa(idx->type()));
-        auto t = convert(idx->type());
-        if (s < 64) return bb.assign(name, "trunc i64 {} to {}", x, t);
-        return x;
-    } else if (auto bit1 = Axm::isa<core::bit1>(def)) {
-        assert(bit1.id() == core::bit1::neg);
-        auto x = emit(bit1->arg());
-        auto t = convert(bit1->type());
-        return bb.assign(name, "xor {} -1, {}", t, x);
-    } else if (auto bit2 = Axm::isa<core::bit2>(def)) {
-        auto [a, b] = bit2->args<2>([this](auto def) { return emit(def); });
-        auto t      = convert(bit2->type());
-
-        auto neg = [&](std::string_view x) { return bb.assign(name + ".neg", "xor {} -1, {}", t, x); };
-
-        switch (bit2.id()) {
-                // clang-format off
-            case core::bit2::and_: return bb.assign(name, "and {} {}, {}", t, a, b);
-            case core::bit2:: or_: return bb.assign(name, "or  {} {}, {}", t, a, b);
-            case core::bit2::xor_: return bb.assign(name, "xor {} {}, {}", t, a, b);
-            case core::bit2::nand: return neg(bb.assign(name, "and {} {}, {}", t, a, b));
-            case core::bit2:: nor: return neg(bb.assign(name, "or  {} {}, {}", t, a, b));
-            case core::bit2::nxor: return neg(bb.assign(name, "xor {} {}, {}", t, a, b));
-            case core::bit2:: iff: return bb.assign(name, "and {} {}, {}", t, neg(a), b);
-            case core::bit2::niff: return bb.assign(name, "or  {} {}, {}", t, neg(a), b);
-            // clang-format on
-            default: fe::unreachable();
-        }
-    } else if (auto shr = Axm::isa<core::shr>(def)) {
-        auto [a, b] = shr->args<2>([this](auto def) { return emit(def); });
-        auto t      = convert(shr->type());
-
-        switch (shr.id()) {
-            case core::shr::a: op = "ashr"; break;
-            case core::shr::l: op = "lshr"; break;
-        }
-
-        return bb.assign(name, "{} {} {}, {}", op, t, a, b);
-    } else if (auto wrap = Axm::isa<core::wrap>(def)) {
-        auto [mode, ab] = wrap->uncurry_args<2>();
-        auto [a, b]     = ab->projs<2>([this](auto def) { return emit(def); });
-        auto t          = convert(wrap->type());
-        auto lmode      = static_cast<core::Mode>(Lit::as(mode));
-
-        switch (wrap.id()) {
-            case core::wrap::add: op = "add"; break;
-            case core::wrap::sub: op = "sub"; break;
-            case core::wrap::mul: op = "mul"; break;
-            case core::wrap::shl: op = "shl"; break;
-        }
-
-        if (fe::has_flag(lmode, core::Mode::nuw)) op += " nuw";
-        if (fe::has_flag(lmode, core::Mode::nsw)) op += " nsw";
-
-        return bb.assign(name, "{} {} {}, {}", op, t, a, b);
-    } else if (auto div = Axm::isa<core::div>(def)) {
-        auto [m, xy] = div->args<2>();
-        auto [x, y]  = xy->projs<2>();
-        auto t       = convert(x->type());
-        emit_unsafe(m);
-        auto a = emit(x);
-        auto b = emit(y);
-
-        switch (div.id()) {
-            case core::div::sdiv: op = "sdiv"; break;
-            case core::div::udiv: op = "udiv"; break;
-            case core::div::srem: op = "srem"; break;
-            case core::div::urem: op = "urem"; break;
-        }
-
-        return bb.assign(name, "{} {} {}, {}", op, t, a, b);
-    } else if (auto icmp = Axm::isa<core::icmp>(def)) {
-        auto [a, b] = icmp->args<2>([this](auto def) { return emit(def); });
-        auto t      = convert(icmp->arg(0)->type());
-        op          = "icmp ";
-
-        switch (icmp.id()) {
-                // clang-format off
-            case core::icmp::e:   op += "eq" ; break;
-            case core::icmp::ne:  op += "ne" ; break;
-            case core::icmp::sg:  op += "sgt"; break;
-            case core::icmp::sge: op += "sge"; break;
-            case core::icmp::sl:  op += "slt"; break;
-            case core::icmp::sle: op += "sle"; break;
-            case core::icmp::ug:  op += "ugt"; break;
-            case core::icmp::uge: op += "uge"; break;
-            case core::icmp::ul:  op += "ult"; break;
-            case core::icmp::ule: op += "ule"; break;
-            // clang-format on
-            default: fe::unreachable();
-        }
-
-        return bb.assign(name, "{} {} {}, {}", op, t, a, b);
-    } else if (auto extr = Axm::isa<core::extrema>(def)) {
-        auto [x, y]   = extr->args<2>();
-        auto t        = convert(x->type());
-        auto a        = emit(x);
-        auto b        = emit(y);
-        std::string f = "llvm.";
-        switch (extr.id()) {
-            case core::extrema::Sm: f += "smin."; break;
-            case core::extrema::SM: f += "smax."; break;
-            case core::extrema::sm: f += "umin."; break;
-            case core::extrema::sM: f += "umax."; break;
-        }
-        f += t;
-        declare("{} @{}({}, {})", t, f, t, t);
-        return bb.assign(name, "tail call {} @{}({} {}, {} {})", t, f, t, a, t, b);
-    } else if (auto abs = Axm::isa<core::abs>(def)) {
-        auto [m, x]   = abs->args<2>();
-        auto t        = convert(x->type());
-        auto a        = emit(x);
-        std::string f = "llvm.abs." + t;
-        declare("{} @{}({}, {})", t, f, t, "i1");
-        return bb.assign(name, "tail call {} @{}({} {}, {} {})", t, f, t, a, "i1", "1");
-    } else if (auto conv = Axm::isa<core::conv>(def)) {
-        auto v_src = emit(conv->arg());
-        auto t_src = convert(conv->arg()->type());
-        auto t_dst = convert(conv->type());
-
-        nat_t w_src = *Idx::size2bitwidth(Idx::isa(conv->arg()->type()));
-        nat_t w_dst = *Idx::size2bitwidth(Idx::isa(conv->type()));
-
-        if (w_src == w_dst) return v_src;
-
-        switch (conv.id()) {
-            case core::conv::s: op = w_src < w_dst ? "sext" : "trunc"; break;
-            case core::conv::u: op = w_src < w_dst ? "zext" : "trunc"; break;
-        }
-
-        return bb.assign(name, "{} {} {} to {}", op, t_src, v_src, t_dst);
-    } else if (auto bitcast = Axm::isa<core::bitcast>(def)) {
-        auto dst_type_ptr = Axm::isa<mem::Ptr>(bitcast->type());
-        auto src_type_ptr = Axm::isa<mem::Ptr>(bitcast->arg()->type());
-        auto v_src        = emit(bitcast->arg());
-        auto t_src        = convert(bitcast->arg()->type());
-        auto t_dst        = convert(bitcast->type());
-
-        if (auto lit = Lit::isa(bitcast->arg()); lit && *lit == 0) return "zeroinitializer";
-        // clang-format off
-        if (src_type_ptr && dst_type_ptr) return bb.assign(name,  "bitcast {} {} to {}", t_src, v_src, t_dst);
-        if (src_type_ptr)                 return bb.assign(name, "ptrtoint {} {} to {}", t_src, v_src, t_dst);
-        if (dst_type_ptr)                 return bb.assign(name, "inttoptr {} {} to {}", t_src, v_src, t_dst);
-        // clang-format on
-
-        auto size2width = [&](const Def* type) {
-            if (type->isa<Nat>()) return 64_n;
-            if (auto size = Idx::isa(type)) return *Idx::size2bitwidth(size);
-            return 0_n;
-        };
-
-        auto src_size = size2width(bitcast->arg()->type());
-        auto dst_size = size2width(bitcast->type());
-
-        op = "bitcast";
-        if (src_size && dst_size) {
-            if (src_size == dst_size) return v_src;
-            op = (src_size < dst_size) ? "zext" : "trunc";
-        }
-        return bb.assign(name, "{} {} {} to {}", op, t_src, v_src, t_dst);
-    } else if (auto lea = Axm::isa<mem::lea>(def)) {
-        auto [ptr, i]  = lea->args<2>();
-        auto pointee   = Axm::as<mem::Ptr>(ptr->type())->arg(0);
-        auto v_ptr     = emit(ptr);
-        auto t_pointee = convert(pointee);
-        auto t_ptr     = convert(ptr->type());
-        if (pointee->isa<Sigma>())
-            return bb.assign(name, "getelementptr inbounds {}, {} {}, i64 0, i32 {}", t_pointee, t_ptr, v_ptr,
-                             Lit::as(i));
-
-        assert(pointee->isa<Arr>());
-        auto [v_i, t_i] = emit_gep_index(i);
-
-        return bb.assign(name, "getelementptr inbounds {}, {} {}, i64 0, {} {}", t_pointee, t_ptr, v_ptr, t_i, v_i);
-    } else if (auto malloc = Axm::isa<mem::malloc>(def)) {
-        auto address_space = malloc->decurry()->arg(1);
-        if (Lit::as(address_space) != 0)
-            if (auto target_specific = isa_targetspecific_intrinsic(bb, def)) return target_specific.value();
-
-        declare("i8* @malloc(i64)");
-
-        emit_unsafe(malloc->arg(0));
-        auto size           = emit(malloc->arg(1));
-        auto ptr_t          = convert(Axm::as<mem::Ptr>(def->proj(1)->type()));
-        auto i8ptr          = bb.assign(name + "i8", "call i8* @malloc(i64 {})", size);
-        std::string i8ptr_t = "i8*";
-        if (Lit::as(address_space) != 0) {
-            i8ptr_t = std::format("i8 addrspace({})*", address_space);
-            i8ptr   = bb.assign(name + "i8conv", "addrspacecast i8* {} to {}", i8ptr, i8ptr_t);
-        }
-        return bb.assign(name, "bitcast {} {} to {}", i8ptr_t, i8ptr, ptr_t);
-    } else if (auto free = Axm::isa<mem::free>(def)) {
-        auto address_space = free->decurry()->arg(1);
-        if (Lit::as(address_space) != 0)
-            if (auto target_specific = isa_targetspecific_intrinsic(bb, def)) return {};
-
-        declare("void @free(i8*)");
-        emit_unsafe(free->arg(0));
-        auto ptr   = emit(free->arg(1));
-        auto ptr_t = convert(Axm::as<mem::Ptr>(free->arg(1)->type()));
-
-        auto i8ptr = bb.assign(name + "i8", "bitcast {} {} to i8 addrspace({})*", ptr_t, ptr, address_space);
-        if (Lit::as(address_space) != 0)
-            i8ptr = bb.assign(name + "i8conv", "addrspacecast i8 addrspace({})* {} to i8*", address_space, i8ptr);
-        bb.tail("call void @free(i8* {})", i8ptr);
-        return {};
-    } else if (auto load = Axm::isa<mem::load>(def)) {
-        emit_unsafe(load->arg(0));
-        auto v_ptr     = emit(load->arg(1));
-        auto t_ptr     = convert(load->arg(1)->type());
-        auto t_pointee = convert(Axm::as<mem::Ptr>(load->arg(1)->type())->arg(0), false);
-        return bb.assign(name, "load {}, {} {}", t_pointee, t_ptr, v_ptr);
-    } else if (auto store = Axm::isa<mem::store>(def)) {
-        emit_unsafe(store->arg(0));
-        auto v_ptr = emit(store->arg(1));
-        auto v_val = emit(store->arg(2));
-        auto t_ptr = convert(store->arg(1)->type());
-        auto t_val = convert(store->arg(2)->type(), false);
-        std::print(bb.body().emplace_back(), "store {} {}, {} {}", t_val, v_val, t_ptr, v_ptr);
-        return {};
-    } else if (auto q = Axm::isa<clos::alloc_jmpbuf>(def)) {
-        declare("i64 @jmpbuf_size()");
-
-        emit_unsafe(q->arg());
-        auto size = name + ".size";
-        bb.assign(size, "call i64 @jmpbuf_size()");
-        return bb.assign(name, "alloca i8, i64 {}", size);
-    } else if (auto setjmp = Axm::isa<clos::setjmp>(def)) {
-        declare("i32 @_setjmp(i8*) returns_twice");
-
-        auto [mem, jmpbuf] = setjmp->arg()->projs<2>();
-        emit_unsafe(mem);
-        auto v_jb = emit(jmpbuf);
-        return bb.assign(name, "call i32 @_setjmp(i8* {})", v_jb);
-    } else if (auto arith = Axm::isa<math::arith>(def)) {
-        auto [mode, ab] = arith->uncurry_args<2>();
-        auto [a, b]     = ab->projs<2>([this](auto def) { return emit(def); });
-        auto t          = convert(arith->type());
-        auto lmode      = static_cast<math::Mode>(Lit::as(mode));
-
-        switch (arith.id()) {
-            case math::arith::add: op = "fadd"; break;
-            case math::arith::sub: op = "fsub"; break;
-            case math::arith::mul: op = "fmul"; break;
-            case math::arith::div: op = "fdiv"; break;
-            case math::arith::rem: op = "frem"; break;
-        }
-
-        if (lmode == math::Mode::fast)
-            op += " fast";
-        else {
-            // clang-format off
-            if (fe::has_flag(lmode, math::Mode::nnan    )) op += " nnan";
-            if (fe::has_flag(lmode, math::Mode::ninf    )) op += " ninf";
-            if (fe::has_flag(lmode, math::Mode::nsz     )) op += " nsz";
-            if (fe::has_flag(lmode, math::Mode::arcp    )) op += " arcp";
-            if (fe::has_flag(lmode, math::Mode::contract)) op += " contract";
-            if (fe::has_flag(lmode, math::Mode::afn     )) op += " afn";
-            if (fe::has_flag(lmode, math::Mode::reassoc )) op += " reassoc";
-            // clang-format on
-        }
-
-        return bb.assign(name, "{} {} {}, {}", op, t, a, b);
-    } else if (auto tri = Axm::isa<math::tri>(def)) {
-        auto a = emit(tri->arg());
-        auto t = convert(tri->type());
-
-        std::string f;
-
-        if (tri.id() == math::tri::sin) {
-            f = std::string("llvm.sin") + detail::llvm_suffix(tri->type());
-        } else if (tri.id() == math::tri::cos) {
-            f = std::string("llvm.cos") + detail::llvm_suffix(tri->type());
-        } else {
-            if (tri.sub() & sub_t(math::tri::a)) f += "a";
-
-            switch (math::tri((fe::to_underlying(tri.id()) & 0x3) | Annex::base<math::tri>())) {
-                case math::tri::sin: f += "sin"; break;
-                case math::tri::cos: f += "cos"; break;
-                case math::tri::tan: f += "tan"; break;
-                case math::tri::ahFF: error("this axm is supposed to be unused");
-                default: fe::unreachable();
-            }
-
-            if (tri.sub() & sub_t(math::tri::h)) f += "h";
-            f += detail::math_suffix(tri->type());
-        }
-
-        declare("{} @{}({})", t, f, t);
-        return bb.assign(name, "tail call {} @{}({} {})", t, f, t, a);
-    } else if (auto extrema = Axm::isa<math::extrema>(def)) {
-        auto [a, b]   = extrema->args<2>([this](auto def) { return emit(def); });
-        auto t        = convert(extrema->type());
-        std::string f = "llvm.";
-        switch (extrema.id()) {
-            case math::extrema::fmin: f += "minnum"; break;
-            case math::extrema::fmax: f += "maxnum"; break;
-            case math::extrema::ieee754min: f += "minimum"; break;
-            case math::extrema::ieee754max: f += "maximum"; break;
-        }
-        f += detail::llvm_suffix(extrema->type());
-
-        declare("{} @{}({}, {})", t, f, t, t);
-        return bb.assign(name, "tail call {} @{}({} {}, {} {})", t, f, t, a, t, b);
-    } else if (auto pow = Axm::isa<math::pow>(def)) {
-        auto [a, b]   = pow->args<2>([this](auto def) { return emit(def); });
-        auto t        = convert(pow->type());
-        std::string f = "llvm.pow";
-        f += detail::llvm_suffix(pow->type());
-        declare("{} @{}({}, {})", t, f, t, t);
-        return bb.assign(name, "tail call {} @{}({} {}, {} {})", t, f, t, a, t, b);
-    } else if (auto rt = Axm::isa<math::rt>(def)) {
-        auto a = emit(rt->arg());
-        auto t = convert(rt->type());
-        std::string f;
-        if (rt.id() == math::rt::sq)
-            f = std::string("llvm.sqrt") + detail::llvm_suffix(rt->type());
-        else
-            f = std::string("cbrt") += detail::math_suffix(rt->type());
-        declare("{} @{}({})", t, f, t);
-        return bb.assign(name, "tail call {} @{}({} {})", t, f, t, a);
-    } else if (auto exp = Axm::isa<math::exp>(def)) {
-        auto a        = emit(exp->arg());
-        auto t        = convert(exp->type());
-        std::string f = "llvm.";
-        f += (exp.sub() & sub_t(math::exp::log)) ? "log" : "exp";
-        f += (exp.sub() & sub_t(math::exp::bin)) ? "2" : (exp.sub() & sub_t(math::exp::dec)) ? "10" : "";
-        f += detail::llvm_suffix(exp->type());
-        // TODO doesn't work for exp10"
-        declare("{} @{}({})", t, f, t);
-        return bb.assign(name, "tail call {} @{}({} {})", t, f, t, a);
-    } else if (auto er = Axm::isa<math::er>(def)) {
-        auto a = emit(er->arg());
-        auto t = convert(er->type());
-        auto f = er.id() == math::er::f ? std::string("erf") : std::string("erfc");
-        f += detail::math_suffix(er->type());
-        declare("{} @{}({})", t, f, t);
-        return bb.assign(name, "tail call {} @{}({} {})", t, f, t, a);
-    } else if (auto gamma = Axm::isa<math::gamma>(def)) {
-        auto a        = emit(gamma->arg());
-        auto t        = convert(gamma->type());
-        std::string f = gamma.id() == math::gamma::t ? "tgamma" : "lgamma";
-        f += detail::math_suffix(gamma->type());
-        declare("{} @{}({})", t, f, t);
-        return bb.assign(name, "tail call {} @{}({} {})", t, f, t, a);
-    } else if (auto cmp = Axm::isa<math::cmp>(def)) {
-        auto [a, b] = cmp->args<2>([this](auto def) { return emit(def); });
-        auto t      = convert(cmp->arg(0)->type());
-        op          = "fcmp ";
-
-        switch (cmp.id()) {
-                // clang-format off
-            case math::cmp::  e: op += "oeq"; break;
-            case math::cmp::  l: op += "olt"; break;
-            case math::cmp:: le: op += "ole"; break;
-            case math::cmp::  g: op += "ogt"; break;
-            case math::cmp:: ge: op += "oge"; break;
-            case math::cmp:: ne: op += "one"; break;
-            case math::cmp::  o: op += "ord"; break;
-            case math::cmp::  u: op += "uno"; break;
-            case math::cmp:: ue: op += "ueq"; break;
-            case math::cmp:: ul: op += "ult"; break;
-            case math::cmp::ule: op += "ule"; break;
-            case math::cmp:: ug: op += "ugt"; break;
-            case math::cmp::uge: op += "uge"; break;
-            case math::cmp::une: op += "une"; break;
-            // clang-format on
-            default: fe::unreachable();
-        }
-
-        return bb.assign(name, "{} {} {}, {}", op, t, a, b);
-    } else if (auto is_finite = Axm::isa<math::is_finite>(def)) {
-        // https://llvm.org/docs/LangRef.html#llvm-is-fpclass-intrinsic
-        // declare i1 @llvm.is.fpclass(<fptype> <op>, i32 <test>)
-        auto a  = emit(is_finite->arg());
-        auto at = convert(is_finite->arg()->type());
-        auto t  = convert(is_finite->type());
-
-        auto s = detail::llvm_suffix(is_finite->arg()->type());
-        auto f = "llvm.is.fpclass";
-        declare("{} @{}{}({}, i32)", t, f, s, at);
-        return bb.assign(name, "tail call {} @{}{}({} {}, i32 504)", t, f, s, at, a);
-    } else if (auto conv = Axm::isa<math::conv>(def)) {
-        auto v_src = emit(conv->arg());
-        auto t_src = convert(conv->arg()->type());
-        auto t_dst = convert(conv->type());
-
-        auto s_src = math::isa_f(conv->arg()->type());
-        auto s_dst = math::isa_f(conv->type());
-
-        switch (conv.id()) {
-            case math::conv::f2f: op = s_src < s_dst ? "fpext" : "fptrunc"; break;
-            case math::conv::s2f: op = "sitofp"; break;
-            case math::conv::u2f: op = "uitofp"; break;
-            case math::conv::f2s: op = "fptosi"; break;
-            case math::conv::f2u: op = "fptoui"; break;
-        }
-
-        return bb.assign(name, "{} {} {} to {}", op, t_src, v_src, t_dst);
-    } else if (auto abs = Axm::isa<math::abs>(def)) {
-        auto a        = emit(abs->arg());
-        auto t        = convert(abs->type());
-        std::string f = "llvm.fabs";
-        f += detail::llvm_suffix(abs->type());
-        declare("{} @{}({})", t, f, t);
-        return bb.assign(name, "tail call {} @{}({} {})", t, f, t, a);
-    } else if (auto round = Axm::isa<math::round>(def)) {
-        auto a        = emit(round->arg());
-        auto t        = convert(round->type());
-        std::string f = "llvm.";
-        switch (round.id()) {
-            case math::round::f: f += "floor"; break;
-            case math::round::c: f += "ceil"; break;
-            case math::round::r: f += "round"; break;
-            case math::round::t: f += "trunc"; break;
-        }
-        f += detail::llvm_suffix(round->type());
-        declare("{} @{}({})", t, f, t);
-        return bb.assign(name, "tail call {} @{}({} {})", t, f, t, a);
-    } else if (auto zip = Axm::isa<vec::zip>(def)) {
-        auto ni_n   = zip->decurry()->decurry()->decurry()->arg();
-        auto nat_ni = *Lit::isa(ni_n->proj(2, 0));
-        auto f      = zip->decurry()->arg();
-        auto inputs = zip->arg();
-        auto t_in   = convert(inputs->proj(nat_ni, 0)->type());
-        auto t_out  = convert(def->type()); // <n x T>
-
-        std::string op;
-        std::string prev;
-
-        if (auto nat_op = Axm::isa<core::nat, 1>(f)) {
-            switch (nat_op.id()) {
-                case core::nat::add: op = "add nuw nsw"; break;
-                case core::nat::sub: {
-                    // nat subtraction saturates at 0: cap per-lane when v2 > v1
-                    auto v1     = emit(inputs->proj(nat_ni, 0));
-                    auto v2     = emit(inputs->proj(nat_ni, 1));
-                    auto ugt    = bb.assign(name + ".ugt", "icmp ugt {} {}, {}", t_in, v2, v1);
-                    auto raw    = bb.assign(name + ".raw", "sub {} {}, {}", t_in, v1, v2);
-                    return prev = bb.assign(name, "select <{} x i1> {}, {} zeroinitializer, {} {}", nat_ni, ugt, t_out,
-                                            t_out, raw);
-                }
-                case core::nat::mul: op = "mul nuw nsw"; break;
-                case core::nat::div: op = "udiv"; break;
-                case core::nat::mod: op = "urem"; break;
-            }
-        } else if (auto arith_op = Axm::isa<math::arith, 1>(f)) {
-            auto lmode = static_cast<math::Mode>(Lit::as(f->as<App>()->arg()));
-            switch (arith_op.id()) {
-                case math::arith::add: op = "fadd"; break;
-                case math::arith::sub: op = "fsub"; break;
-                case math::arith::mul: op = "fmul"; break;
-                case math::arith::div: op = "fdiv"; break;
-                case math::arith::rem: op = "frem"; break;
-            }
-
-            if (lmode == math::Mode::fast)
-                op += " fast";
-            else {
-                if (fe::has_flag(lmode, math::Mode::nnan)) op += " nnan";
-                if (fe::has_flag(lmode, math::Mode::ninf)) op += " ninf";
-                if (fe::has_flag(lmode, math::Mode::nsz)) op += " nsz";
-                if (fe::has_flag(lmode, math::Mode::arcp)) op += " arcp";
-                if (fe::has_flag(lmode, math::Mode::contract)) op += " contract";
-                if (fe::has_flag(lmode, math::Mode::afn)) op += " afn";
-                if (fe::has_flag(lmode, math::Mode::reassoc)) op += " reassoc";
-            }
-        } else if (auto ncmp_op = Axm::isa<core::ncmp, 1>(f)) {
-            op = "icmp ";
-            switch (ncmp_op.id()) {
-                case core::ncmp::e: op += "eq"; break;
-                case core::ncmp::ne: op += "ne"; break;
-                case core::ncmp::g: op += "ugt"; break;
-                case core::ncmp::ge: op += "uge"; break;
-                case core::ncmp::l: op += "ult"; break;
-                case core::ncmp::le: op += "ule"; break;
-                default: fe::unreachable();
-            }
-        } else if (auto icmp_op = Axm::isa<core::icmp, 1>(f)) {
-            op = "icmp ";
-            switch (icmp_op.id()) {
-                case core::icmp::e: op += "eq"; break;
-                case core::icmp::ne: op += "ne"; break;
-                case core::icmp::sg: op += "sgt"; break;
-                case core::icmp::sge: op += "sge"; break;
-                case core::icmp::sl: op += "slt"; break;
-                case core::icmp::sle: op += "sle"; break;
-                case core::icmp::ug: op += "ugt"; break;
-                case core::icmp::uge: op += "uge"; break;
-                case core::icmp::ul: op += "ult"; break;
-                case core::icmp::ule: op += "ule"; break;
-                default: fe::unreachable();
-            }
-        } else if (auto mcmp_op = Axm::isa<math::cmp, 1>(f)) {
-            op = "fcmp ";
-            switch (mcmp_op.id()) {
-                case math::cmp::e: op += "oeq"; break;
-                case math::cmp::l: op += "olt"; break;
-                case math::cmp::le: op += "ole"; break;
-                case math::cmp::g: op += "ogt"; break;
-                case math::cmp::ge: op += "oge"; break;
-                case math::cmp::ne: op += "one"; break;
-                case math::cmp::o: op += "ord"; break;
-                case math::cmp::u: op += "uno"; break;
-                case math::cmp::ue: op += "ueq"; break;
-                case math::cmp::ul: op += "ult"; break;
-                case math::cmp::ule: op += "ule"; break;
-                case math::cmp::ug: op += "ugt"; break;
-                case math::cmp::uge: op += "uge"; break;
-                case math::cmp::une: op += "une"; break;
-                default: fe::unreachable();
-            }
-        } else {
-            error("unhandled vec.zip operation: {}", f);
-        }
-
-        auto v1 = emit(inputs->proj(nat_ni, 0));
-        auto v2 = emit(inputs->proj(nat_ni, 1));
-        prev    = bb.assign(name, "{} {} {}, {}", op, t_in, v1, v2);
-        return prev;
-    } else if (auto res = isa_targetspecific_intrinsic(bb, def)) {
-        return res.value();
-    }
-    error("unhandled def in LLVM backend: {} : {}", def, def->type());
 }
 
 } // namespace plug::ll

--- a/include/mim/plug/ll_nvptx/phase/ll_nvptx.h
+++ b/include/mim/plug/ll_nvptx/phase/ll_nvptx.h
@@ -3,7 +3,7 @@
 #include <optional>
 #include <string>
 
-#include "mim/plug/ll/ll.h"
+#include <mim/plug/ll/ll.h>
 
 namespace mim {
 

--- a/include/mim/util/dbg.h
+++ b/include/mim/util/dbg.h
@@ -2,21 +2,15 @@
 
 #include <algorithm>
 #include <sstream>
-#include <stdexcept>
 
 #include <absl/container/flat_hash_map.h>
 #include <absl/container/flat_hash_set.h>
+#include <fe/assert.h>
 #include <fe/loc.h>
 #include <fe/sym.h>
 #include <fe/term.h>
 
 namespace mim {
-
-/// Wraps `std::format` to throw `T` with a formatted message.
-template<class T = std::logic_error, class... Args>
-[[noreturn]] void error(std::format_string<Args...> fmt, Args&&... args) {
-    throw T("error: " + std::format(fmt, std::forward<Args>(args)...));
-}
 
 using fe::Loc;
 using fe::Pos;

--- a/include/mim/util/sys.h
+++ b/include/mim/util/sys.h
@@ -2,7 +2,9 @@
 
 #include <filesystem>
 #include <optional>
+#include <stdexcept>
 #include <string>
+#include <string_view>
 
 #ifdef _WIN32
 #    define MIM_WHICH "where"
@@ -26,8 +28,21 @@ std::string exec(std::string cmd);
 
 std::string find_cmd(std::string);
 
+/// Thrown by sys::require_cmd when a command cannot be located on the system.
+class CmdNotFound : public std::logic_error {
+public:
+    CmdNotFound(const std::string& s)
+        : std::logic_error(s) {}
+};
+
+/// Locates @p name on the system or throws CmdNotFound.
+std::string require_cmd(std::string_view name);
+
 /// Wraps `std::system` and makes the return value usable.
 int system(std::string);
+
+/// Runs @p cmd via sys::system and throws if it exits with a non-zero status.
+void require_run(const std::string& cmd);
 
 /// Wraps sys::system and puts `.exe` at the back (Windows) and `./` at the front (otherwise) of @p cmd.
 int run(std::string cmd, std::string args = {});

--- a/lit/mem/seo/basic_phi.mim
+++ b/lit/mem/seo/basic_phi.mim
@@ -1,4 +1,4 @@
-// RUN: %mim %s -o - | %FileCheck %s
+// RUN: %mim %s -p opt -o - | %FileCheck %s
 plugin mem;
 
 cfun dont_know[mem: %mem.M 0]: [%mem.M 0, Bool];

--- a/lit/mem/seo/overwrite_on_one_branch.mim
+++ b/lit/mem/seo/overwrite_on_one_branch.mim
@@ -1,4 +1,4 @@
-// RUN: %mim %s -o - | %FileCheck %s
+// RUN: %mim %s -p opt -o - | %FileCheck %s
 plugin mem;
 
 cfun dont_know[mem: %mem.M 0]: [%mem.M 0, Bool];

--- a/lit/tensor/conv_dynamic.mim
+++ b/lit/tensor/conv_dynamic.mim
@@ -1,4 +1,4 @@
-// RUN: %mim %s -o - | %FileCheck %s
+// RUN: %mim %s -p opt -o - | %FileCheck %s
 
 // %tensor.conv with fully *dynamic* (symbolic) shapes: the input/weight extents are function parameters, so
 // `conv_shape` cannot fold to a literal output shape. Instead it stays as a %core.nat.div/sub/mul/add expression

--- a/py/src/mim/plug/regex.py
+++ b/py/src/mim/plug/regex.py
@@ -21,8 +21,6 @@ class RegBuilder(MimPlugin):
         self.lvl = log_level
         self.world = self.driver.world()
         if initialize:
-            # `ll` must be loaded in the same pass as `compile` so that `ll.mim`'s
-            # `import compile` resolves `%compile.Phase`; its emit phase produces `<libname>.ll`.
             driver.load_plugins(["regex", "ll"])
 
     def _char_lit(self, lit) -> Def:

--- a/src/mim/cli/main.cpp
+++ b/src/mim/cli/main.cpp
@@ -220,7 +220,7 @@ int main(int argc, char** argv) {
                     }
                 }
             } else {
-                error("couldn't read file '{}'", input);
+                fe::throwf("couldn't read file '{}'", input);
             }
         } catch (const Error& e) { // e.loc.path doesn't exist anymore in outer scope so catch Error here
             std::cerr << e;

--- a/src/mim/driver.cpp
+++ b/src/mim/driver.cpp
@@ -96,7 +96,7 @@ void Driver::load(Sym name) {
         }
     }
 
-    if (!handle) error("cannot open plugin '{}'", name);
+    if (!handle) fe::throwf("cannot open plugin '{}'", name);
 
     if (auto get_info = reinterpret_cast<decltype(&mim_get_plugin)>(dl::get(handle.get(), "mim_get_plugin"))) {
         auto plugin = get_info();
@@ -115,7 +115,7 @@ void Driver::load(Sym name) {
         if (auto reg = plugin.register_phases)      reg(phases_);
         // clang-format on
     } else {
-        error("mim/plugin has no 'mim_get_plugin()'");
+        fe::throwf("mim/plugin has no 'mim_get_plugin()'");
     }
 }
 

--- a/src/mim/phase.cpp
+++ b/src/mim/phase.cpp
@@ -129,7 +129,7 @@ void RWPhase::start() {
     auto max_iters = driver().flags().max_fp_iters;
     bool todo      = true;
     for (uint32_t i = 0; todo; ++i) {
-        if (i >= max_iters) error("phase `{}` did not reach a fixed point after {} iterations", name(), max_iters);
+        if (i >= max_iters) fe::throwf("phase `{}` did not reach a fixed point after {} iterations", name(), max_iters);
         VLOG("iteration: {}", i);
         todo = analyze();
     }
@@ -201,7 +201,8 @@ void PhaseMan::start() {
     auto any_stale = [&stale]() { return std::ranges::any_of(stale, [](bool b) { return b; }); };
 
     for (uint32_t iter = 0; any_stale(); ++iter) {
-        if (iter >= max_iters) error("phase `{}` did not reach a fixed point after {} iterations", name(), max_iters);
+        if (iter >= max_iters)
+            fe::throwf("phase `{}` did not reach a fixed point after {} iterations", name(), max_iters);
         if (fixed_point()) VLOG("🔄 fixed-point iteration: {}", iter);
 
         bool todo = false;

--- a/src/mim/phase/optimize.cpp
+++ b/src/mim/phase/optimize.cpp
@@ -46,7 +46,7 @@ void optimize(World& world) {
             if (auto app = body->isa<App>()) phase->apply(app);
             phase->run();
         } else
-            world.ELOG("axm not found in passes");
+            fe::throwf("no phase registered for stage '{}'; is its plugin loaded?", callee);
     }
 }
 

--- a/src/mim/plug/affine/phase/lower_index.cpp
+++ b/src/mim/plug/affine/phase/lower_index.cpp
@@ -52,7 +52,7 @@ const Def* LowerIndex::rewrite_imm_App(const App* app) {
                 return w.call(core::wrap::sub, core::Mode::none, Defs{w.lit(w.type_i64(), 0), a});
             }
             case affine::op::mul: {
-                error("affine.op.mul should have been rewritten to affine.semiop.mul and then to core.mul");
+                fe::throwf("affine.op.mul should have been rewritten to affine.semiop.mul and then to core.mul");
             }
         }
     }
@@ -61,7 +61,7 @@ const Def* LowerIndex::rewrite_imm_App(const App* app) {
         auto [x, c] = rewrite(app->arg())->projs<2>();
         switch (semiop.id()) {
             case affine::semiop::mul: {
-                if (Axm::isa<refly::check>(c)) error("affine.op.mul called with non-constant second argument");
+                if (Axm::isa<refly::check>(c)) fe::throwf("affine.op.mul called with non-constant second argument");
                 // `c` is a `Nat` constant; reinterpret it on the `Idx 0` carrier.
                 return w.call(core::wrap::mul, core::Mode::none, Defs{x, w.call<core::bitcast>(w.type_i64(), c)});
             }

--- a/src/mim/plug/gpu/gpu.cpp
+++ b/src/mim/plug/gpu/gpu.cpp
@@ -22,19 +22,19 @@ void reg_phases(Flags2Phases& phases) {
         if (auto malloc = Axm::isa<mem::malloc>(def)) {
             auto addr_space = Lit::as(malloc->decurry()->arg(1));
             if (addr_space == shared_as || addr_space == const_as || addr_space == local_as)
-                error("Invalid use of %mem.malloc: cannot be used in address space {}: {}", addr_space, malloc);
+                fe::throwf("Invalid use of %mem.malloc: cannot be used in address space {}: {}", addr_space, malloc);
         } else if (auto free = Axm::isa<mem::free>(def)) {
             auto addr_space = Lit::as(free->decurry()->arg(1));
             if (addr_space == shared_as || addr_space == const_as || addr_space == local_as)
-                error("Invalid use of %mem.free: cannot be used in address space {}: {}", addr_space, free);
+                fe::throwf("Invalid use of %mem.free: cannot be used in address space {}: {}", addr_space, free);
         } else if (auto mslot = Axm::isa<mem::mslot>(def)) {
             auto addr_space = Lit::as(mslot->decurry()->arg(1));
             if (addr_space == global_as || addr_space == const_as)
-                error("Invalid use of %mem.mslot: cannot be used in address space {}: {}", addr_space, mslot);
+                fe::throwf("Invalid use of %mem.mslot: cannot be used in address space {}: {}", addr_space, mslot);
         } else if (auto store = Axm::isa<mem::store>(def)) {
             auto addr_space = Lit::as(store->decurry()->arg(1));
             if (addr_space == const_as)
-                error("Invalid use of %mem.store: cannot be used in address space {}: {}", addr_space, store);
+                fe::throwf("Invalid use of %mem.store: cannot be used in address space {}: {}", addr_space, store);
         }
         return {};
     });

--- a/src/mim/plug/gpu/phase/mem_checks.cpp
+++ b/src/mim/plug/gpu/phase/mem_checks.cpp
@@ -46,8 +46,8 @@ const Def* MemChecks::rewrite_imm_App(const App* app) {
 
         MemFinder mem_finder(kernel_args_t);
         if (mem_finder.next_mem()) {
-            error("You may not pass any %mem.M across device boundaries: passing {} : {} from host to kernel '{}'",
-                  kernel_args, kernel_args_t, kernel);
+            fe::throwf("You may not pass any %mem.M across device boundaries: passing {} : {} from host to kernel '{}'",
+                       kernel_args, kernel_args_t, kernel);
         }
     }
     return Super::rewrite_imm_App(app);
@@ -60,13 +60,13 @@ void MemChecks::rewrite_external(Def* def) {
         while (auto mem = intype_mem_finder.next_mem()) {
             auto addr_space = mem->arg();
             if (Lit::as(addr_space) != 0)
-                error("The main function may not take %mem.M n with a non-zero n as an argument");
+                fe::throwf("The main function may not take %mem.M n with a non-zero n as an argument");
         }
 
         MemFinder outtype_mem_finder(lam->type()->ret_dom());
         while (auto mem = outtype_mem_finder.next_mem()) {
             auto addr_space = mem->arg();
-            if (Lit::as(addr_space) != 0) error("The main function may not return any %mem.M n with a non-zero n");
+            if (Lit::as(addr_space) != 0) fe::throwf("The main function may not return any %mem.M n with a non-zero n");
         }
     }
     Super::rewrite_external(def);

--- a/src/mim/plug/gpu/phase/split_apply.cpp
+++ b/src/mim/plug/gpu/phase/split_apply.cpp
@@ -12,7 +12,7 @@ static void run_stage(World& world, flags_t annex) {
     auto callee       = App::uncurry_callee(body);
 
     auto create_phase = world.driver().phase(callee->flags());
-    if (!create_phase) error("Could not get phase");
+    if (!create_phase) fe::throwf("Could not get phase");
 
     auto stage = (*create_phase)(world);
     auto phase = stage.get()->as<Phase>();

--- a/src/mim/plug/ll/ll.cpp
+++ b/src/mim/plug/ll/ll.cpp
@@ -1,17 +1,24 @@
 #include "mim/plug/ll/ll.h"
 
 #include <fstream>
+#include <iomanip>
+#include <ranges>
 #include <string>
 
 #include <mim/config.h>
 #include <mim/phase.h>
 #include <mim/plugin.h>
 
+#include "mim/plug/core/core.h"
 #include "mim/plug/ll/autogen.h"
 
 namespace mim::plug::ll {
 
 using namespace std::string_literals;
+
+namespace clos = mim::plug::clos;
+namespace core = mim::plug::core;
+namespace vec  = mim::plug::vec;
 
 /// Pipeline phase for `%ll.emit`.
 /// Writes the LLVM IR of the fully lowered world to `<world>.ll` (or `a.ll` if the world is unnamed).
@@ -36,6 +43,1045 @@ public:
         emitter.run();
     }
 };
+
+/*
+ * Heavy, target-independent emitter methods.
+ * These live here (compiled once into libmim_ll) instead of the header so that
+ * libmim_ll_nvptx does not recompile them; ll_nvptx reaches them via the
+ * `extern "C"` shims below, looked up with GET_FUN_PTR (see ll.h).
+ */
+
+std::string Emitter::convert_impl(const Def* type, bool simd) {
+    if (auto i = types_.find(type); i != types_.end()) return i->second;
+
+    assert(!Axm::isa<mem::M>(type));
+    std::ostringstream s;
+    std::string name;
+
+    if (type->isa<Nat>()) {
+        return types_[type] = "i64";
+    } else if (auto size = Idx::isa(type)) {
+        return types_[type] = "i" + std::to_string(*Idx::size2bitwidth(size));
+    } else if (auto w = math::isa_f(type)) {
+        switch (*w) {
+            case 16: return types_[type] = "half";
+            case 32: return types_[type] = "float";
+            case 64: return types_[type] = "double";
+            default: fe::unreachable();
+        }
+    } else if (auto ptr = Axm::isa<mem::Ptr>(type)) {
+        auto [pointee, addr_space] = ptr->args<2>();
+        std::print(s, "{} addrspace({})*", convert(pointee, false), addr_space);
+    } else if (auto arr = type->isa<Arr>()) {
+        if (auto se = is_simd(arr); se && simd) {
+            auto [size, elem] = *se;
+            std::print(s, "<{} x {}>", size, convert(elem));
+        } else {
+            u64 size = 0;
+            if (auto arity = Lit::isa(arr->arity())) size = *arity;
+            std::print(s, "[{} x {}]", size, convert(arr->body(), false));
+        }
+    } else if (auto pi = type->isa<Pi>()) {
+        assert(Pi::isa_returning(pi) && "should never have to convert type of BB");
+        std::print(s, "{} (", convert_ret_pi(pi->ret_pi()));
+
+        if (auto t = detail::isa_mem_sigma_2(pi->dom()))
+            s << convert(t);
+        else {
+            auto doms = pi->doms();
+            for (auto sep = ""; auto dom : doms.view().rsubspan(1)) {
+                if (Axm::isa<mem::M>(dom)) continue;
+                s << sep << convert(dom);
+                sep = ", ";
+            }
+        }
+        s << ")*";
+    } else if (auto t = detail::isa_mem_sigma_2(type)) {
+        return convert(t);
+    } else if (auto sigma = type->isa<Sigma>()) {
+        if (sigma->isa_mut()) {
+            name          = id(sigma);
+            types_[sigma] = name;
+            std::print(s, "{} = type", name);
+        }
+
+        std::print(s, "{{");
+        for (auto sep = ""; auto t : sigma->ops()) {
+            if (Axm::isa<mem::M>(t)) continue;
+            s << sep << convert(t);
+            sep = ", ";
+        }
+        std::print(s, "}}");
+    } else {
+        fe::unreachable();
+    }
+
+    if (name.empty()) return types_[type] = s.str();
+
+    assert(!s.str().empty());
+    type_decls_ << s.str() << '\n';
+    return types_[type] = name;
+}
+
+void Emitter::finalize_impl() {
+    for (auto& [lam, bb] : lam2bb_) {
+        for (const auto& [phi, args] : bb.phis) {
+            std::print(bb.head().emplace_back(), "{} = phi {} ", id(phi), convert(phi->type()));
+            for (auto sep = ""; const auto& [arg, pred] : args) {
+                std::print(bb.head().back(), "{}[ {}, {} ]", sep, arg, pred);
+                sep = ", ";
+            }
+        }
+    }
+
+    for (auto mut : Scheduler::schedule(nest())) {
+        if (auto lam = mut->isa_mut<Lam>()) {
+            assert(lam2bb_.contains(lam));
+            auto& bb = lam2bb_[lam];
+            std::print(func_impls_, "{}:\n", lam->unique_name());
+
+            ++tab;
+            for (const auto& part : bb.parts)
+                for (const auto& line : part)
+                    std::println(func_impls_, "{}{}", tab, line.str());
+            --tab;
+            func_impls_ << std::endl;
+        }
+    }
+
+    std::print(func_impls_, "}}\n\n");
+}
+
+/*
+ Block           type              return
+BB:
+          Cn [M, a, A]         →    2 phi
+          Cn «2;A»             →    2 phi
+          Cn [M, «2;A»]        →    1 phi
+Ret:
+          Cn[M,A,A]            →    1 phi
+          Cn «2;A»             →    1 phi
+          Cn[M, «2;A»]         →    1 phi
+
+Fun:
+          Cn[A, A, Cn R]       →    2 args + ret
+          Cn[«2; A», Cn R]     →    1 args + ret
+          Cn[M, A, A, Cn R]    →    2 args + ret
+          Cn[M, «2; A», Cn R]  →    1 args + ret
+*/
+void Emitter::emit_epilogue_impl(Lam* lam) {
+    auto app = lam->body()->as<App>();
+    auto& bb = lam2bb_[lam];
+    if (app->callee() == root()->ret_var()) { // return
+        Vector<std::string> values;
+        DefVec types;
+        for (auto arg : app->args()) {
+            if (auto val = emit_unsafe(arg); !val.empty()) {
+                values.emplace_back(val);
+                types.emplace_back(arg->type());
+            }
+        }
+
+        switch (values.size()) {
+            case 0: return bb.tail("ret void");
+            case 1:
+                return Axm::isa<mem::M>(types[0]) ? bb.tail("ret void")
+                                                  : bb.tail("ret {} {}", convert(types[0]), values[0]);
+            default: {
+                std::string type;
+                std::string prev;
+
+                if (auto se = is_simd_aggregate(types)) {
+                    auto common_src = find_common_simd_src(app);
+                    if (common_src) {
+                        auto v_src = emit(common_src);
+                        auto t     = convert(common_src->type());
+                        return bb.tail("ret {} {}", t, v_src);
+                    }
+                    auto [size, elem] = *se;
+                    auto val_t        = convert(elem);
+
+                    type = std::format("<{} x {}>", size, val_t);
+                    for (auto val : values) {
+                        if (prev.empty())
+                            prev = "<";
+                        else
+                            prev += ", ";
+                        prev += std::format("{} {}", val_t, val);
+                    }
+                    prev += ">";
+                } else {
+                    prev = "undef";
+                    type = convert(world().sigma(types));
+                    for (size_t i = 0, n = values.size(); i != n; ++i) {
+                        if (auto mem = Axm::isa<mem::M>(types[i])) continue;
+                        auto v_elem = values[i];
+                        auto t_elem = convert(types[i]);
+                        auto namei  = "%ret_val." + std::to_string(i);
+                        bb.tail("{} = insertvalue {} {}, {} {}, {}", namei, type, prev, t_elem, v_elem, i);
+                        prev = namei;
+                    }
+                }
+                bb.tail("ret {} {}", type, prev);
+            }
+        }
+
+    } else if (auto dispatch = Dispatch(app)) {
+        for (auto callee : dispatch.tuple()->projs([](const Def* def) { return def->isa_mut<Lam>(); }))
+            if (size_t n = callee->num_tvars(); n == 1 && is_simd(callee->var(0)->type()))
+                emit_phi(callee, callee->var(0), emit(app->arg(n, 0)), lam);
+            else
+                emit_phi_args(callee, app, lam);
+
+        auto v_index = emit(dispatch.index());
+        size_t n     = dispatch.num_targets();
+        auto bbs     = absl::FixedArray<std::string>(n);
+        for (size_t i = 0; i != n; ++i)
+            bbs[i] = emit(dispatch.target(i));
+
+        if (auto branch = Branch(app)) return bb.tail("br i1 {}, label {}, label {}", v_index, bbs[1], bbs[0]);
+
+        auto t_index = convert(dispatch.index()->type());
+        bb.tail("switch {} {}, label {} [ ", t_index, v_index, bbs[0]);
+        for (size_t i = 1; i != n; ++i)
+            std::print(bb.tail().back(), "{} {}, label {} ", t_index, std::to_string(i), bbs[i]);
+        std::print(bb.tail().back(), "]");
+    } else if (app->callee()->isa<Bot>()) {
+        return bb.tail("ret ; bottom: unreachable");
+    } else if (auto callee = Lam::isa_mut_basicblock(app->callee())) { // ordinary jump
+
+        if (auto common_src = find_common_simd_src(app)) {
+            auto v_src      = emit(common_src);
+            auto callee_var = callee->var();
+            if (simd_phi_.find(callee) == simd_phi_.end()) simd_phi_[callee] = callee_var;
+            auto key = simd_phi_[callee];
+            emit_phi(callee, key, v_src, lam);
+            for (auto var : callee->vars())
+                locals_[var] = id(key);
+            locals_[callee_var] = id(key);
+        } else {
+            emit_phi_args(callee, app, lam);
+        }
+        return bb.tail("br label {}", id(callee));
+
+    } else if (auto longjmp = Axm::isa<clos::longjmp>(app)) {
+        declare("void @longjmp(i8*, i32) noreturn");
+
+        auto [mem, jbuf, tag] = app->args<3>();
+        emit_unsafe(mem);
+        auto v_jb  = emit(jbuf);
+        auto v_tag = emit(tag);
+        bb.tail("call void @longjmp(i8* {}, i32 {})", v_jb, v_tag);
+        return bb.tail("unreachable");
+    } else if (auto mslot = Axm::isa<mem::mslot>(app)) {
+        // Continuation-based stack slot: allocate and jump to the passed continuation with the fresh pointer.
+        auto [Ta, rest]            = mslot->uncurry_args<2>();
+        auto [pointee, addr_space] = Ta->projs<2>();
+        auto [msize, ret]          = rest->projs<2>();
+        emit_unsafe(msize->proj(0)); // mem
+        // TODO array with size
+        auto ret_lam = ret->as_mut<Lam>();
+        auto ptr     = ret_lam->var(2, 1);
+        auto v_ptr   = "%" + app->unique_name() + ".slot";
+        std::print(bb.body().emplace_back(), "{} = alloca {}", v_ptr, convert(pointee, false));
+        emit_phi(ret_lam, ptr, v_ptr, lam);
+        return bb.tail("br label {}", id(ret_lam));
+    } else if (Pi::isa_returning(app->callee_type())) { // function call
+        auto v_callee = emit(app->callee());
+
+        Vector<std::string> args;
+        auto app_args = app->args();
+        for (auto arg : app_args.view().rsubspan(1))
+            if (auto v_arg = emit_unsafe(arg); !v_arg.empty()) args.emplace_back(convert(arg->type()) + " " + v_arg);
+
+        if (app->args().back()->isa<Bot>()) {
+            // TODO: Perhaps it'd be better to simply η-wrap this prior to the BE...
+            assert(convert_ret_pi(app->callee_type()->ret_pi()) == "void");
+            bb.tail("call void {}({})", v_callee, fe::Join(args));
+            return bb.tail("unreachable");
+        }
+
+        auto ret_lam = app->args().back()->as_mut<Lam>();
+        size_t n     = 0;
+        for (auto var : ret_lam->vars())
+            if (!Axm::isa<mem::M>(var->type())) ++n;
+
+        if (n == 0) {
+            bb.tail("call void {}({})", v_callee, fe::Join(args));
+        } else {
+            auto name  = "%" + app->unique_name() + "ret";
+            auto t_ret = convert_ret_pi(ret_lam->type());
+            bb.tail("{} = call {} {}({})", name, t_ret, v_callee, fe::Join(args));
+            emit_phi(ret_lam, ret_lam->var(), name, lam);
+        }
+
+        return bb.tail("br label {}", id(ret_lam));
+    }
+}
+
+std::string Emitter::emit_bb_impl(BB& bb, const Def* def) {
+    if (auto lam = def->isa<Lam>()) return id(lam);
+
+    auto name = id(def);
+    std::string op;
+
+    auto emit_tuple = [&](const Def* tuple) {
+        if (detail::isa_mem_sigma_2(tuple->type())) {
+            emit_unsafe(tuple->proj(2, 0));
+            return emit(tuple->proj(2, 1));
+        }
+
+        if (tuple->is_closed()) {
+            bool is_array   = tuple->type()->isa<Arr>();
+            auto simd_array = convert(tuple->type()).front() == '<'; // needed to respect pointer context
+            std::string s;
+            s += simd_array ? "<" : is_array ? "[" : "{";
+            auto sep = "";
+            for (size_t i = 0, n = tuple->num_projs(); i != n; ++i) {
+                auto e = tuple->proj(n, i);
+                if (auto v_elem = emit_unsafe(e); !v_elem.empty()) {
+                    auto t_elem = convert(e->type());
+                    s += sep + t_elem + " " + v_elem;
+                    sep = ", ";
+                }
+            }
+
+            return s += simd_array ? ">" : is_array ? "]" : "}";
+        }
+
+        std::string prev = "undef";
+        auto t           = convert(tuple->type());
+        for (size_t src = 0, dst = 0, n = tuple->num_projs(); src != n; ++src) {
+            auto e = tuple->proj(n, src);
+            if (auto elem = emit_unsafe(e); !elem.empty()) {
+                auto elem_t = convert(e->type());
+                // TODO: check dst vs src
+                auto namei = name + "." + std::to_string(dst);
+                if (t.front() == '<') // not using is_simd to respect the pointer context (Pointer Pointee case)
+                    prev = bb.assign(namei, "insertelement {} {}, {} {}, {} {}", t, prev, elem_t, elem, elem_t, dst);
+                else
+                    prev = bb.assign(namei, "insertvalue {} {}, {} {}, {}", t, prev, elem_t, elem, dst);
+                dst++;
+            }
+        }
+        return prev;
+    };
+
+    if (def->isa<Var>()) {
+        if (is_simd(def->type())) return id(def);
+        auto ts = def->type()->projs();
+        if (std::ranges::any_of(ts, [](auto t) { return Axm::isa<mem::M>(t); })) return {};
+        return emit_tuple(def);
+    }
+
+    auto emit_gep_index = [&](const Def* index) {
+        auto v_i = emit(index);
+        auto t_i = convert(index->type());
+
+        if (auto size = Idx::isa(index->type())) {
+            if (auto w = Idx::size2bitwidth(size); w && *w < 64) {
+                v_i = bb.assign(name + ".zext",
+                                "zext {} {} to i{} ; add one more bit for gep index as it is treated as signed value",
+                                t_i, v_i, *w + 1);
+                t_i = "i" + std::to_string(*w + 1);
+            }
+        }
+
+        return std::pair(v_i, t_i);
+    };
+
+    if (auto lit = def->isa<Lit>()) {
+        if (lit->type()->isa<Nat>() || Idx::isa(lit->type())) {
+            return std::to_string(lit->get());
+        } else if (auto w = math::isa_f(lit->type())) {
+            std::stringstream s;
+            u64 hex;
+
+            switch (*w) {
+                case 16:
+                    s << "0xH" << std::setfill('0') << std::setw(4) << std::right << std::hex << lit->get<u16>();
+                    return s.str();
+                case 32: {
+                    hex = std::bit_cast<u64>(f64(lit->get<f32>()));
+                    break;
+                }
+                case 64: hex = lit->get<u64>(); break;
+                default: fe::unreachable();
+            }
+
+            s << "0x" << std::setfill('0') << std::setw(16) << std::right << std::hex << hex;
+            return s.str();
+        }
+        fe::unreachable();
+    } else if (def->isa<Bot>()) {
+        return "undef";
+    } else if (auto top = def->isa<Top>()) {
+        if (Axm::isa<mem::M>(top->type())) return {};
+        // bail out to error below
+    } else if (auto tuple = def->isa<Tuple>()) {
+        return emit_tuple(tuple);
+    } else if (auto pack = def->isa<Pack>()) {
+        if (auto lit = Lit::isa(pack->body()); lit && *lit == 0) return "zeroinitializer";
+        return emit_tuple(pack);
+    } else if (auto sel = Select(def)) {
+        auto t                = convert(sel.extract()->type());
+        auto [elem_a, elem_b] = sel.pair()->projs<2>([&](auto e) { return emit_unsafe(e); });
+        auto cond_t           = convert(sel.cond()->type());
+        auto cond             = emit(sel.cond());
+        return bb.assign(name, "select {} {}, {} {}, {} {}", cond_t, cond, t, elem_b, t, elem_a);
+    } else if (auto extract = def->isa<Extract>()) {
+        auto tuple = extract->tuple();
+        auto index = extract->index();
+        auto v_tup = emit_unsafe(tuple);
+        if (is_simd(tuple->type()) && !Axm::isa<mem::M>(tuple->type())) return v_tup;
+
+        // this exact location is important: after emitting the tuple -> ordering of mem ops
+        // before emitting the index, as it might be a weird value for mem vars.
+        if (Axm::isa<mem::M>(extract->type())) return {};
+        if (auto sigma = extract->type()->isa<Sigma>(); sigma && sigma->num_ops() == 0) return {};
+
+        auto t_tup = convert(tuple->type());
+        if (auto li = Lit::isa(index)) {
+            if (detail::isa_mem_sigma_2(tuple->type())) return v_tup;
+            // Adjust index: convert() drops %mem.M elements from sigmas,
+            // so subtract the number of mem elements preceding the index.
+            auto v_i = *li;
+            if (auto sigma = tuple->type()->isa<Sigma>())
+                for (u64 i = 0; i < *li; ++i)
+                    if (Axm::isa<mem::M>(sigma->op(i))) --v_i;
+
+            return bb.assign(name, "extractvalue {} {}, {}", t_tup, v_tup, v_i);
+        }
+
+        auto t_elem     = convert(extract->type());
+        auto [v_i, t_i] = emit_gep_index(index);
+
+        std::print(lam2bb_[root()].body().emplace_front(),
+                   "{}.alloca = alloca {} ; copy to alloca to emulate extract with store + gep + load", name, t_tup);
+        std::print(bb.body().emplace_back(), "store {} {}, {}* {}.alloca", t_tup, v_tup, t_tup, name);
+        std::print(bb.body().emplace_back(), "{}.gep = getelementptr inbounds {}, {}* {}.alloca, i64 0, {} {}", name,
+                   t_tup, t_tup, name, t_i, v_i);
+        return bb.assign(name, "load {}, {}* {}.gep", t_elem, t_elem, name);
+    } else if (auto insert = def->isa<Insert>()) {
+        assert(!Axm::isa<mem::M>(insert->tuple()->proj(0)->type()));
+        auto t_tup = convert(insert->tuple()->type());
+        auto t_val = convert(insert->value()->type());
+        auto v_tup = emit(insert->tuple());
+        auto v_val = emit(insert->value());
+        if (auto idx = Lit::isa(insert->index())) {
+            auto v_idx = emit(insert->index());
+            if (is_simd(insert->tuple()->type()))
+
+                return bb.assign(name, "insertelement {} {}, {} {}, i32 {}", t_tup, v_tup, t_val, v_val, v_idx);
+            else
+
+                return bb.assign(name, " insertvalue {} {}, {} {}, {}", t_tup, v_tup, t_val, v_val, v_idx);
+        } else {
+            if (is_simd(insert->tuple()->type())) {
+                auto v_i = emit(insert->index());
+                auto t_i = convert(insert->index()->type());
+                if (t_i != "i32") {
+                    auto w_src = *Idx::size2bitwidth(Idx::isa(insert->index()->type()));
+                    v_i        = bb.assign(name + ".idx", "{} {} {} to i32", w_src < 32 ? "zext" : "trunc", t_i, v_i);
+                }
+                return bb.assign(name, "insertelement {} {}, {} {}, i32 {}", t_tup, v_tup, t_val, v_val, v_i);
+            }
+            auto t_elem     = convert(insert->value()->type());
+            auto [v_i, t_i] = emit_gep_index(insert->index());
+            std::print(lam2bb_[root()].body().emplace_front(),
+                       "{}.alloca = alloca {} ; copy to alloca to emulate insert with store + gep + load", name, t_tup);
+            std::print(bb.body().emplace_back(), "store {} {}, {}* {}.alloca", t_tup, v_tup, t_tup, name);
+            std::print(bb.body().emplace_back(), "{}.gep = getelementptr inbounds {}, {}* {}.alloca, i64 0, {} {}",
+                       name, t_tup, t_tup, name, t_i, v_i);
+            std::print(bb.body().emplace_back(), "store {} {}, {}* {}.gep", t_val, v_val, t_val, name);
+            return bb.assign(name, "load {}, {}* {}.alloca", t_tup, t_tup, name);
+        }
+    } else if (auto global = def->isa<Global>()) {
+        auto v_init                = emit(global->init());
+        auto [pointee, addr_space] = Axm::as<mem::Ptr>(global->type())->args<2>();
+        std::print(vars_decls_, "{} = global {} {}\n", name, convert(pointee), v_init);
+        return globals_[global] = name;
+    } else if (auto nat = Axm::isa<core::nat>(def)) {
+        auto [a, b] = nat->args<2>([this](auto def) { return emit(def); });
+
+        switch (nat.id()) {
+            case core::nat::add: return bb.assign(name, "add nsw nuw i64 {}, {}", a, b);
+            case core::nat::sub: {
+                // nat subtraction saturates at 0: cap result when b > a
+                auto ugt = bb.assign(name + ".ugt", "icmp ugt i64 {}, {}", b, a);
+                auto raw = bb.assign(name + ".raw", "sub i64 {}, {}", a, b);
+                return bb.assign(name, "select i1 {}, i64 0, i64 {}", ugt, raw);
+            }
+            case core::nat::mul: return bb.assign(name, "mul nsw nuw i64 {}, {}", a, b);
+            // %core.nat.div/mod define division/modulo by zero as `a / 0 = 0` and `a % 0 = a`.
+            // replace a zero divisor by 1 to keep udiv/urem well-defined, then select the
+            // defined result for the zero case (0 for div, a for mod).
+            case core::nat::div: {
+                auto bz   = bb.assign(name + ".bz", "icmp eq i64 {}, 0", b);
+                auto bsaf = bb.assign(name + ".bsafe", "select i1 {}, i64 1, i64 {}", bz, b);
+                auto q    = bb.assign(name + ".q", "udiv i64 {}, {}", a, bsaf);
+                return bb.assign(name, "select i1 {}, i64 0, i64 {}", bz, q);
+            }
+            case core::nat::mod: {
+                auto bz   = bb.assign(name + ".bz", "icmp eq i64 {}, 0", b);
+                auto bsaf = bb.assign(name + ".bsafe", "select i1 {}, i64 1, i64 {}", bz, b);
+                auto r    = bb.assign(name + ".r", "urem i64 {}, {}", a, bsaf);
+                return bb.assign(name, "select i1 {}, i64 {}, i64 {}", bz, a, r);
+            }
+        }
+    } else if (auto ncmp = Axm::isa<core::ncmp>(def)) {
+        auto [a, b] = ncmp->args<2>([this](auto def) { return emit(def); });
+        op          = "icmp ";
+
+        switch (ncmp.id()) {
+                // clang-format off
+            case core::ncmp::e:  op += "eq" ; break;
+            case core::ncmp::ne: op += "ne" ; break;
+            case core::ncmp::g:  op += "ugt"; break;
+            case core::ncmp::ge: op += "uge"; break;
+            case core::ncmp::l:  op += "ult"; break;
+            case core::ncmp::le: op += "ule"; break;
+            // clang-format on
+            default: fe::unreachable();
+        }
+
+        return bb.assign(name, "{} i64 {}, {}", op, a, b);
+    } else if (auto idx = Axm::isa<core::idx>(def)) {
+        auto x = emit(idx->arg());
+        auto s = *Idx::size2bitwidth(Idx::isa(idx->type()));
+        auto t = convert(idx->type());
+        if (s < 64) return bb.assign(name, "trunc i64 {} to {}", x, t);
+        return x;
+    } else if (auto bit1 = Axm::isa<core::bit1>(def)) {
+        assert(bit1.id() == core::bit1::neg);
+        auto x = emit(bit1->arg());
+        auto t = convert(bit1->type());
+        return bb.assign(name, "xor {} -1, {}", t, x);
+    } else if (auto bit2 = Axm::isa<core::bit2>(def)) {
+        auto [a, b] = bit2->args<2>([this](auto def) { return emit(def); });
+        auto t      = convert(bit2->type());
+
+        auto neg = [&](std::string_view x) { return bb.assign(name + ".neg", "xor {} -1, {}", t, x); };
+
+        switch (bit2.id()) {
+                // clang-format off
+            case core::bit2::and_: return bb.assign(name, "and {} {}, {}", t, a, b);
+            case core::bit2:: or_: return bb.assign(name, "or  {} {}, {}", t, a, b);
+            case core::bit2::xor_: return bb.assign(name, "xor {} {}, {}", t, a, b);
+            case core::bit2::nand: return neg(bb.assign(name, "and {} {}, {}", t, a, b));
+            case core::bit2:: nor: return neg(bb.assign(name, "or  {} {}, {}", t, a, b));
+            case core::bit2::nxor: return neg(bb.assign(name, "xor {} {}, {}", t, a, b));
+            case core::bit2:: iff: return bb.assign(name, "and {} {}, {}", t, neg(a), b);
+            case core::bit2::niff: return bb.assign(name, "or  {} {}, {}", t, neg(a), b);
+            // clang-format on
+            default: fe::unreachable();
+        }
+    } else if (auto shr = Axm::isa<core::shr>(def)) {
+        auto [a, b] = shr->args<2>([this](auto def) { return emit(def); });
+        auto t      = convert(shr->type());
+
+        switch (shr.id()) {
+            case core::shr::a: op = "ashr"; break;
+            case core::shr::l: op = "lshr"; break;
+        }
+
+        return bb.assign(name, "{} {} {}, {}", op, t, a, b);
+    } else if (auto wrap = Axm::isa<core::wrap>(def)) {
+        auto [mode, ab] = wrap->uncurry_args<2>();
+        auto [a, b]     = ab->projs<2>([this](auto def) { return emit(def); });
+        auto t          = convert(wrap->type());
+        auto lmode      = static_cast<core::Mode>(Lit::as(mode));
+
+        switch (wrap.id()) {
+            case core::wrap::add: op = "add"; break;
+            case core::wrap::sub: op = "sub"; break;
+            case core::wrap::mul: op = "mul"; break;
+            case core::wrap::shl: op = "shl"; break;
+        }
+
+        if (fe::has_flag(lmode, core::Mode::nuw)) op += " nuw";
+        if (fe::has_flag(lmode, core::Mode::nsw)) op += " nsw";
+
+        return bb.assign(name, "{} {} {}, {}", op, t, a, b);
+    } else if (auto div = Axm::isa<core::div>(def)) {
+        auto [m, xy] = div->args<2>();
+        auto [x, y]  = xy->projs<2>();
+        auto t       = convert(x->type());
+        emit_unsafe(m);
+        auto a = emit(x);
+        auto b = emit(y);
+
+        switch (div.id()) {
+            case core::div::sdiv: op = "sdiv"; break;
+            case core::div::udiv: op = "udiv"; break;
+            case core::div::srem: op = "srem"; break;
+            case core::div::urem: op = "urem"; break;
+        }
+
+        return bb.assign(name, "{} {} {}, {}", op, t, a, b);
+    } else if (auto icmp = Axm::isa<core::icmp>(def)) {
+        auto [a, b] = icmp->args<2>([this](auto def) { return emit(def); });
+        auto t      = convert(icmp->arg(0)->type());
+        op          = "icmp ";
+
+        switch (icmp.id()) {
+                // clang-format off
+            case core::icmp::e:   op += "eq" ; break;
+            case core::icmp::ne:  op += "ne" ; break;
+            case core::icmp::sg:  op += "sgt"; break;
+            case core::icmp::sge: op += "sge"; break;
+            case core::icmp::sl:  op += "slt"; break;
+            case core::icmp::sle: op += "sle"; break;
+            case core::icmp::ug:  op += "ugt"; break;
+            case core::icmp::uge: op += "uge"; break;
+            case core::icmp::ul:  op += "ult"; break;
+            case core::icmp::ule: op += "ule"; break;
+            // clang-format on
+            default: fe::unreachable();
+        }
+
+        return bb.assign(name, "{} {} {}, {}", op, t, a, b);
+    } else if (auto extr = Axm::isa<core::extrema>(def)) {
+        auto [x, y]   = extr->args<2>();
+        auto t        = convert(x->type());
+        auto a        = emit(x);
+        auto b        = emit(y);
+        std::string f = "llvm.";
+        switch (extr.id()) {
+            case core::extrema::Sm: f += "smin."; break;
+            case core::extrema::SM: f += "smax."; break;
+            case core::extrema::sm: f += "umin."; break;
+            case core::extrema::sM: f += "umax."; break;
+        }
+        f += t;
+        declare("{} @{}({}, {})", t, f, t, t);
+        return bb.assign(name, "tail call {} @{}({} {}, {} {})", t, f, t, a, t, b);
+    } else if (auto abs = Axm::isa<core::abs>(def)) {
+        auto [m, x]   = abs->args<2>();
+        auto t        = convert(x->type());
+        auto a        = emit(x);
+        std::string f = "llvm.abs." + t;
+        declare("{} @{}({}, {})", t, f, t, "i1");
+        return bb.assign(name, "tail call {} @{}({} {}, {} {})", t, f, t, a, "i1", "1");
+    } else if (auto conv = Axm::isa<core::conv>(def)) {
+        auto v_src = emit(conv->arg());
+        auto t_src = convert(conv->arg()->type());
+        auto t_dst = convert(conv->type());
+
+        nat_t w_src = *Idx::size2bitwidth(Idx::isa(conv->arg()->type()));
+        nat_t w_dst = *Idx::size2bitwidth(Idx::isa(conv->type()));
+
+        if (w_src == w_dst) return v_src;
+
+        switch (conv.id()) {
+            case core::conv::s: op = w_src < w_dst ? "sext" : "trunc"; break;
+            case core::conv::u: op = w_src < w_dst ? "zext" : "trunc"; break;
+        }
+
+        return bb.assign(name, "{} {} {} to {}", op, t_src, v_src, t_dst);
+    } else if (auto bitcast = Axm::isa<core::bitcast>(def)) {
+        auto dst_type_ptr = Axm::isa<mem::Ptr>(bitcast->type());
+        auto src_type_ptr = Axm::isa<mem::Ptr>(bitcast->arg()->type());
+        auto v_src        = emit(bitcast->arg());
+        auto t_src        = convert(bitcast->arg()->type());
+        auto t_dst        = convert(bitcast->type());
+
+        if (auto lit = Lit::isa(bitcast->arg()); lit && *lit == 0) return "zeroinitializer";
+        // clang-format off
+        if (src_type_ptr && dst_type_ptr) return bb.assign(name,  "bitcast {} {} to {}", t_src, v_src, t_dst);
+        if (src_type_ptr)                 return bb.assign(name, "ptrtoint {} {} to {}", t_src, v_src, t_dst);
+        if (dst_type_ptr)                 return bb.assign(name, "inttoptr {} {} to {}", t_src, v_src, t_dst);
+        // clang-format on
+
+        auto size2width = [&](const Def* type) {
+            if (type->isa<Nat>()) return 64_n;
+            if (auto size = Idx::isa(type)) return *Idx::size2bitwidth(size);
+            return 0_n;
+        };
+
+        auto src_size = size2width(bitcast->arg()->type());
+        auto dst_size = size2width(bitcast->type());
+
+        op = "bitcast";
+        if (src_size && dst_size) {
+            if (src_size == dst_size) return v_src;
+            op = (src_size < dst_size) ? "zext" : "trunc";
+        }
+        return bb.assign(name, "{} {} {} to {}", op, t_src, v_src, t_dst);
+    } else if (auto lea = Axm::isa<mem::lea>(def)) {
+        auto [ptr, i]  = lea->args<2>();
+        auto pointee   = Axm::as<mem::Ptr>(ptr->type())->arg(0);
+        auto v_ptr     = emit(ptr);
+        auto t_pointee = convert(pointee);
+        auto t_ptr     = convert(ptr->type());
+        if (pointee->isa<Sigma>())
+            return bb.assign(name, "getelementptr inbounds {}, {} {}, i64 0, i32 {}", t_pointee, t_ptr, v_ptr,
+                             Lit::as(i));
+
+        assert(pointee->isa<Arr>());
+        auto [v_i, t_i] = emit_gep_index(i);
+
+        return bb.assign(name, "getelementptr inbounds {}, {} {}, i64 0, {} {}", t_pointee, t_ptr, v_ptr, t_i, v_i);
+    } else if (auto malloc = Axm::isa<mem::malloc>(def)) {
+        auto address_space = malloc->decurry()->arg(1);
+        if (Lit::as(address_space) != 0)
+            if (auto target_specific = isa_targetspecific_intrinsic(bb, def)) return target_specific.value();
+
+        declare("i8* @malloc(i64)");
+
+        emit_unsafe(malloc->arg(0));
+        auto size           = emit(malloc->arg(1));
+        auto ptr_t          = convert(Axm::as<mem::Ptr>(def->proj(1)->type()));
+        auto i8ptr          = bb.assign(name + "i8", "call i8* @malloc(i64 {})", size);
+        std::string i8ptr_t = "i8*";
+        if (Lit::as(address_space) != 0) {
+            i8ptr_t = std::format("i8 addrspace({})*", address_space);
+            i8ptr   = bb.assign(name + "i8conv", "addrspacecast i8* {} to {}", i8ptr, i8ptr_t);
+        }
+        return bb.assign(name, "bitcast {} {} to {}", i8ptr_t, i8ptr, ptr_t);
+    } else if (auto free = Axm::isa<mem::free>(def)) {
+        auto address_space = free->decurry()->arg(1);
+        if (Lit::as(address_space) != 0)
+            if (auto target_specific = isa_targetspecific_intrinsic(bb, def)) return {};
+
+        declare("void @free(i8*)");
+        emit_unsafe(free->arg(0));
+        auto ptr   = emit(free->arg(1));
+        auto ptr_t = convert(Axm::as<mem::Ptr>(free->arg(1)->type()));
+
+        auto i8ptr = bb.assign(name + "i8", "bitcast {} {} to i8 addrspace({})*", ptr_t, ptr, address_space);
+        if (Lit::as(address_space) != 0)
+            i8ptr = bb.assign(name + "i8conv", "addrspacecast i8 addrspace({})* {} to i8*", address_space, i8ptr);
+        bb.tail("call void @free(i8* {})", i8ptr);
+        return {};
+    } else if (auto load = Axm::isa<mem::load>(def)) {
+        emit_unsafe(load->arg(0));
+        auto v_ptr     = emit(load->arg(1));
+        auto t_ptr     = convert(load->arg(1)->type());
+        auto t_pointee = convert(Axm::as<mem::Ptr>(load->arg(1)->type())->arg(0), false);
+        return bb.assign(name, "load {}, {} {}", t_pointee, t_ptr, v_ptr);
+    } else if (auto store = Axm::isa<mem::store>(def)) {
+        emit_unsafe(store->arg(0));
+        auto v_ptr = emit(store->arg(1));
+        auto v_val = emit(store->arg(2));
+        auto t_ptr = convert(store->arg(1)->type());
+        auto t_val = convert(store->arg(2)->type(), false);
+        std::print(bb.body().emplace_back(), "store {} {}, {} {}", t_val, v_val, t_ptr, v_ptr);
+        return {};
+    } else if (auto q = Axm::isa<clos::alloc_jmpbuf>(def)) {
+        declare("i64 @jmpbuf_size()");
+
+        emit_unsafe(q->arg());
+        auto size = name + ".size";
+        bb.assign(size, "call i64 @jmpbuf_size()");
+        return bb.assign(name, "alloca i8, i64 {}", size);
+    } else if (auto setjmp = Axm::isa<clos::setjmp>(def)) {
+        declare("i32 @_setjmp(i8*) returns_twice");
+
+        auto [mem, jmpbuf] = setjmp->arg()->projs<2>();
+        emit_unsafe(mem);
+        auto v_jb = emit(jmpbuf);
+        return bb.assign(name, "call i32 @_setjmp(i8* {})", v_jb);
+    } else if (auto arith = Axm::isa<math::arith>(def)) {
+        auto [mode, ab] = arith->uncurry_args<2>();
+        auto [a, b]     = ab->projs<2>([this](auto def) { return emit(def); });
+        auto t          = convert(arith->type());
+        auto lmode      = static_cast<math::Mode>(Lit::as(mode));
+
+        switch (arith.id()) {
+            case math::arith::add: op = "fadd"; break;
+            case math::arith::sub: op = "fsub"; break;
+            case math::arith::mul: op = "fmul"; break;
+            case math::arith::div: op = "fdiv"; break;
+            case math::arith::rem: op = "frem"; break;
+        }
+
+        if (lmode == math::Mode::fast)
+            op += " fast";
+        else {
+            // clang-format off
+            if (fe::has_flag(lmode, math::Mode::nnan    )) op += " nnan";
+            if (fe::has_flag(lmode, math::Mode::ninf    )) op += " ninf";
+            if (fe::has_flag(lmode, math::Mode::nsz     )) op += " nsz";
+            if (fe::has_flag(lmode, math::Mode::arcp    )) op += " arcp";
+            if (fe::has_flag(lmode, math::Mode::contract)) op += " contract";
+            if (fe::has_flag(lmode, math::Mode::afn     )) op += " afn";
+            if (fe::has_flag(lmode, math::Mode::reassoc )) op += " reassoc";
+            // clang-format on
+        }
+
+        return bb.assign(name, "{} {} {}, {}", op, t, a, b);
+    } else if (auto tri = Axm::isa<math::tri>(def)) {
+        auto a = emit(tri->arg());
+        auto t = convert(tri->type());
+
+        std::string f;
+
+        if (tri.id() == math::tri::sin) {
+            f = std::string("llvm.sin") + detail::llvm_suffix(tri->type());
+        } else if (tri.id() == math::tri::cos) {
+            f = std::string("llvm.cos") + detail::llvm_suffix(tri->type());
+        } else {
+            if (tri.sub() & sub_t(math::tri::a)) f += "a";
+
+            switch (math::tri((fe::to_underlying(tri.id()) & 0x3) | Annex::base<math::tri>())) {
+                case math::tri::sin: f += "sin"; break;
+                case math::tri::cos: f += "cos"; break;
+                case math::tri::tan: f += "tan"; break;
+                case math::tri::ahFF: error("this axm is supposed to be unused");
+                default: fe::unreachable();
+            }
+
+            if (tri.sub() & sub_t(math::tri::h)) f += "h";
+            f += detail::math_suffix(tri->type());
+        }
+
+        declare("{} @{}({})", t, f, t);
+        return bb.assign(name, "tail call {} @{}({} {})", t, f, t, a);
+    } else if (auto extrema = Axm::isa<math::extrema>(def)) {
+        auto [a, b]   = extrema->args<2>([this](auto def) { return emit(def); });
+        auto t        = convert(extrema->type());
+        std::string f = "llvm.";
+        switch (extrema.id()) {
+            case math::extrema::fmin: f += "minnum"; break;
+            case math::extrema::fmax: f += "maxnum"; break;
+            case math::extrema::ieee754min: f += "minimum"; break;
+            case math::extrema::ieee754max: f += "maximum"; break;
+        }
+        f += detail::llvm_suffix(extrema->type());
+
+        declare("{} @{}({}, {})", t, f, t, t);
+        return bb.assign(name, "tail call {} @{}({} {}, {} {})", t, f, t, a, t, b);
+    } else if (auto pow = Axm::isa<math::pow>(def)) {
+        auto [a, b]   = pow->args<2>([this](auto def) { return emit(def); });
+        auto t        = convert(pow->type());
+        std::string f = "llvm.pow";
+        f += detail::llvm_suffix(pow->type());
+        declare("{} @{}({}, {})", t, f, t, t);
+        return bb.assign(name, "tail call {} @{}({} {}, {} {})", t, f, t, a, t, b);
+    } else if (auto rt = Axm::isa<math::rt>(def)) {
+        auto a = emit(rt->arg());
+        auto t = convert(rt->type());
+        std::string f;
+        if (rt.id() == math::rt::sq)
+            f = std::string("llvm.sqrt") + detail::llvm_suffix(rt->type());
+        else
+            f = std::string("cbrt") += detail::math_suffix(rt->type());
+        declare("{} @{}({})", t, f, t);
+        return bb.assign(name, "tail call {} @{}({} {})", t, f, t, a);
+    } else if (auto exp = Axm::isa<math::exp>(def)) {
+        auto a        = emit(exp->arg());
+        auto t        = convert(exp->type());
+        std::string f = "llvm.";
+        f += (exp.sub() & sub_t(math::exp::log)) ? "log" : "exp";
+        f += (exp.sub() & sub_t(math::exp::bin)) ? "2" : (exp.sub() & sub_t(math::exp::dec)) ? "10" : "";
+        f += detail::llvm_suffix(exp->type());
+        // TODO doesn't work for exp10"
+        declare("{} @{}({})", t, f, t);
+        return bb.assign(name, "tail call {} @{}({} {})", t, f, t, a);
+    } else if (auto er = Axm::isa<math::er>(def)) {
+        auto a = emit(er->arg());
+        auto t = convert(er->type());
+        auto f = er.id() == math::er::f ? std::string("erf") : std::string("erfc");
+        f += detail::math_suffix(er->type());
+        declare("{} @{}({})", t, f, t);
+        return bb.assign(name, "tail call {} @{}({} {})", t, f, t, a);
+    } else if (auto gamma = Axm::isa<math::gamma>(def)) {
+        auto a        = emit(gamma->arg());
+        auto t        = convert(gamma->type());
+        std::string f = gamma.id() == math::gamma::t ? "tgamma" : "lgamma";
+        f += detail::math_suffix(gamma->type());
+        declare("{} @{}({})", t, f, t);
+        return bb.assign(name, "tail call {} @{}({} {})", t, f, t, a);
+    } else if (auto cmp = Axm::isa<math::cmp>(def)) {
+        auto [a, b] = cmp->args<2>([this](auto def) { return emit(def); });
+        auto t      = convert(cmp->arg(0)->type());
+        op          = "fcmp ";
+
+        switch (cmp.id()) {
+                // clang-format off
+            case math::cmp::  e: op += "oeq"; break;
+            case math::cmp::  l: op += "olt"; break;
+            case math::cmp:: le: op += "ole"; break;
+            case math::cmp::  g: op += "ogt"; break;
+            case math::cmp:: ge: op += "oge"; break;
+            case math::cmp:: ne: op += "one"; break;
+            case math::cmp::  o: op += "ord"; break;
+            case math::cmp::  u: op += "uno"; break;
+            case math::cmp:: ue: op += "ueq"; break;
+            case math::cmp:: ul: op += "ult"; break;
+            case math::cmp::ule: op += "ule"; break;
+            case math::cmp:: ug: op += "ugt"; break;
+            case math::cmp::uge: op += "uge"; break;
+            case math::cmp::une: op += "une"; break;
+            // clang-format on
+            default: fe::unreachable();
+        }
+
+        return bb.assign(name, "{} {} {}, {}", op, t, a, b);
+    } else if (auto is_finite = Axm::isa<math::is_finite>(def)) {
+        // https://llvm.org/docs/LangRef.html#llvm-is-fpclass-intrinsic
+        // declare i1 @llvm.is.fpclass(<fptype> <op>, i32 <test>)
+        auto a  = emit(is_finite->arg());
+        auto at = convert(is_finite->arg()->type());
+        auto t  = convert(is_finite->type());
+
+        auto s = detail::llvm_suffix(is_finite->arg()->type());
+        auto f = "llvm.is.fpclass";
+        declare("{} @{}{}({}, i32)", t, f, s, at);
+        return bb.assign(name, "tail call {} @{}{}({} {}, i32 504)", t, f, s, at, a);
+    } else if (auto conv = Axm::isa<math::conv>(def)) {
+        auto v_src = emit(conv->arg());
+        auto t_src = convert(conv->arg()->type());
+        auto t_dst = convert(conv->type());
+
+        auto s_src = math::isa_f(conv->arg()->type());
+        auto s_dst = math::isa_f(conv->type());
+
+        switch (conv.id()) {
+            case math::conv::f2f: op = s_src < s_dst ? "fpext" : "fptrunc"; break;
+            case math::conv::s2f: op = "sitofp"; break;
+            case math::conv::u2f: op = "uitofp"; break;
+            case math::conv::f2s: op = "fptosi"; break;
+            case math::conv::f2u: op = "fptoui"; break;
+        }
+
+        return bb.assign(name, "{} {} {} to {}", op, t_src, v_src, t_dst);
+    } else if (auto abs = Axm::isa<math::abs>(def)) {
+        auto a        = emit(abs->arg());
+        auto t        = convert(abs->type());
+        std::string f = "llvm.fabs";
+        f += detail::llvm_suffix(abs->type());
+        declare("{} @{}({})", t, f, t);
+        return bb.assign(name, "tail call {} @{}({} {})", t, f, t, a);
+    } else if (auto round = Axm::isa<math::round>(def)) {
+        auto a        = emit(round->arg());
+        auto t        = convert(round->type());
+        std::string f = "llvm.";
+        switch (round.id()) {
+            case math::round::f: f += "floor"; break;
+            case math::round::c: f += "ceil"; break;
+            case math::round::r: f += "round"; break;
+            case math::round::t: f += "trunc"; break;
+        }
+        f += detail::llvm_suffix(round->type());
+        declare("{} @{}({})", t, f, t);
+        return bb.assign(name, "tail call {} @{}({} {})", t, f, t, a);
+    } else if (auto zip = Axm::isa<vec::zip>(def)) {
+        auto ni_n   = zip->decurry()->decurry()->decurry()->arg();
+        auto nat_ni = *Lit::isa(ni_n->proj(2, 0));
+        auto f      = zip->decurry()->arg();
+        auto inputs = zip->arg();
+        auto t_in   = convert(inputs->proj(nat_ni, 0)->type());
+        auto t_out  = convert(def->type()); // <n x T>
+
+        std::string op;
+        std::string prev;
+
+        if (auto nat_op = Axm::isa<core::nat, 1>(f)) {
+            switch (nat_op.id()) {
+                case core::nat::add: op = "add nuw nsw"; break;
+                case core::nat::sub: {
+                    // nat subtraction saturates at 0: cap per-lane when v2 > v1
+                    auto v1     = emit(inputs->proj(nat_ni, 0));
+                    auto v2     = emit(inputs->proj(nat_ni, 1));
+                    auto ugt    = bb.assign(name + ".ugt", "icmp ugt {} {}, {}", t_in, v2, v1);
+                    auto raw    = bb.assign(name + ".raw", "sub {} {}, {}", t_in, v1, v2);
+                    return prev = bb.assign(name, "select <{} x i1> {}, {} zeroinitializer, {} {}", nat_ni, ugt, t_out,
+                                            t_out, raw);
+                }
+                case core::nat::mul: op = "mul nuw nsw"; break;
+                case core::nat::div: op = "udiv"; break;
+                case core::nat::mod: op = "urem"; break;
+            }
+        } else if (auto arith_op = Axm::isa<math::arith, 1>(f)) {
+            auto lmode = static_cast<math::Mode>(Lit::as(f->as<App>()->arg()));
+            switch (arith_op.id()) {
+                case math::arith::add: op = "fadd"; break;
+                case math::arith::sub: op = "fsub"; break;
+                case math::arith::mul: op = "fmul"; break;
+                case math::arith::div: op = "fdiv"; break;
+                case math::arith::rem: op = "frem"; break;
+            }
+
+            if (lmode == math::Mode::fast)
+                op += " fast";
+            else {
+                if (fe::has_flag(lmode, math::Mode::nnan)) op += " nnan";
+                if (fe::has_flag(lmode, math::Mode::ninf)) op += " ninf";
+                if (fe::has_flag(lmode, math::Mode::nsz)) op += " nsz";
+                if (fe::has_flag(lmode, math::Mode::arcp)) op += " arcp";
+                if (fe::has_flag(lmode, math::Mode::contract)) op += " contract";
+                if (fe::has_flag(lmode, math::Mode::afn)) op += " afn";
+                if (fe::has_flag(lmode, math::Mode::reassoc)) op += " reassoc";
+            }
+        } else if (auto ncmp_op = Axm::isa<core::ncmp, 1>(f)) {
+            op = "icmp ";
+            switch (ncmp_op.id()) {
+                case core::ncmp::e: op += "eq"; break;
+                case core::ncmp::ne: op += "ne"; break;
+                case core::ncmp::g: op += "ugt"; break;
+                case core::ncmp::ge: op += "uge"; break;
+                case core::ncmp::l: op += "ult"; break;
+                case core::ncmp::le: op += "ule"; break;
+                default: fe::unreachable();
+            }
+        } else if (auto icmp_op = Axm::isa<core::icmp, 1>(f)) {
+            op = "icmp ";
+            switch (icmp_op.id()) {
+                case core::icmp::e: op += "eq"; break;
+                case core::icmp::ne: op += "ne"; break;
+                case core::icmp::sg: op += "sgt"; break;
+                case core::icmp::sge: op += "sge"; break;
+                case core::icmp::sl: op += "slt"; break;
+                case core::icmp::sle: op += "sle"; break;
+                case core::icmp::ug: op += "ugt"; break;
+                case core::icmp::uge: op += "uge"; break;
+                case core::icmp::ul: op += "ult"; break;
+                case core::icmp::ule: op += "ule"; break;
+                default: fe::unreachable();
+            }
+        } else if (auto mcmp_op = Axm::isa<math::cmp, 1>(f)) {
+            op = "fcmp ";
+            switch (mcmp_op.id()) {
+                case math::cmp::e: op += "oeq"; break;
+                case math::cmp::l: op += "olt"; break;
+                case math::cmp::le: op += "ole"; break;
+                case math::cmp::g: op += "ogt"; break;
+                case math::cmp::ge: op += "oge"; break;
+                case math::cmp::ne: op += "one"; break;
+                case math::cmp::o: op += "ord"; break;
+                case math::cmp::u: op += "uno"; break;
+                case math::cmp::ue: op += "ueq"; break;
+                case math::cmp::ul: op += "ult"; break;
+                case math::cmp::ule: op += "ule"; break;
+                case math::cmp::ug: op += "ugt"; break;
+                case math::cmp::uge: op += "uge"; break;
+                case math::cmp::une: op += "une"; break;
+                default: fe::unreachable();
+            }
+        } else {
+            error("unhandled vec.zip operation: {}", f);
+        }
+
+        auto v1 = emit(inputs->proj(nat_ni, 0));
+        auto v2 = emit(inputs->proj(nat_ni, 1));
+        prev    = bb.assign(name, "{} {} {}, {}", op, t_in, v1, v2);
+        return prev;
+    } else if (auto res = isa_targetspecific_intrinsic(bb, def)) {
+        return res.value();
+    }
+    error("unhandled def in LLVM backend: {} : {}", def, def->type());
+}
+
+extern "C" {
+MIM_EXPORT void mim_ll_convert(Emitter& e, const Def* type, bool simd, std::string& res) {
+    res = e.convert_impl(type, simd);
+}
+MIM_EXPORT void mim_ll_finalize(Emitter& e) { e.finalize_impl(); }
+MIM_EXPORT void mim_ll_emit_epilogue(Emitter& e, Lam* lam) { e.emit_epilogue_impl(lam); }
+MIM_EXPORT void mim_ll_emit_bb(Emitter& e, BB& bb, const Def* def, std::string& res) { res = e.emit_bb_impl(bb, def); }
+}
 
 } // namespace mim::plug::ll
 

--- a/src/mim/plug/ll/ll.cpp
+++ b/src/mim/plug/ll/ll.cpp
@@ -54,20 +54,20 @@ public:
 std::string Emitter::convert_impl(const Def* type, bool simd) {
     if (auto i = types_.find(type); i != types_.end()) return i->second;
 
-    assert(!Axm::isa<mem::M>(type));
+    if (Axm::isa<mem::M>(type)) fe::throwf("ll backend: cannot convert %mem.M type '{}'", type);
     std::ostringstream s;
     std::string name;
 
     if (type->isa<Nat>()) {
         return types_[type] = "i64";
-    } else if (auto size = Idx::isa(type)) {
-        return types_[type] = "i" + std::to_string(*Idx::size2bitwidth(size));
+    } else if (Idx::isa(type)) {
+        return types_[type] = "i" + std::to_string(Idx::expect_bitwidth(type, "a statically-sized index type"));
     } else if (auto w = math::isa_f(type)) {
         switch (*w) {
             case 16: return types_[type] = "half";
             case 32: return types_[type] = "float";
             case 64: return types_[type] = "double";
-            default: fe::unreachable();
+            default: fe::throwf("ll backend: unsupported floating-point width {} in type '{}'", *w, type);
         }
     } else if (auto ptr = Axm::isa<mem::Ptr>(type)) {
         auto [pointee, addr_space] = ptr->args<2>();
@@ -82,7 +82,7 @@ std::string Emitter::convert_impl(const Def* type, bool simd) {
             std::print(s, "[{} x {}]", size, convert(arr->body(), false));
         }
     } else if (auto pi = type->isa<Pi>()) {
-        assert(Pi::isa_returning(pi) && "should never have to convert type of BB");
+        if (!Pi::isa_returning(pi)) fe::throwf("ll backend: cannot convert the type of a basic block: '{}'", pi);
         std::print(s, "{} (", convert_ret_pi(pi->ret_pi()));
 
         if (auto t = detail::isa_mem_sigma_2(pi->dom()))
@@ -113,12 +113,12 @@ std::string Emitter::convert_impl(const Def* type, bool simd) {
         }
         std::print(s, "}}");
     } else {
-        fe::unreachable();
+        fe::throwf("ll backend: cannot convert type '{}' to LLVM", type);
     }
 
     if (name.empty()) return types_[type] = s.str();
 
-    assert(!s.str().empty());
+    if (s.str().empty()) fe::throwf("ll backend: empty type declaration for '{}'", type);
     type_decls_ << s.str() << '\n';
     return types_[type] = name;
 }
@@ -136,7 +136,7 @@ void Emitter::finalize_impl() {
 
     for (auto mut : Scheduler::schedule(nest())) {
         if (auto lam = mut->isa_mut<Lam>()) {
-            assert(lam2bb_.contains(lam));
+            if (!lam2bb_.contains(lam)) fe::throwf("ll backend: no basic block was emitted for '{}'", lam);
             auto& bb = lam2bb_[lam];
             std::print(func_impls_, "{}:\n", lam->unique_name());
 
@@ -170,7 +170,7 @@ Fun:
           Cn[M, «2; A», Cn R]  →    1 args + ret
 */
 void Emitter::emit_epilogue_impl(Lam* lam) {
-    auto app = lam->body()->as<App>();
+    auto app = lam->body()->expect<App>("an application in tail position");
     auto& bb = lam2bb_[lam];
     // A target-specific intrinsic in tail position (e.g. %gpu.launch) emits its own code and
     // yields the continuation to branch to.
@@ -283,7 +283,7 @@ void Emitter::emit_epilogue_impl(Lam* lam) {
         auto [msize, ret]          = rest->projs<2>();
         emit_unsafe(msize->proj(0)); // mem
         // TODO array with size
-        auto ret_lam = ret->as_mut<Lam>();
+        auto ret_lam = ret->expect_mut<Lam>("a %mem.slot continuation");
         auto ptr     = ret_lam->var(2, 1);
         auto v_ptr   = emit_slot(bb, app, pointee, addr_space);
         emit_phi(ret_lam, ptr, v_ptr, lam);
@@ -298,12 +298,13 @@ void Emitter::emit_epilogue_impl(Lam* lam) {
 
         if (app->args().back()->isa<Bot>()) {
             // TODO: Perhaps it'd be better to simply η-wrap this prior to the BE...
-            assert(convert_ret_pi(app->callee_type()->ret_pi()) == "void");
+            if (convert_ret_pi(app->callee_type()->ret_pi()) != "void")
+                fe::throwf("ll backend: call with a ⊥ return continuation must return void, but '{}' does not", app);
             bb.tail("call void {}({})", v_callee, fe::Join(args));
             return bb.tail("unreachable");
         }
 
-        auto ret_lam = app->args().back()->as_mut<Lam>();
+        auto ret_lam = app->args().back()->expect_mut<Lam>("a return continuation");
         size_t n     = 0;
         for (auto var : ret_lam->vars())
             if (!Axm::isa<mem::M>(var->type())) ++n;
@@ -408,13 +409,13 @@ std::string Emitter::emit_bb_impl(BB& bb, const Def* def) {
                     break;
                 }
                 case 64: hex = lit->get<u64>(); break;
-                default: fe::unreachable();
+                default: fe::throwf("ll backend: unsupported floating-point width {} for literal '{}'", *w, def);
             }
 
             s << "0x" << std::setfill('0') << std::setw(16) << std::right << std::hex << hex;
             return s.str();
         }
-        fe::unreachable();
+        fe::throwf("ll backend: cannot emit literal '{}' of type '{}'", def, def->type());
     } else if (def->isa<Bot>()) {
         return "undef";
     } else if (auto top = def->isa<Top>()) {
@@ -465,7 +466,8 @@ std::string Emitter::emit_bb_impl(BB& bb, const Def* def) {
                    t_tup, t_tup, name, t_i, v_i);
         return bb.assign(name, "load {}, {}* {}.gep", t_elem, t_elem, name);
     } else if (auto insert = def->isa<Insert>()) {
-        assert(!Axm::isa<mem::M>(insert->tuple()->proj(0)->type()));
+        if (Axm::isa<mem::M>(insert->tuple()->proj(0)->type()))
+            fe::throwf("ll backend: cannot insert into a tuple with a %mem.M element: '{}'", insert);
         auto t_tup = convert(insert->tuple()->type());
         auto t_val = convert(insert->value()->type());
         auto v_tup = emit(insert->tuple());
@@ -483,7 +485,7 @@ std::string Emitter::emit_bb_impl(BB& bb, const Def* def) {
                 auto v_i = emit(insert->index());
                 auto t_i = convert(insert->index()->type());
                 if (t_i != "i32") {
-                    auto w_src = *Idx::size2bitwidth(Idx::isa(insert->index()->type()));
+                    auto w_src = Idx::expect_bitwidth(insert->index()->type(), "an %insert index of known width");
                     v_i        = bb.assign(name + ".idx", "{} {} {} to i32", w_src < 32 ? "zext" : "trunc", t_i, v_i);
                 }
                 return bb.assign(name, "insertelement {} {}, {} {}, i32 {}", t_tup, v_tup, t_val, v_val, v_i);
@@ -500,7 +502,7 @@ std::string Emitter::emit_bb_impl(BB& bb, const Def* def) {
         }
     } else if (auto global = def->isa<Global>()) {
         auto v_init                = emit(global->init());
-        auto [pointee, addr_space] = Axm::as<mem::Ptr>(global->type())->args<2>();
+        auto [pointee, addr_space] = Axm::expect<mem::Ptr>(global->type(), "a %mem.Ptr")->args<2>();
         std::print(vars_decls_, "{} = global {} {}\n", name, convert(pointee), v_init);
         return globals_[global] = name;
     } else if (auto nat = Axm::isa<core::nat>(def)) {
@@ -544,18 +546,18 @@ std::string Emitter::emit_bb_impl(BB& bb, const Def* def) {
             case core::ncmp::l:  op += "ult"; break;
             case core::ncmp::le: op += "ule"; break;
             // clang-format on
-            default: fe::unreachable();
+            default: fe::throwf("ll backend: unhandled %core.ncmp id in '{}'", def);
         }
 
         return bb.assign(name, "{} i64 {}, {}", op, a, b);
     } else if (auto idx = Axm::isa<core::idx>(def)) {
         auto x = emit(idx->arg());
-        auto s = *Idx::size2bitwidth(Idx::isa(idx->type()));
+        auto s = Idx::expect_bitwidth(idx->type(), "a %core.idx result of known width");
         auto t = convert(idx->type());
         if (s < 64) return bb.assign(name, "trunc i64 {} to {}", x, t);
         return x;
     } else if (auto bit1 = Axm::isa<core::bit1>(def)) {
-        assert(bit1.id() == core::bit1::neg);
+        if (bit1.id() != core::bit1::neg) fe::throwf("ll backend: unhandled %core.bit1 id in '{}'", def);
         auto x = emit(bit1->arg());
         auto t = convert(bit1->type());
         return bb.assign(name, "xor {} -1, {}", t, x);
@@ -576,7 +578,7 @@ std::string Emitter::emit_bb_impl(BB& bb, const Def* def) {
             case core::bit2:: iff: return bb.assign(name, "and {} {}, {}", t, neg(a), b);
             case core::bit2::niff: return bb.assign(name, "or  {} {}, {}", t, neg(a), b);
             // clang-format on
-            default: fe::unreachable();
+            default: fe::throwf("ll backend: unhandled %core.bit2 id in '{}'", def);
         }
     } else if (auto shr = Axm::isa<core::shr>(def)) {
         auto [a, b] = shr->args<2>([this](auto def) { return emit(def); });
@@ -592,7 +594,7 @@ std::string Emitter::emit_bb_impl(BB& bb, const Def* def) {
         auto [mode, ab] = wrap->uncurry_args<2>();
         auto [a, b]     = ab->projs<2>([this](auto def) { return emit(def); });
         auto t          = convert(wrap->type());
-        auto lmode      = static_cast<core::Mode>(Lit::as(mode));
+        auto lmode      = static_cast<core::Mode>(Lit::expect(mode, "a %core.wrap mode"));
 
         switch (wrap.id()) {
             case core::wrap::add: op = "add"; break;
@@ -639,7 +641,7 @@ std::string Emitter::emit_bb_impl(BB& bb, const Def* def) {
             case core::icmp::ul:  op += "ult"; break;
             case core::icmp::ule: op += "ule"; break;
             // clang-format on
-            default: fe::unreachable();
+            default: fe::throwf("ll backend: unhandled %core.icmp id in '{}'", def);
         }
 
         return bb.assign(name, "{} {} {}, {}", op, t, a, b);
@@ -670,8 +672,8 @@ std::string Emitter::emit_bb_impl(BB& bb, const Def* def) {
         auto t_src = convert(conv->arg()->type());
         auto t_dst = convert(conv->type());
 
-        nat_t w_src = *Idx::size2bitwidth(Idx::isa(conv->arg()->type()));
-        nat_t w_dst = *Idx::size2bitwidth(Idx::isa(conv->type()));
+        nat_t w_src = Idx::expect_bitwidth(conv->arg()->type(), "a %core.conv source of known width");
+        nat_t w_dst = Idx::expect_bitwidth(conv->type(), "a %core.conv target of known width");
 
         if (w_src == w_dst) return v_src;
 
@@ -697,7 +699,7 @@ std::string Emitter::emit_bb_impl(BB& bb, const Def* def) {
 
         auto size2width = [&](const Def* type) {
             if (type->isa<Nat>()) return 64_n;
-            if (auto size = Idx::isa(type)) return *Idx::size2bitwidth(size);
+            if (Idx::isa(type)) return Idx::expect_bitwidth(type, "a statically-sized index type");
             return 0_n;
         };
 
@@ -712,47 +714,47 @@ std::string Emitter::emit_bb_impl(BB& bb, const Def* def) {
         return bb.assign(name, "{} {} {} to {}", op, t_src, v_src, t_dst);
     } else if (auto lea = Axm::isa<mem::lea>(def)) {
         auto [ptr, i]  = lea->args<2>();
-        auto pointee   = Axm::as<mem::Ptr>(ptr->type())->arg(0);
+        auto pointee   = Axm::expect<mem::Ptr>(ptr->type(), "a %mem.Ptr")->arg(0);
         auto v_ptr     = emit(ptr);
         auto t_pointee = convert(pointee);
         auto t_ptr     = convert(ptr->type());
         if (pointee->isa<Sigma>())
             return bb.assign(name, "getelementptr inbounds {}, {} {}, i64 0, i32 {}", t_pointee, t_ptr, v_ptr,
-                             Lit::as(i));
+                             Lit::expect(i, "a struct-field index"));
 
-        assert(pointee->isa<Arr>());
+        if (!pointee->isa<Arr>()) fe::throwf("ll backend: %mem.lea on a pointer to a non-aggregate '{}'", pointee);
         auto [v_i, t_i] = emit_gep_index(i);
 
         return bb.assign(name, "getelementptr inbounds {}, {} {}, i64 0, {} {}", t_pointee, t_ptr, v_ptr, t_i, v_i);
     } else if (auto malloc = Axm::isa<mem::malloc>(def)) {
         auto address_space = malloc->decurry()->arg(1);
-        if (Lit::as(address_space) != 0)
+        if (Lit::expect(address_space, "an address space") != 0)
             if (auto target_specific = isa_targetspecific_intrinsic(bb, def)) return target_specific.value();
 
         declare("i8* @malloc(i64)");
 
         emit_unsafe(malloc->arg(0));
         auto size           = emit(malloc->arg(1));
-        auto ptr_t          = convert(Axm::as<mem::Ptr>(def->proj(1)->type()));
+        auto ptr_t          = convert(Axm::expect<mem::Ptr>(def->proj(1)->type(), "a %mem.Ptr"));
         auto i8ptr          = bb.assign(name + "i8", "call i8* @malloc(i64 {})", size);
         std::string i8ptr_t = "i8*";
-        if (Lit::as(address_space) != 0) {
+        if (Lit::expect(address_space, "an address space") != 0) {
             i8ptr_t = std::format("i8 addrspace({})*", address_space);
             i8ptr   = bb.assign(name + "i8conv", "addrspacecast i8* {} to {}", i8ptr, i8ptr_t);
         }
         return bb.assign(name, "bitcast {} {} to {}", i8ptr_t, i8ptr, ptr_t);
     } else if (auto free = Axm::isa<mem::free>(def)) {
         auto address_space = free->decurry()->arg(1);
-        if (Lit::as(address_space) != 0)
+        if (Lit::expect(address_space, "an address space") != 0)
             if (auto target_specific = isa_targetspecific_intrinsic(bb, def)) return {};
 
         declare("void @free(i8*)");
         emit_unsafe(free->arg(0));
         auto ptr   = emit(free->arg(1));
-        auto ptr_t = convert(Axm::as<mem::Ptr>(free->arg(1)->type()));
+        auto ptr_t = convert(Axm::expect<mem::Ptr>(free->arg(1)->type(), "a %mem.Ptr"));
 
         auto i8ptr = bb.assign(name + "i8", "bitcast {} {} to i8 addrspace({})*", ptr_t, ptr, address_space);
-        if (Lit::as(address_space) != 0)
+        if (Lit::expect(address_space, "an address space") != 0)
             i8ptr = bb.assign(name + "i8conv", "addrspacecast i8 addrspace({})* {} to i8*", address_space, i8ptr);
         bb.tail("call void @free(i8* {})", i8ptr);
         return {};
@@ -760,7 +762,7 @@ std::string Emitter::emit_bb_impl(BB& bb, const Def* def) {
         emit_unsafe(load->arg(0));
         auto v_ptr     = emit(load->arg(1));
         auto t_ptr     = convert(load->arg(1)->type());
-        auto t_pointee = convert(Axm::as<mem::Ptr>(load->arg(1)->type())->arg(0), false);
+        auto t_pointee = convert(Axm::expect<mem::Ptr>(load->arg(1)->type(), "a %mem.Ptr")->arg(0), false);
         return bb.assign(name, "load {}, {} {}", t_pointee, t_ptr, v_ptr);
     } else if (auto store = Axm::isa<mem::store>(def)) {
         emit_unsafe(store->arg(0));
@@ -788,7 +790,7 @@ std::string Emitter::emit_bb_impl(BB& bb, const Def* def) {
         auto [mode, ab] = arith->uncurry_args<2>();
         auto [a, b]     = ab->projs<2>([this](auto def) { return emit(def); });
         auto t          = convert(arith->type());
-        auto lmode      = static_cast<math::Mode>(Lit::as(mode));
+        auto lmode      = static_cast<math::Mode>(Lit::expect(mode, "a %math.arith mode"));
 
         switch (arith.id()) {
             case math::arith::add: op = "fadd"; break;
@@ -830,8 +832,8 @@ std::string Emitter::emit_bb_impl(BB& bb, const Def* def) {
                 case math::tri::sin: f += "sin"; break;
                 case math::tri::cos: f += "cos"; break;
                 case math::tri::tan: f += "tan"; break;
-                case math::tri::ahFF: error("this axm is supposed to be unused");
-                default: fe::unreachable();
+                case math::tri::ahFF: fe::throwf("this axm is supposed to be unused");
+                default: fe::throwf("ll backend: unhandled %math.tri id in '{}'", def);
             }
 
             if (tri.sub() & sub_t(math::tri::h)) f += "h";
@@ -917,7 +919,7 @@ std::string Emitter::emit_bb_impl(BB& bb, const Def* def) {
             case math::cmp::uge: op += "uge"; break;
             case math::cmp::une: op += "une"; break;
             // clang-format on
-            default: fe::unreachable();
+            default: fe::throwf("ll backend: unhandled %math.cmp id in '{}'", def);
         }
 
         return bb.assign(name, "{} {} {}, {}", op, t, a, b);
@@ -971,7 +973,7 @@ std::string Emitter::emit_bb_impl(BB& bb, const Def* def) {
         return bb.assign(name, "tail call {} @{}({} {})", t, f, t, a);
     } else if (auto zip = Axm::isa<vec::zip>(def)) {
         auto ni_n   = zip->decurry()->decurry()->decurry()->arg();
-        auto nat_ni = *Lit::isa(ni_n->proj(2, 0));
+        auto nat_ni = Lit::expect(ni_n->proj(2, 0), "a %vec.zip lane count");
         auto f      = zip->decurry()->arg();
         auto inputs = zip->arg();
         auto t_in   = convert(inputs->proj(nat_ni, 0)->type());
@@ -997,7 +999,8 @@ std::string Emitter::emit_bb_impl(BB& bb, const Def* def) {
                 case core::nat::mod: op = "urem"; break;
             }
         } else if (auto arith_op = Axm::isa<math::arith, 1>(f)) {
-            auto lmode = static_cast<math::Mode>(Lit::as(f->as<App>()->arg()));
+            auto lmode = static_cast<math::Mode>(
+                Lit::expect(f->expect<App>("a zipped %math.arith")->arg(), "a %math.arith mode"));
             switch (arith_op.id()) {
                 case math::arith::add: op = "fadd"; break;
                 case math::arith::sub: op = "fsub"; break;
@@ -1026,7 +1029,7 @@ std::string Emitter::emit_bb_impl(BB& bb, const Def* def) {
                 case core::ncmp::ge: op += "uge"; break;
                 case core::ncmp::l: op += "ult"; break;
                 case core::ncmp::le: op += "ule"; break;
-                default: fe::unreachable();
+                default: fe::throwf("ll backend: unhandled zipped %core.ncmp id in '{}'", def);
             }
         } else if (auto icmp_op = Axm::isa<core::icmp, 1>(f)) {
             op = "icmp ";
@@ -1041,7 +1044,7 @@ std::string Emitter::emit_bb_impl(BB& bb, const Def* def) {
                 case core::icmp::uge: op += "uge"; break;
                 case core::icmp::ul: op += "ult"; break;
                 case core::icmp::ule: op += "ule"; break;
-                default: fe::unreachable();
+                default: fe::throwf("ll backend: unhandled zipped %core.icmp id in '{}'", def);
             }
         } else if (auto mcmp_op = Axm::isa<math::cmp, 1>(f)) {
             op = "fcmp ";
@@ -1060,10 +1063,10 @@ std::string Emitter::emit_bb_impl(BB& bb, const Def* def) {
                 case math::cmp::ug: op += "ugt"; break;
                 case math::cmp::uge: op += "uge"; break;
                 case math::cmp::une: op += "une"; break;
-                default: fe::unreachable();
+                default: fe::throwf("ll backend: unhandled zipped %math.cmp id in '{}'", def);
             }
         } else {
-            error("unhandled vec.zip operation: {}", f);
+            fe::throwf("unhandled vec.zip operation: {}", f);
         }
 
         auto v1 = emit(inputs->proj(nat_ni, 0));
@@ -1073,7 +1076,7 @@ std::string Emitter::emit_bb_impl(BB& bb, const Def* def) {
     } else if (auto res = isa_targetspecific_intrinsic(bb, def)) {
         return res.value();
     }
-    error("unhandled def in LLVM backend: {} : {}", def, def->type());
+    fe::throwf("unhandled def in LLVM backend: {} : {}", def, def->type());
 }
 
 extern "C" {

--- a/src/mim/plug/ll/ll.cpp
+++ b/src/mim/plug/ll/ll.cpp
@@ -172,6 +172,9 @@ Fun:
 void Emitter::emit_epilogue_impl(Lam* lam) {
     auto app = lam->body()->as<App>();
     auto& bb = lam2bb_[lam];
+    // A target-specific intrinsic in tail position (e.g. %gpu.launch) emits its own code and
+    // yields the continuation to branch to.
+    if (auto ret = isa_targetspecific_intrinsic(bb, app)) return bb.tail("br label {}", *ret);
     if (app->callee() == root()->ret_var()) { // return
         Vector<std::string> values;
         DefVec types;
@@ -282,8 +285,7 @@ void Emitter::emit_epilogue_impl(Lam* lam) {
         // TODO array with size
         auto ret_lam = ret->as_mut<Lam>();
         auto ptr     = ret_lam->var(2, 1);
-        auto v_ptr   = "%" + app->unique_name() + ".slot";
-        std::print(bb.body().emplace_back(), "{} = alloca {}", v_ptr, convert(pointee, false));
+        auto v_ptr   = emit_slot(bb, app, pointee, addr_space);
         emit_phi(ret_lam, ptr, v_ptr, lam);
         return bb.tail("br label {}", id(ret_lam));
     } else if (Pi::isa_returning(app->callee_type())) { // function call

--- a/src/mim/plug/ll_nvptx/ll_nvptx.cpp
+++ b/src/mim/plug/ll_nvptx/ll_nvptx.cpp
@@ -40,13 +40,13 @@ public:
 /// Locates @p name on the system or throws CmdNotFound.
 std::string require_cmd(std::string_view name) {
     auto cmd = sys::find_cmd(std::string(name));
-    if (!std::filesystem::exists(cmd)) error<CmdNotFound>("Could not find command: {} {}", name, cmd);
+    if (!std::filesystem::exists(cmd)) fe::throwf<CmdNotFound>("Could not find command: {} {}", name, cmd);
     return cmd;
 }
 
 /// Runs @p cmd and throws if it exits with a non-zero status.
 void run_cmd(const std::string& cmd) {
-    if (auto rc = sys::system(cmd); rc != 0) error("Command exited with error code {}", rc);
+    if (auto rc = sys::system(cmd); rc != 0) fe::throwf("Command exited with error code {}", rc);
 }
 
 constexpr auto Default_Compute_Cap = "75";
@@ -123,11 +123,11 @@ std::string find_libdevice() {
     auto debian_fallback = std::filesystem::path("/usr/lib/nvidia-cuda-toolkit/libdevice/") / Libdevice_Name;
     if (std::filesystem::exists(debian_fallback)) return debian_fallback.string();
 
-    error<CmdNotFound>("Unable to find '{}'. Try setting the CUDA_HOME environment variable.", Libdevice_Name);
+    fe::throwf<CmdNotFound>("Unable to find '{}'. Try setting the CUDA_HOME environment variable.", Libdevice_Name);
 }
 
 void link_libdevice(const NvptxCompileArgs& c) {
-    if (!std::filesystem::exists(c.libdevice_path)) error("libdevice path does not exist: {}", c.libdevice_path);
+    if (!std::filesystem::exists(c.libdevice_path)) fe::throwf("libdevice path does not exist: {}", c.libdevice_path);
     auto llvm_link = require_cmd("llvm-link");
     run_cmd(std::format("{} {} {} {} -o {}", llvm_link, c.link_llvm_args, c.dev_ll_name, c.libdevice_path,
                         c.dev_bc_raw_name));
@@ -205,7 +205,7 @@ public:
         }
 
         auto split_apply_phase = Phase::create(world().driver().phases(), world().annex<gpu::split_apply>());
-        auto setup_phase       = split_apply_phase.get()->as<RWPhase>();
+        auto setup_phase       = split_apply_phase.get()->expect<RWPhase>("%gpu.split_apply to be an RWPhase");
         setup_phase->run();
 
         DeviceEmitFlags device_flags;
@@ -214,7 +214,8 @@ public:
             device_flags = emit_device(setup_phase->new_world(), dev_ofs);
         }
         if (c.embed_device_code) {
-            if (!c.embed_ptx && !c.embed_cubin) error("Embedding requested with no images (neither PTX nor CUBIN).");
+            if (!c.embed_ptx && !c.embed_cubin)
+                fe::throwf("Embedding requested with no images (neither PTX nor CUBIN).");
             try {
                 if (c.compute_cap.empty()) c.compute_cap = get_compute_capability();
                 if (device_flags.uses_libdevice) {

--- a/src/mim/plug/ll_nvptx/ll_nvptx.cpp
+++ b/src/mim/plug/ll_nvptx/ll_nvptx.cpp
@@ -31,28 +31,10 @@ struct NvptxCompileArgs {
                                 fatbinary_args;
 };
 
-class CmdNotFound : public std::logic_error {
-public:
-    CmdNotFound(const std::string& s)
-        : std::logic_error(s) {}
-};
-
-/// Locates @p name on the system or throws CmdNotFound.
-std::string require_cmd(std::string_view name) {
-    auto cmd = sys::find_cmd(std::string(name));
-    if (!std::filesystem::exists(cmd)) fe::throwf<CmdNotFound>("Could not find command: {} {}", name, cmd);
-    return cmd;
-}
-
-/// Runs @p cmd and throws if it exits with a non-zero status.
-void run_cmd(const std::string& cmd) {
-    if (auto rc = sys::system(cmd); rc != 0) fe::throwf("Command exited with error code {}", rc);
-}
-
 constexpr auto Default_Compute_Cap = "75";
 
 std::string get_compute_capability() {
-    auto nvidia_smi = require_cmd("nvidia-smi");
+    auto nvidia_smi = sys::require_cmd("nvidia-smi");
     auto out        = sys::exec(std::format("{} --query-gpu=compute_cap --format=csv,noheader", nvidia_smi));
     std::erase_if(out, ::isspace);
     // out should now have form "7.5" referencing the compute capability "sm_75"
@@ -123,36 +105,37 @@ std::string find_libdevice() {
     auto debian_fallback = std::filesystem::path("/usr/lib/nvidia-cuda-toolkit/libdevice/") / Libdevice_Name;
     if (std::filesystem::exists(debian_fallback)) return debian_fallback.string();
 
-    fe::throwf<CmdNotFound>("Unable to find '{}'. Try setting the CUDA_HOME environment variable.", Libdevice_Name);
+    fe::throwf<sys::CmdNotFound>("Unable to find '{}'. Try setting the CUDA_HOME environment variable.",
+                                 Libdevice_Name);
 }
 
 void link_libdevice(const NvptxCompileArgs& c) {
     if (!std::filesystem::exists(c.libdevice_path)) fe::throwf("libdevice path does not exist: {}", c.libdevice_path);
-    auto llvm_link = require_cmd("llvm-link");
-    run_cmd(std::format("{} {} {} {} -o {}", llvm_link, c.link_llvm_args, c.dev_ll_name, c.libdevice_path,
-                        c.dev_bc_raw_name));
+    auto llvm_link = sys::require_cmd("llvm-link");
+    sys::require_run(std::format("{} {} {} {} -o {}", llvm_link, c.link_llvm_args, c.dev_ll_name, c.libdevice_path,
+                                 c.dev_bc_raw_name));
 }
 
 void optimize_bytecode(const NvptxCompileArgs& c) {
-    auto opt = require_cmd("opt");
-    run_cmd(std::format("{} {} {} -o {}", opt, c.opt_args, c.dev_bc_raw_name, c.dev_bc_opt_name));
+    auto opt = sys::require_cmd("opt");
+    sys::require_run(std::format("{} {} {} -o {}", opt, c.opt_args, c.dev_bc_raw_name, c.dev_bc_opt_name));
 }
 
 void compile2ptx(const NvptxCompileArgs& c, bool uses_libdevice) {
     auto compile_input = uses_libdevice ? c.dev_bc_opt_name : c.dev_ll_name;
-    auto llc           = require_cmd("llc");
-    run_cmd(std::format("{} -march=nvptx64 -mcpu=sm_{} {} {} -o {}", llc, c.compute_cap, c.llc_args, compile_input,
-                        c.dev_ptx_name));
+    auto llc           = sys::require_cmd("llc");
+    sys::require_run(std::format("{} -march=nvptx64 -mcpu=sm_{} {} {} -o {}", llc, c.compute_cap, c.llc_args,
+                                 compile_input, c.dev_ptx_name));
 }
 
 void compile2cubin(const NvptxCompileArgs& c) {
-    auto ptxas = require_cmd("ptxas");
-    run_cmd(std::format("{} -arch=sm_{} {} {} -o {}", ptxas, c.compute_cap, c.ptxas_args, c.dev_ptx_name,
-                        c.dev_cubin_name));
+    auto ptxas = sys::require_cmd("ptxas");
+    sys::require_run(std::format("{} -arch=sm_{} {} {} -o {}", ptxas, c.compute_cap, c.ptxas_args, c.dev_ptx_name,
+                                 c.dev_cubin_name));
 }
 
 void compile2fatbin(const NvptxCompileArgs& c) {
-    auto fatbinary = require_cmd("fatbinary");
+    auto fatbinary = sys::require_cmd("fatbinary");
     auto ptx_args  = ""s;
     if (c.embed_ptx) {
         ptx_args = std::format("--image3=kind=ptx,sm={},file={}", c.compute_cap, c.dev_ptx_name);
@@ -160,8 +143,8 @@ void compile2fatbin(const NvptxCompileArgs& c) {
     }
     auto cubin_args = ""s;
     if (c.embed_cubin) cubin_args = std::format("--image3=kind=elf,sm={},file={}", c.compute_cap, c.dev_cubin_name);
-    run_cmd(std::format("{} --create={} -64 {} {} {}", fatbinary, c.dev_fatbin_name, c.fatbinary_args, ptx_args,
-                        cubin_args));
+    sys::require_run(std::format("{} --create={} -64 {} {} {}", fatbinary, c.dev_fatbin_name, c.fatbinary_args,
+                                 ptx_args, cubin_args));
 }
 
 } // namespace
@@ -226,7 +209,7 @@ public:
                 compile2ptx(c, device_flags.uses_libdevice);
                 compile2cubin(c);
                 compile2fatbin(c);
-            } catch (const CmdNotFound& e) {
+            } catch (const sys::CmdNotFound& e) {
                 WLOG("{}", e.what());
                 WLOG("Falling back to not embedding device code.");
                 c.embed_device_code = false;

--- a/src/mim/plug/ll_nvptx/ll_nvptx.cpp
+++ b/src/mim/plug/ll_nvptx/ll_nvptx.cpp
@@ -49,7 +49,7 @@ void run_cmd(const std::string& cmd) {
     if (auto rc = sys::system(cmd); rc != 0) error("Command exited with error code {}", rc);
 }
 
-constexpr auto default_compute_cap = "75";
+constexpr auto Default_Compute_Cap = "75";
 
 std::string get_compute_capability() {
     auto nvidia_smi = require_cmd("nvidia-smi");
@@ -60,16 +60,16 @@ std::string get_compute_capability() {
     auto dot_pos = out.find('.');
     if (dot_pos == std::string::npos) {
         std::println(std::cerr, "Could not determine compute capability, continuing with default: '{}'.",
-                     default_compute_cap);
-        return default_compute_cap;
+                     Default_Compute_Cap);
+        return Default_Compute_Cap;
     }
 
     for (size_t i = 0; i < out.size(); ++i) {
         if (i == dot_pos) continue;
         if (!std::isdigit(out[i])) {
             std::println(std::cerr, "Could not determine compute capability, continuing with default: '{}'.",
-                         default_compute_cap);
-            return default_compute_cap;
+                         Default_Compute_Cap);
+            return Default_Compute_Cap;
         }
     }
 
@@ -78,7 +78,7 @@ std::string get_compute_capability() {
     return compute_cap;
 }
 
-constexpr auto LIBDEVICE_NAME = "libdevice.10.bc"sv;
+constexpr auto Libdevice_Name = "libdevice.10.bc"sv;
 
 std::optional<std::filesystem::path> parse_nvcc_profile(const std::filesystem::path& cuda_bin_path) {
     auto profile_path = cuda_bin_path / "nvcc.profile";
@@ -103,7 +103,7 @@ std::optional<std::filesystem::path> parse_nvcc_profile(const std::filesystem::p
         }
     }
     if (top_dir.empty() || lib_dir.empty()) return std::nullopt;
-    auto path          = cuda_bin_path / top_dir / lib_dir / LIBDEVICE_NAME;
+    auto path          = cuda_bin_path / top_dir / lib_dir / Libdevice_Name;
     auto resolved_path = path.lexically_normal();
     if (!std::filesystem::exists(resolved_path)) return std::nullopt;
     return resolved_path;
@@ -117,13 +117,13 @@ std::string find_libdevice() {
         if (auto libdevice_path = parse_nvcc_profile(cuda_bin_path)) return libdevice_path->string();
     }
     if (const char* cuda_home_env = std::getenv("CUDA_HOME")) {
-        auto libdevice_path = std::filesystem::path(cuda_home_env) / "nvvm" / "libdevice" / LIBDEVICE_NAME;
+        auto libdevice_path = std::filesystem::path(cuda_home_env) / "nvvm" / "libdevice" / Libdevice_Name;
         if (std::filesystem::exists(libdevice_path)) return libdevice_path.string();
     }
-    auto debian_fallback = std::filesystem::path("/usr/lib/nvidia-cuda-toolkit/libdevice/") / LIBDEVICE_NAME;
+    auto debian_fallback = std::filesystem::path("/usr/lib/nvidia-cuda-toolkit/libdevice/") / Libdevice_Name;
     if (std::filesystem::exists(debian_fallback)) return debian_fallback.string();
 
-    error<CmdNotFound>("Unable to find '{}'. Try setting the CUDA_HOME environment variable.", LIBDEVICE_NAME);
+    error<CmdNotFound>("Unable to find '{}'. Try setting the CUDA_HOME environment variable.", Libdevice_Name);
 }
 
 void link_libdevice(const NvptxCompileArgs& c) {

--- a/src/mim/plug/ll_nvptx/ll_nvptx.cpp
+++ b/src/mim/plug/ll_nvptx/ll_nvptx.cpp
@@ -19,10 +19,16 @@ namespace {
 struct NvptxCompileArgs {
     std::string host_ll_name, dev_ll_name, dev_ptx_name, dev_cubin_name, dev_fatbin_name, dev_bc_raw_name,
         dev_bc_opt_name;
-    bool embed_device_code, embed_ptx, embed_cubin;
-    std::string compute_cap;
-    std::string libdevice_path;
-    std::string link_llvm_args, opt_args, llc_args, ptxas_args, fatbinary_args;
+#ifdef __linux__
+    bool embed_device_code = true;
+#else
+    bool embed_device_code = false;
+#endif
+    bool embed_ptx   = true;
+    bool embed_cubin = true;
+    std::string compute_cap, libdevice_path;
+    std::string link_llvm_args, opt_args = R"(-passes="default<O2>,nvvm-reflect")", llc_args, ptxas_args,
+                                fatbinary_args;
 };
 
 class CmdNotFound : public std::logic_error {
@@ -31,13 +37,24 @@ public:
         : std::logic_error(s) {}
 };
 
+/// Locates @p name on the system or throws CmdNotFound.
+std::string require_cmd(std::string_view name) {
+    auto cmd = sys::find_cmd(std::string(name));
+    if (!std::filesystem::exists(cmd)) error<CmdNotFound>("Could not find command: {} {}", name, cmd);
+    return cmd;
+}
+
+/// Runs @p cmd and throws if it exits with a non-zero status.
+void run_cmd(const std::string& cmd) {
+    if (auto rc = sys::system(cmd); rc != 0) error("Command exited with error code {}", rc);
+}
+
 constexpr auto default_compute_cap = "75";
 
 std::string get_compute_capability() {
-    auto nvidia_smi = sys::find_cmd("nvidia-smi");
-    if (!std::filesystem::exists(nvidia_smi)) error<CmdNotFound>("Could not find command: nvidia-smi {}", nvidia_smi);
-    auto out = sys::exec(std::format("{} --query-gpu=compute_cap --format=csv,noheader", nvidia_smi));
-    out.erase(std::remove_if(out.begin(), out.end(), ::isspace), out.end());
+    auto nvidia_smi = require_cmd("nvidia-smi");
+    auto out        = sys::exec(std::format("{} --query-gpu=compute_cap --format=csv,noheader", nvidia_smi));
+    std::erase_if(out, ::isspace);
     // out should now have form "7.5" referencing the compute capability "sm_75"
 
     auto dot_pos = out.find('.');
@@ -70,18 +87,16 @@ std::optional<std::filesystem::path> parse_nvcc_profile(const std::filesystem::p
     std::ifstream file(profile_path);
     if (!file.is_open()) return std::nullopt;
 
-    std::string line;
-    std::string top_dir = "";
-    std::string lib_dir = "";
+    std::string line, top_dir, lib_dir;
 
     while (std::getline(file, line)) {
-        line.erase(std::remove_if(line.begin(), line.end(), ::isspace), line.end());
+        std::erase_if(line, ::isspace);
         if (line.starts_with("TOP=")) {
             auto macro_pos = line.find("$(_HERE_)/");
             if (macro_pos == std::string::npos) break;
             top_dir = line.substr(macro_pos + 10);
         }
-        if (line.rfind("NVVMIR_LIBRARY_DIR=", 0) == 0) {
+        if (line.starts_with("NVVMIR_LIBRARY_DIR=")) {
             auto macro_pos = line.find("$(TOP)/");
             if (macro_pos == std::string::npos) break;
             lib_dir = line.substr(macro_pos + 7);
@@ -113,56 +128,40 @@ std::string find_libdevice() {
 
 void link_libdevice(const NvptxCompileArgs& c) {
     if (!std::filesystem::exists(c.libdevice_path)) error("libdevice path does not exist: {}", c.libdevice_path);
-    auto llvm_link = sys::find_cmd("llvm-link");
-    if (!std::filesystem::exists(llvm_link)) error<CmdNotFound>("Could not find command: llvm-link {}", llvm_link);
-    auto cmd = std::format("{} {} {} {} -o {}", llvm_link, c.link_llvm_args, c.dev_ll_name, c.libdevice_path,
-                           c.dev_bc_raw_name);
-    auto rc  = sys::system(cmd);
-    if (rc != 0) error("Command exited with error code {}", rc);
+    auto llvm_link = require_cmd("llvm-link");
+    run_cmd(std::format("{} {} {} {} -o {}", llvm_link, c.link_llvm_args, c.dev_ll_name, c.libdevice_path,
+                        c.dev_bc_raw_name));
 }
 
 void optimize_bytecode(const NvptxCompileArgs& c) {
-    auto opt = sys::find_cmd("opt");
-    if (!std::filesystem::exists(opt)) error<CmdNotFound>("Could not find command: opt {}", opt);
-    auto cmd = std::format("{} {} {} -o {}", opt, c.opt_args, c.dev_bc_raw_name, c.dev_bc_opt_name);
-    auto rc  = sys::system(cmd);
-    if (rc != 0) error("Command exited with error code {}", rc);
+    auto opt = require_cmd("opt");
+    run_cmd(std::format("{} {} {} -o {}", opt, c.opt_args, c.dev_bc_raw_name, c.dev_bc_opt_name));
 }
 
 void compile2ptx(const NvptxCompileArgs& c, bool uses_libdevice) {
     auto compile_input = uses_libdevice ? c.dev_bc_opt_name : c.dev_ll_name;
-    auto llc           = sys::find_cmd("llc");
-    if (!std::filesystem::exists(llc)) error<CmdNotFound>("Could not find command: llc {}", llc);
-    auto cmd = std::format("{} -march=nvptx64 -mcpu=sm_{} {} {} -o {}", llc, c.compute_cap, c.llc_args, compile_input,
-                           c.dev_ptx_name);
-    auto rc  = sys::system(cmd);
-    if (rc != 0) error("Command exited with error code {}", rc);
+    auto llc           = require_cmd("llc");
+    run_cmd(std::format("{} -march=nvptx64 -mcpu=sm_{} {} {} -o {}", llc, c.compute_cap, c.llc_args, compile_input,
+                        c.dev_ptx_name));
 }
 
 void compile2cubin(const NvptxCompileArgs& c) {
-    auto ptxas = sys::find_cmd("ptxas");
-    if (!std::filesystem::exists(ptxas)) error<CmdNotFound>("Could not find command: ptxas {}", ptxas);
-    auto cmd = std::format("{} -arch=sm_{} {} {} -o {}", ptxas, c.compute_cap, c.ptxas_args, c.dev_ptx_name,
-                           c.dev_cubin_name);
-    auto rc  = sys::system(cmd);
-    if (rc != 0) error("Command exited with error code {}", rc);
+    auto ptxas = require_cmd("ptxas");
+    run_cmd(std::format("{} -arch=sm_{} {} {} -o {}", ptxas, c.compute_cap, c.ptxas_args, c.dev_ptx_name,
+                        c.dev_cubin_name));
 }
 
 void compile2fatbin(const NvptxCompileArgs& c) {
-    auto fatbinary = sys::find_cmd("fatbinary");
-    if (!std::filesystem::exists(fatbinary)) error<CmdNotFound>("Could not find command: fatbinary {}", fatbinary);
-    std::vector<std::string> args;
-    auto ptx_args = ""s;
+    auto fatbinary = require_cmd("fatbinary");
+    auto ptx_args  = ""s;
     if (c.embed_ptx) {
         ptx_args = std::format("--image3=kind=ptx,sm={},file={}", c.compute_cap, c.dev_ptx_name);
         if (!c.ptxas_args.empty()) ptx_args += std::format(" --cmdline={}", c.ptxas_args);
     }
     auto cubin_args = ""s;
     if (c.embed_cubin) cubin_args = std::format("--image3=kind=elf,sm={},file={}", c.compute_cap, c.dev_cubin_name);
-    auto cmd = std::format("{} --create={} -64 {} {} {}", fatbinary, c.dev_fatbin_name, c.fatbinary_args, ptx_args,
-                           cubin_args);
-    auto rc  = sys::system(cmd);
-    if (rc != 0) error("Command exited with error code {}", rc);
+    run_cmd(std::format("{} --create={} -64 {} {} {}", fatbinary, c.dev_fatbin_name, c.fatbinary_args, ptx_args,
+                        cubin_args));
 }
 
 } // namespace
@@ -175,60 +174,34 @@ public:
     void start() override {
         auto name = world().name() ? std::string(world().name().view()) : "a"s;
 
-        auto c = NvptxCompileArgs{
-            .host_ll_name    = name + ".ll"s,
-            .dev_ll_name     = name + "_dev.ll"s,
-            .dev_ptx_name    = name + "_dev.ptx"s,
-            .dev_cubin_name  = name + "_dev.cubin"s,
-            .dev_fatbin_name = name + "_dev.fatbin"s,
-            .dev_bc_raw_name = name + "_dev_raw.bc"s,
-            .dev_bc_opt_name = name + "_dev_opt.bc"s,
-#ifdef __linux__
-            .embed_device_code = true,
-#else
-            .embed_device_code = false,
-#endif
-            .embed_ptx      = true,
-            .embed_cubin    = true,
-            .compute_cap    = ""s,
-            .libdevice_path = ""s,
-            .link_llvm_args = ""s,
-            .opt_args       = "-passes=\"default<O2>,nvvm-reflect\""s,
-            .llc_args       = ""s,
-            .ptxas_args     = ""s,
-            .fatbinary_args = ""s,
-        };
+        auto c            = NvptxCompileArgs{};
+        c.host_ll_name    = name + ".ll"s;
+        c.dev_ll_name     = name + "_dev.ll"s;
+        c.dev_ptx_name    = name + "_dev.ptx"s;
+        c.dev_cubin_name  = name + "_dev.cubin"s;
+        c.dev_fatbin_name = name + "_dev.fatbin"s;
+        c.dev_bc_raw_name = name + "_dev_raw.bc"s;
+        c.dev_bc_opt_name = name + "_dev_opt.bc"s;
 
         for (const auto& arg : args()) {
             world().DLOG("ll backend arg: `{}`", arg);
-            if (arg.starts_with("o="))
-                c.host_ll_name = arg.substr(2);
-            else if (arg.starts_with("output="))
-                c.host_ll_name = arg.substr(7);
-            else if (arg.starts_with("o-dev="))
-                c.dev_ll_name = arg.substr(6);
-            else if (arg.starts_with("output-dev="))
-                c.dev_ll_name = arg.substr(11);
-            else if (arg == "no-embed")
-                c.embed_device_code = false;
-            else if (arg == "no-ptx-embed")
-                c.embed_ptx = false;
-            else if (arg == "no-cubin-embed")
-                c.embed_cubin = false;
-            else if (arg.starts_with("sm="))
-                c.compute_cap = arg.substr(3);
-            else if (arg.starts_with("libdevice="))
-                c.libdevice_path = arg.substr(10);
-            else if (arg.starts_with("Xlink_llvm="))
-                c.link_llvm_args = arg.substr(11);
-            else if (arg.starts_with("Xopt="))
-                c.opt_args = arg.substr(5);
-            else if (arg.starts_with("Xllc="))
-                c.llc_args = arg.substr(5);
-            else if (arg.starts_with("Xptxas="))
-                c.ptxas_args = arg.substr(7);
-            else if (arg.starts_with("Xfatbinary="))
-                c.fatbinary_args = arg.substr(11);
+            // clang-format off
+            if (false) {}
+            else if (arg.starts_with("o="))          c.host_ll_name      = arg.substr(2);
+            else if (arg.starts_with("output="))     c.host_ll_name      = arg.substr(7);
+            else if (arg.starts_with("o-dev="))      c.dev_ll_name       = arg.substr(6);
+            else if (arg.starts_with("output-dev=")) c.dev_ll_name       = arg.substr(11);
+            else if (arg.starts_with("sm="))         c.compute_cap       = arg.substr(3);
+            else if (arg.starts_with("libdevice="))  c.libdevice_path    = arg.substr(10);
+            else if (arg.starts_with("Xlink_llvm=")) c.link_llvm_args    = arg.substr(11);
+            else if (arg.starts_with("Xopt="))       c.opt_args          = arg.substr(5);
+            else if (arg.starts_with("Xllc="))       c.llc_args          = arg.substr(5);
+            else if (arg.starts_with("Xptxas="))     c.ptxas_args        = arg.substr(7);
+            else if (arg.starts_with("Xfatbinary=")) c.fatbinary_args    = arg.substr(11);
+            else if (arg == "no-embed")              c.embed_device_code = false;
+            else if (arg == "no-ptx-embed")          c.embed_ptx         = false;
+            else if (arg == "no-cubin-embed")        c.embed_cubin       = false;
+            // clang-format on
         }
 
         auto split_apply_phase = Phase::create(world().driver().phases(), world().annex<gpu::split_apply>());

--- a/src/mim/plug/ll_nvptx/phase/ll_nvptx.cpp
+++ b/src/mim/plug/ll_nvptx/phase/ll_nvptx.cpp
@@ -31,8 +31,6 @@ public:
     void start() final;
     void find_kernels(const Def*);
 
-    void emit_epilogue(Lam*) final;
-
     std::optional<std::string> isa_targetspecific_intrinsic(ll::BB&, const Def*) final;
 
 protected:
@@ -61,7 +59,6 @@ public:
         : Super(world, "llvm_nvptx_device_emitter", ostream) {}
 
     void start() final;
-    void emit_epilogue(Lam*) override;
 
     std::string prepare() override;
 
@@ -74,6 +71,13 @@ private:
     std::string convert(const Def* def, bool simd = false) override {
         if (simd) WLOG("Ignoring simd=true for type conversion in device code.");
         return Super::convert(def, false);
+    }
+
+    /// Device slots live in a module-scope global in their requested address space, not on the stack.
+    std::string emit_slot(ll::BB&, const App* app, const Def* pointee, const Def* addr_space) override {
+        auto v_ptr = "@" + app->unique_name() + ".slot";
+        std::print(vars_decls_, "{} = internal addrspace({}) global {} undef\n", v_ptr, addr_space, convert(pointee));
+        return v_ptr;
     }
 
     absl::btree_map<std::string, int> symbols_;
@@ -116,27 +120,27 @@ void HostEmitter::find_kernels(const Def* def) {
     }
 }
 
-constexpr auto CU_INIT                = "cuInit";
-constexpr auto CU_CTX_CREATE          = "cuCtxCreate_v4";
-constexpr auto CU_CTX_DESTROY         = "cuCtxDestroy_v2";
-constexpr auto CU_DEVICE_GET          = "cuDeviceGet";
-constexpr auto CU_LAUNCH_KERNEL       = "cuLaunchKernel_ptsz";
-constexpr auto CU_MEM_ALLOC           = "cuMemAlloc_v2";
-constexpr auto CU_MEM_ALLOC_ASYNC     = "cuMemAllocAsync_ptsz";
-constexpr auto CU_MEM_FREE            = "cuMemFree_v2";
-constexpr auto CU_MEM_FREE_ASYNC      = "cuMemFreeAsync_ptsz";
-constexpr auto CU_MEMCPY_HTOD         = "cuMemcpyHtoD_v2";
-constexpr auto CU_MEMCPY_HTOD_ASYNC   = "cuMemcpyHtoDAsync_v2_ptsz";
-constexpr auto CU_MEMCPY_DTOH         = "cuMemcpyDtoH_v2";
-constexpr auto CU_MEMCPY_DTOH_ASYNC   = "cuMemcpyDtoHAsync_v2_ptsz";
-constexpr auto CU_MODULE_LOAD_FATBIN  = "cuModuleLoadFatBinary";
-constexpr auto CU_MODULE_GET_FUNCTION = "cuModuleGetFunction";
-constexpr auto CU_MODULE_UNLOAD       = "cuModuleUnload";
-constexpr auto CU_STREAM_CREATE       = "cuStreamCreate";
-constexpr auto CU_STREAM_DESTROY      = "cuStreamDestroy_v2";
-constexpr auto CU_STREAM_SYNC         = "cuStreamSynchronize_ptsz";
+constexpr auto Cu_Init                = "cuInit";
+constexpr auto Cu_Ctx_Create          = "cuCtxCreate_v4";
+constexpr auto Cu_Ctx_Destroy         = "cuCtxDestroy_v2";
+constexpr auto Cu_Device_Get          = "cuDeviceGet";
+constexpr auto Cu_Launch_Kernel       = "cuLaunchKernel_ptsz";
+constexpr auto Cu_Mem_Alloc           = "cuMemAlloc_v2";
+constexpr auto Cu_Mem_Alloc_Async     = "cuMemAllocAsync_ptsz";
+constexpr auto Cu_Mem_Free            = "cuMemFree_v2";
+constexpr auto Cu_Mem_Free_Async      = "cuMemFreeAsync_ptsz";
+constexpr auto Cu_Memcpy_Htod         = "cuMemcpyHtoD_v2";
+constexpr auto Cu_Memcpy_Htod_Async   = "cuMemcpyHtoDAsync_v2_ptsz";
+constexpr auto Cu_Memcpy_Dtoh         = "cuMemcpyDtoH_v2";
+constexpr auto Cu_Memcpy_Dtoh_Async   = "cuMemcpyDtoHAsync_v2_ptsz";
+constexpr auto Cu_Module_Load_Fatbin  = "cuModuleLoadFatBinary";
+constexpr auto Cu_Module_Get_Function = "cuModuleGetFunction";
+constexpr auto Cu_Module_Unload       = "cuModuleUnload";
+constexpr auto Cu_Stream_Create       = "cuStreamCreate";
+constexpr auto Cu_Stream_Destroy      = "cuStreamDestroy_v2";
+constexpr auto Cu_Stream_Sync         = "cuStreamSynchronize_ptsz";
 
-void HostEmitter::emit_cu_error_handling(ll::BB& bb, const std::string& cu_result, bool tail) {
+void HostEmitter::emit_cu_error_handling(ll::BB& /*bb*/, const std::string& /*cu_result*/, bool /*tail*/) {
     // TODO: implement
     return;
 }
@@ -153,30 +157,6 @@ std::string HostEmitter::convert(const Def* type, bool simd) {
     return Super::convert(type, simd);
 }
 
-void HostEmitter::emit_epilogue(Lam* lam) {
-    auto& bb = lam2bb_[lam];
-
-    // HACK: we partially re-implement the checks in Super::emit_epilogue to catch target-specific applications
-    auto app = lam->body()->as<App>();
-    if (auto ret = isa_targetspecific_intrinsic(bb, app)) {
-        assert(ret.has_value());
-        if (app->callee() == root()->ret_var()) // return
-            assert(false && "Return not implemented in NVPTX backend");
-        else if (auto dispatch = Dispatch(app))
-            assert(false && "Dispatch not implemented in NVPTX backend");
-        else if (app->callee()->isa<Bot>())
-            assert(false && "Bot not implemented in NVPTX backend");
-        else if (auto _ = Lam::isa_mut_basicblock(app->callee())) // ordinary jump
-            assert(false && "Ordinary Jump not implemented in NVPTX backend");
-        else if (Pi::isa_returning(app->callee_type())) // function call
-            bb.tail("br label {}", ret.value());
-        else
-            assert(false && "Unexpected return case in NVPTX backend");
-    } else {
-        Super::emit_epilogue(lam);
-    }
-}
-
 std::optional<std::string> HostEmitter::isa_targetspecific_intrinsic(ll::BB& bb, const Def* def) {
     auto name = id(def);
     std::string op;
@@ -187,24 +167,24 @@ std::optional<std::string> HostEmitter::isa_targetspecific_intrinsic(ll::BB& bb,
         auto dev_num   = 0; // TODO: consider parameterizing this
         auto ctx_flags = 0; // TODO: consider parameterizing this
 
-        declare("i32 @{}(i32)", CU_INIT);
-        auto init_res = bb.assign(name + "_init_res", "call i32 @{}(i32 0)", CU_INIT);
+        declare("i32 @{}(i32)", Cu_Init);
+        auto init_res = bb.assign(name + "_init_res", "call i32 @{}(i32 0)", Cu_Init);
         emit_cu_error_handling(bb, init_res);
 
-        declare("i32 @{}(ptr, i32)", CU_DEVICE_GET);
+        declare("i32 @{}(ptr, i32)", Cu_Device_Get);
         auto dev_ptr = bb.assign(name + "_dev_ptr", "alloca i32");
         auto dev_get_res
-            = bb.assign(name + "_get_res", "call i32 @{}(ptr {}, i32 {})", CU_DEVICE_GET, dev_ptr, dev_num);
+            = bb.assign(name + "_get_res", "call i32 @{}(ptr {}, i32 {})", Cu_Device_Get, dev_ptr, dev_num);
         emit_cu_error_handling(bb, dev_get_res);
 
-        declare("i32 @{}(ptr, ptr, i32, i32)", CU_CTX_CREATE);
+        declare("i32 @{}(ptr, ptr, i32, i32)", Cu_Ctx_Create);
         std::print(vars_decls_, "{} = global ptr null\n", ctx_name_);
         auto dev     = bb.assign(name + "_dev", "load i32, ptr {}", dev_ptr);
-        auto ctx_res = bb.assign(name + "_ctx_res", "call i32 @{}(ptr {}, ptr null, i32 {}, i32 {})", CU_CTX_CREATE,
+        auto ctx_res = bb.assign(name + "_ctx_res", "call i32 @{}(ptr {}, ptr null, i32 {}, i32 {})", Cu_Ctx_Create,
                                  ctx_name_, ctx_flags, dev);
         emit_cu_error_handling(bb, ctx_res);
 
-        declare("i32 @{}(ptr, ptr)", CU_MODULE_LOAD_FATBIN);
+        declare("i32 @{}(ptr, ptr)", Cu_Module_Load_Fatbin);
         std::print(vars_decls_, "{} = global ptr null\n", mod_name_);
         if (device_fatbin_file_.has_value()) {
             std::ifstream fatbin_file(device_fatbin_file_.value(), std::ios::binary);
@@ -231,64 +211,64 @@ std::optional<std::string> HostEmitter::isa_targetspecific_intrinsic(ll::BB& bb,
                        "{} = private constant [YOUR_FATBIN_DATA_SIZE_GOES_HERE x i8] YOUR_FATBIN_DATA_GOES_HERE\n",
                        fatbin_name_);
         }
-        auto mod_res = bb.assign(name + "_mod_res", "call i32 @{}(ptr {}, ptr {})", CU_MODULE_LOAD_FATBIN, mod_name_,
+        auto mod_res = bb.assign(name + "_mod_res", "call i32 @{}(ptr {}, ptr {})", Cu_Module_Load_Fatbin, mod_name_,
                                  fatbin_name_);
         emit_cu_error_handling(bb, mod_res);
         auto mod_inner = bb.assign(name + "_mod_inner", "load ptr, ptr {}", mod_name_);
 
-        declare("i32 @{}(ptr, ptr, ptr)", CU_MODULE_GET_FUNCTION);
+        declare("i32 @{}(ptr, ptr, ptr)", Cu_Module_Get_Function);
         for (auto [kernel, kid] : kernel_ids_) {
             auto kname    = id(kernel).substr(1);
             auto func_ptr = bb.assign("%" + kname + "_funcptr", "getelementptr inbounds ptr, ptr {}, i64 {}",
                                       kernel_array_name_, kid);
             auto func_res = bb.assign("%" + kname + "_getfuncres", "call i32 @{}(ptr {}, ptr {}, ptr {}{})",
-                                      CU_MODULE_GET_FUNCTION, func_ptr, mod_inner, kernel_name_prefix, kid);
+                                      Cu_Module_Get_Function, func_ptr, mod_inner, kernel_name_prefix, kid);
             emit_cu_error_handling(bb, func_res);
         }
 
         auto mem = init->arg();
         return emit_unsafe(mem);
     } else if (auto deinit = Axm::isa<gpu::deinit>(def)) {
-        declare("i32 @{}(ptr)", CU_MODULE_UNLOAD);
+        declare("i32 @{}(ptr)", Cu_Module_Unload);
         bb.tail("{}_mod = load ptr, ptr {}", name, mod_name_);
-        bb.tail("{}_mod_unload_res = call i32 @{}(ptr {}_mod)", name, CU_MODULE_UNLOAD, name);
+        bb.tail("{}_mod_unload_res = call i32 @{}(ptr {}_mod)", name, Cu_Module_Unload, name);
         emit_cu_error_handling(bb, name + "_mod_unload_res", true);
 
-        declare("i32 @{}(ptr)", CU_CTX_DESTROY);
+        declare("i32 @{}(ptr)", Cu_Ctx_Destroy);
         bb.tail("{}_ctx = load ptr, ptr {}", name, ctx_name_);
-        bb.tail("{}_ctx_destroy_res = call i32 @{}(ptr {}_ctx)", name, CU_CTX_DESTROY, name);
+        bb.tail("{}_ctx_destroy_res = call i32 @{}(ptr {}_ctx)", name, Cu_Ctx_Destroy, name);
         emit_cu_error_handling(bb, name + "_ctx_destroy_res", true);
 
         emit_unsafe(deinit->arg(0));
         return emit_unsafe(deinit->arg(1));
     } else if (auto stream_init = Axm::isa<gpu::stream_init>(def)) {
-        declare("i32 @{}(ptr, i32)", CU_STREAM_CREATE);
+        declare("i32 @{}(ptr, i32)", Cu_Stream_Create);
 
         emit_unsafe(stream_init->arg(0));
         emit_unsafe(stream_init->arg(1));
         auto stream_ptr = emit(stream_init->arg(2));
 
-        auto res = bb.assign(name, "call i32 @{}(ptr {}, i32 0)", CU_STREAM_CREATE, stream_ptr);
+        auto res = bb.assign(name, "call i32 @{}(ptr {}, i32 0)", Cu_Stream_Create, stream_ptr);
         emit_cu_error_handling(bb, res);
         return res;
     } else if (auto stream_deinit = Axm::isa<gpu::stream_deinit>(def)) {
-        declare("i32 @{}(ptr)", CU_STREAM_DESTROY);
+        declare("i32 @{}(ptr)", Cu_Stream_Destroy);
 
         emit_unsafe(stream_deinit->arg(0));
         emit_unsafe(stream_deinit->arg(1));
         auto stream = emit(stream_deinit->arg(2));
 
-        auto res = bb.assign(name, "call i32 @{}(ptr {})", CU_STREAM_DESTROY, stream);
+        auto res = bb.assign(name, "call i32 @{}(ptr {})", Cu_Stream_Destroy, stream);
         emit_cu_error_handling(bb, res);
         return res;
     } else if (auto stream_sync = Axm::isa<gpu::stream_sync>(def)) {
-        declare("i32 @{}(ptr)", CU_STREAM_SYNC);
+        declare("i32 @{}(ptr)", Cu_Stream_Sync);
 
         emit_unsafe(stream_sync->arg(0));
         emit_unsafe(stream_sync->arg(1));
         auto stream = emit(stream_sync->arg(2));
 
-        auto res = bb.assign(name, "call i32 @{}(ptr {})", CU_STREAM_SYNC, stream);
+        auto res = bb.assign(name, "call i32 @{}(ptr {})", Cu_Stream_Sync, stream);
         emit_cu_error_handling(bb, res);
         return res;
     } else if (auto alloc = Axm::isa<gpu::alloc>(def)) {
@@ -300,9 +280,9 @@ std::optional<std::string> HostEmitter::isa_targetspecific_intrinsic(ll::BB& bb,
         }
 
         if (is_async)
-            declare("i32 @{}(ptr, i64, ptr)", CU_MEM_ALLOC_ASYNC);
+            declare("i32 @{}(ptr, i64, ptr)", Cu_Mem_Alloc_Async);
         else
-            declare("i32 @{}(ptr, i64)", CU_MEM_ALLOC);
+            declare("i32 @{}(ptr, i64)", Cu_Mem_Alloc);
 
         emit_unsafe(alloc->arg(0));
         auto alloc_t    = alloc->decurry()->arg();
@@ -316,10 +296,10 @@ std::optional<std::string> HostEmitter::isa_targetspecific_intrinsic(ll::BB& bb,
         std::string alloc_res;
         if (is_async) {
             auto stream = emit(alloc->arg(1));
-            alloc_res   = bb.assign(name + "res", "call i32 @{}(ptr {}, i64 {}, ptr {})", CU_MEM_ALLOC_ASYNC, alloc_ptr,
+            alloc_res   = bb.assign(name + "res", "call i32 @{}(ptr {}, i64 {}, ptr {})", Cu_Mem_Alloc_Async, alloc_ptr,
                                     alloc_size, stream);
         } else
-            alloc_res = bb.assign(name + "res", "call i32 @{}(ptr {}, i64 {})", CU_MEM_ALLOC, alloc_ptr, alloc_size);
+            alloc_res = bb.assign(name + "res", "call i32 @{}(ptr {}, i64 {})", Cu_Mem_Alloc, alloc_ptr, alloc_size);
 
         emit_cu_error_handling(bb, alloc_res);
         return bb.assign(name, "load {}, {} addrspace(0)* {}", ptr_t, ptr_t, alloc_ptr);
@@ -332,9 +312,9 @@ std::optional<std::string> HostEmitter::isa_targetspecific_intrinsic(ll::BB& bb,
         }
 
         if (is_async)
-            declare("i32 @{}(i64)", CU_MEM_FREE_ASYNC);
+            declare("i32 @{}(i64)", Cu_Mem_Free_Async);
         else
-            declare("i32 @{}(i64)", CU_MEM_FREE);
+            declare("i32 @{}(i64)", Cu_Mem_Free);
 
         emit_unsafe(free->arg(0));
         auto ptr = emit(free->arg(1));
@@ -342,9 +322,9 @@ std::optional<std::string> HostEmitter::isa_targetspecific_intrinsic(ll::BB& bb,
         std::string free_res;
         if (is_async) {
             auto stream = emit(free->arg(2));
-            free_res    = bb.assign(name + "res", "call i32 @{}(i64 {}, ptr {})", CU_MEM_FREE_ASYNC, ptr, stream);
+            free_res    = bb.assign(name + "res", "call i32 @{}(i64 {}, ptr {})", Cu_Mem_Free_Async, ptr, stream);
         } else
-            free_res = bb.assign(name + "res", "call i32 @{}(i64 {})", CU_MEM_FREE, ptr);
+            free_res = bb.assign(name + "res", "call i32 @{}(i64 {})", Cu_Mem_Free, ptr);
 
         emit_cu_error_handling(bb, free_res);
         return free_res;
@@ -357,9 +337,9 @@ std::optional<std::string> HostEmitter::isa_targetspecific_intrinsic(ll::BB& bb,
         }
 
         if (is_async)
-            declare("i32 @{}(i64, ptr, i64, ptr)", CU_MEMCPY_HTOD_ASYNC);
+            declare("i32 @{}(i64, ptr, i64, ptr)", Cu_Memcpy_Htod_Async);
         else
-            declare("i32 @{}(i64, ptr, i64)", CU_MEMCPY_HTOD);
+            declare("i32 @{}(i64, ptr, i64)", Cu_Memcpy_Htod);
 
         auto type      = copy_to_device->decurry()->arg();
         World& w       = type->world();
@@ -374,10 +354,10 @@ std::optional<std::string> HostEmitter::isa_targetspecific_intrinsic(ll::BB& bb,
         std::string copy_res;
         if (is_async) {
             auto stream = emit(copy_to_device->arg(4));
-            copy_res    = bb.assign(name + "res", "call i32 @{}(i64 {}, ptr {}, i64 {}, ptr {})", CU_MEMCPY_HTOD_ASYNC,
+            copy_res    = bb.assign(name + "res", "call i32 @{}(i64 {}, ptr {}, i64 {}, ptr {})", Cu_Memcpy_Htod_Async,
                                     dev_ptr, host_ptr, size, stream);
         } else
-            copy_res = bb.assign(name + "res", "call i32 @{}(i64 {}, ptr {}, i64 {})", CU_MEMCPY_HTOD, dev_ptr,
+            copy_res = bb.assign(name + "res", "call i32 @{}(i64 {}, ptr {}, i64 {})", Cu_Memcpy_Htod, dev_ptr,
                                  host_ptr, size);
 
         emit_cu_error_handling(bb, copy_res);
@@ -390,9 +370,9 @@ std::optional<std::string> HostEmitter::isa_targetspecific_intrinsic(ll::BB& bb,
             default: fe::unreachable();
         }
         if (is_async)
-            declare("i32 @{}(ptr, i64, i64, ptr)", CU_MEMCPY_DTOH_ASYNC);
+            declare("i32 @{}(ptr, i64, i64, ptr)", Cu_Memcpy_Dtoh_Async);
         else
-            declare("i32 @{}(ptr, i64, i64)", CU_MEMCPY_DTOH);
+            declare("i32 @{}(ptr, i64, i64)", Cu_Memcpy_Dtoh);
 
         auto [type]    = copy_to_host->decurry()->args<1>();
         World& w       = type->world();
@@ -407,17 +387,17 @@ std::optional<std::string> HostEmitter::isa_targetspecific_intrinsic(ll::BB& bb,
         std::string copy_res;
         if (is_async) {
             auto stream = emit(copy_to_host->arg(4));
-            copy_res    = bb.assign(name + "res", "call i32 @{}(ptr {}, i64 {}, i64 {}, ptr {})", CU_MEMCPY_DTOH_ASYNC,
+            copy_res    = bb.assign(name + "res", "call i32 @{}(ptr {}, i64 {}, i64 {}, ptr {})", Cu_Memcpy_Dtoh_Async,
                                     host_ptr, dev_ptr, size, stream);
         } else
-            copy_res = bb.assign(name + "res", "call i32 @{}(ptr {}, i64 {}, i64 {})", CU_MEMCPY_DTOH, host_ptr,
+            copy_res = bb.assign(name + "res", "call i32 @{}(ptr {}, i64 {}, i64 {})", Cu_Memcpy_Dtoh, host_ptr,
                                  dev_ptr, size);
 
         emit_cu_error_handling(bb, copy_res);
         return copy_res;
     } else if (auto launch = Axm::isa<gpu::launch>(def)) {
         // TODO: rewrite to use modern cuLaunchKernelEx instead
-        declare("i32 @{}(ptr, i32, i32, i32, i32, i32, i32, i32, ptr, ptr, ptr)", CU_LAUNCH_KERNEL);
+        declare("i32 @{}(ptr, i32, i32, i32, i32, i32, i32, i32, ptr, ptr, ptr)", Cu_Launch_Kernel);
 
         auto [implicits, launch_config, kernel_def, arg_def, func_args] = launch->uncurry_args<5>();
         auto [n_groups_def, n_items_def, stream_def, m, MT]             = launch_config->projs<5>();
@@ -458,35 +438,11 @@ std::optional<std::string> HostEmitter::isa_targetspecific_intrinsic(ll::BB& bb,
             = bb.assign(name,
                         "call i32 @{}(ptr {}, i32 {}, i32 1, i32 1, i32 {}, i32 1, i32 1, "
                         "i32 {}, ptr {}, ptr {}, ptr null)",
-                        CU_LAUNCH_KERNEL, func_inner, n_groups, n_items, shared_mem_bytes, stream, args_inner);
+                        Cu_Launch_Kernel, func_inner, n_groups, n_items, shared_mem_bytes, stream, args_inner);
         emit_cu_error_handling(bb, launch_res);
         return ret_lam;
     }
     return std::nullopt;
-}
-
-void DeviceEmitter::emit_epilogue(Lam* lam) {
-    auto& bb = lam2bb_[lam];
-
-    // HACK: we partially re-implement the checks in Super::emit_epilogue to catch target-specific applications
-    auto app = lam->body()->as<App>();
-    if (auto mslot = Axm::isa<mem::mslot>(app)) {
-        // Continuation-based stack slot: allocate and jump to the passed continuation with the fresh pointer.
-        auto [Ta, rest]   = mslot->uncurry_args<2>();
-        auto [T, a]       = Ta->projs<2>();
-        auto [msize, ret] = rest->projs<2>();
-        emit_unsafe(msize->proj(0)); // mem
-        // TODO array with size
-        auto ret_lam = ret->as_mut<Lam>();
-        auto ptr     = ret_lam->var(2, 1);
-        auto v_ptr   = "@" + app->unique_name() + ".slot";
-        std::print(vars_decls_, "{} = internal addrspace({}) global {} undef\n", v_ptr, a, convert(T));
-        lam2bb_[ret_lam].phis[ptr].emplace_back(v_ptr, id(lam, true));
-        globals_[ptr] = id(ptr);
-        return bb.tail("br label {}", id(ret_lam));
-    } else {
-        Super::emit_epilogue(lam);
-    }
 }
 
 void DeviceEmitter::start() {

--- a/src/mim/plug/ll_nvptx/phase/ll_nvptx.cpp
+++ b/src/mim/plug/ll_nvptx/phase/ll_nvptx.cpp
@@ -112,8 +112,7 @@ void HostEmitter::find_kernels(const Def* def) {
 
     if (auto launch = Axm::isa<gpu::launch>(def)) {
         auto kernel     = launch->decurry()->decurry()->arg();
-        auto kernel_lam = kernel->isa_mut<Lam>();
-        assert(kernel_lam && "Expect kernel passed to %gpu.launch to be a mutable lambda");
+        auto kernel_lam = kernel->expect_mut<Lam>("the kernel passed to %gpu.launch to be a mutable lambda");
         if (kernel_ids_.contains(kernel_lam)) return;
         auto kid                = kernel_ids_.size();
         kernel_ids_[kernel_lam] = kid;
@@ -188,7 +187,7 @@ std::optional<std::string> HostEmitter::isa_targetspecific_intrinsic(ll::BB& bb,
         std::print(vars_decls_, "{} = global ptr null\n", mod_name_);
         if (device_fatbin_file_.has_value()) {
             std::ifstream fatbin_file(device_fatbin_file_.value(), std::ios::binary);
-            if (!fatbin_file) error("Could not open {} as binary file", device_fatbin_file_.value());
+            if (!fatbin_file) fe::throwf("Could not open {} as binary file", device_fatbin_file_.value());
 
             auto start = std::istreambuf_iterator<char>(fatbin_file);
             auto end   = std::istreambuf_iterator<char>();
@@ -276,7 +275,7 @@ std::optional<std::string> HostEmitter::isa_targetspecific_intrinsic(ll::BB& bb,
         switch (alloc.id()) {
             case gpu::alloc::block: is_async = false; break;
             case gpu::alloc::asyn: is_async = true; break;
-            default: fe::unreachable();
+            default: fe::throwf("ll_nvptx backend: unhandled %gpu.alloc id in '{}'", def);
         }
 
         if (is_async)
@@ -290,7 +289,7 @@ std::optional<std::string> HostEmitter::isa_targetspecific_intrinsic(ll::BB& bb,
         auto type_size  = w.call(core::trait::size, alloc_t);
         auto alloc_size = emit(type_size);
 
-        auto ptr_t = convert(Axm::as<mem::Ptr>(def->proj(1)->type()));
+        auto ptr_t = convert(Axm::expect<mem::Ptr>(def->proj(1)->type(), "a %mem.Ptr"));
 
         auto alloc_ptr = bb.assign(name + "ptr", "alloca {}", ptr_t);
         std::string alloc_res;
@@ -308,7 +307,7 @@ std::optional<std::string> HostEmitter::isa_targetspecific_intrinsic(ll::BB& bb,
         switch (free.id()) {
             case gpu::free::block: is_async = false; break;
             case gpu::free::asyn: is_async = true; break;
-            default: fe::unreachable();
+            default: fe::throwf("ll_nvptx backend: unhandled %gpu.free id in '{}'", def);
         }
 
         if (is_async)
@@ -333,7 +332,7 @@ std::optional<std::string> HostEmitter::isa_targetspecific_intrinsic(ll::BB& bb,
         switch (copy_to_device.id()) {
             case gpu::copy_to_device::block: is_async = false; break;
             case gpu::copy_to_device::asyn: is_async = true; break;
-            default: fe::unreachable();
+            default: fe::throwf("ll_nvptx backend: unhandled %gpu.copy_to_device id in '{}'", def);
         }
 
         if (is_async)
@@ -367,7 +366,7 @@ std::optional<std::string> HostEmitter::isa_targetspecific_intrinsic(ll::BB& bb,
         switch (copy_to_host.id()) {
             case gpu::copy_to_host::block: is_async = false; break;
             case gpu::copy_to_host::asyn: is_async = true; break;
-            default: fe::unreachable();
+            default: fe::throwf("ll_nvptx backend: unhandled %gpu.copy_to_host id in '{}'", def);
         }
         if (is_async)
             declare("i32 @{}(ptr, i64, i64, ptr)", Cu_Memcpy_Dtoh_Async);
@@ -404,14 +403,14 @@ std::optional<std::string> HostEmitter::isa_targetspecific_intrinsic(ll::BB& bb,
         auto [mem, ret_lam_def]                                         = func_args->projs<2>();
 
         Lam* lam = kernel_def->isa_mut<Lam>();
-        if (!lam) error("kernel is not a lamda {}", kernel_def);
-        if (!kernel_ids_.contains(lam)) error("unknown kernel {}", lam);
+        if (!lam) fe::throwf("kernel is not a lamda {}", kernel_def);
+        if (!kernel_ids_.contains(lam)) fe::throwf("unknown kernel {}", lam);
         auto kid = kernel_ids_[lam];
 
         auto shared_mem_bytes = 0;
-        if (auto smem_count = Lit::as(m)) {
-            if (smem_count != 1) error("You can only have one dynamic allocation of shared memory per kernel");
-            shared_mem_bytes = Lit::as(world().call(core::trait::size, MT));
+        if (auto smem_count = Lit::expect(m, "a shared-memory allocation count")) {
+            if (smem_count != 1) fe::throwf("You can only have one dynamic allocation of shared memory per kernel");
+            shared_mem_bytes = Lit::expect(world().call(core::trait::size, MT), "a shared-memory size");
         }
 
         emit_unsafe(mem);
@@ -447,8 +446,7 @@ std::optional<std::string> HostEmitter::isa_targetspecific_intrinsic(ll::BB& bb,
 
 void DeviceEmitter::start() {
     for (auto kernel : world().externals().muts()) {
-        auto kernel_lam = kernel->isa_mut<Lam>();
-        assert(kernel_lam && "Expect kernel passed to %gpu.launch to be a mutable lambda");
+        auto kernel_lam = kernel->expect_mut<Lam>("an external kernel to be a mutable lambda");
         kernels_.emplace(kernel_lam);
     }
     Super::start();
@@ -475,7 +473,7 @@ std::string DeviceEmitter::prepare() {
         auto type        = def->type();
         auto type_name   = convert(type);
         auto opt_idx_lit = Idx::isa_lit(type);
-        if (!opt_idx_lit) error("Type of '{}' must have known index type but has {}", def, type);
+        if (!opt_idx_lit) fe::throwf("Type of '{}' must have known index type but has {}", def, type);
         auto idx_lit = opt_idx_lit.value();
         locals_[def] = name;
         declare("i32 @llvm.nvvm.read.ptx.sreg.{}()", sreg);
@@ -487,20 +485,22 @@ std::string DeviceEmitter::prepare() {
             auto i32 = bb.assign(name + "i32", "call i32 @llvm.nvvm.read.ptx.sreg.{}()", sreg);
             bb.assign(name, "trunc i32 {} to {}", i32, type_name);
         } else {
-            error("Warp ID too large, must fit into I32");
+            fe::throwf("Warp ID too large, must fit into I32");
         }
     };
     register_sreg_idx(group_id, "ctaid.x");
     register_sreg_idx(item_id, "tid.x");
 
-    auto shared_as = Lit::as(world().annex<gpu::addr_space_shared>());
+    auto shared_as = Lit::expect(world().annex<gpu::addr_space_shared>(), "the shared address space");
     if (auto sigma = smem->type()->isa<Sigma>()) {
-        assert(sigma->num_ops() == 0 && "Expect empty sigma for shared memory variable");
+        if (sigma->num_ops() != 0)
+            fe::throwf("ll_nvptx backend: shared-memory variable must be an empty sigma, but got '{}'", smem->type());
     } else {
-        auto ptr = Axm::isa<mem::Ptr>(smem->type());
-        assert(ptr && "Expect pointer type for shared memory variable");
+        auto ptr    = Axm::expect<mem::Ptr>(smem->type(), "a shared-memory pointer type");
         auto [T, a] = ptr->args<2>();
-        assert(Lit::as(a) == shared_as && "Expect shared memory pointer type for shared memory variable");
+        if (Lit::expect(a, "an address space") != shared_as)
+            fe::throwf("ll_nvptx backend: shared-memory variable must live in the shared address space, but got '{}'",
+                       smem->type());
         auto name     = "@" + smem->unique_name();
         locals_[smem] = name;
         std::print(vars_decls_, "{} = internal addrspace({}) global {} undef\n", name, a, convert(T));

--- a/src/mim/plug/nvptx/nvptx.mim
+++ b/src/mim/plug/nvptx/nvptx.mim
@@ -17,8 +17,6 @@ import compile;
 ///
 let %nvptx.Stream = %mem.Ptr0 I8;
 ///
-/// ## Stages
-///
-/// ### Repls
+/// ## Phases
 ///
 axm %nvptx.stream_impl_repl: %compile.Phase;

--- a/src/mim/plug/tensor/phase/lower_map_reduce.cpp
+++ b/src/mim/plug/tensor/phase/lower_map_reduce.cpp
@@ -7,8 +7,8 @@
 
 #include "mim/plug/affine/affine.h"
 #include "mim/plug/core/core.h"
-#include "mim/plug/mem/mem.h"
 #include "mim/plug/cps/cps.h"
+#include "mim/plug/mem/mem.h"
 #include "mim/plug/tensor/tensor.h"
 
 namespace mim::plug::tensor::phase {
@@ -244,7 +244,7 @@ const Def* LowerMapReduce::lower_map_reduce(const App* app) {
         comb->set("comb");
         current_mut->app(true, comb, {w.tuple({element_acc, w.tuple(input_elements)}), cont});
         return call;
-    } catch (const std::exception& e) { error("error during lowering map_reduce: {}", e.what()); }
+    } catch (const std::exception& e) { fe::throwf("error during lowering map_reduce: {}", e.what()); }
 }
 
 const Def* LowerMapReduce::build_pointwise(const Def* inputs,

--- a/src/mim/plug/tensor/phase/lower_to_mem.cpp
+++ b/src/mim/plug/tensor/phase/lower_to_mem.cpp
@@ -29,7 +29,8 @@ bool contains_pi(const Def* t) {
 /// pack `‹i; f i›` or a genuine literal `((1, 2), (3, 4))` yields `nullptr`.
 const Def* splat_scalar(const Def* d) {
     if (!d->isa<Pack>()) return nullptr;
-    while (auto pack = d->isa<Pack>()) d = pack->body();
+    while (auto pack = d->isa<Pack>())
+        d = pack->body();
     return (d->is_closed() && !d->type()->isa<Arr>()) ? d : nullptr;
 }
 
@@ -44,7 +45,7 @@ bool is_tensor_op(const App* app) {
 void LowerToMem::collect_tensor_types() {
     // The default pipeline lowers tensors exclusively through buffers — there is no value-semantics
     // fallback. A program shape the conversion cannot handle is a hard error, not silent residue.
-    auto gate = [](const char* why, const Def* culprit) { error("cannot bufferize: {} ({})", why, culprit); };
+    auto gate = [](const char* why, const Def* culprit) { fe::throwf("cannot bufferize: {} ({})", why, culprit); };
     // Fully folded shapes (`«1; T»` ≡ `T`) denote plain scalars — recording them would poison every
     // function whose signature mentions the element type, so only genuine array types count as tensors.
     auto add_tensor_ty = [this](const Def* t) {
@@ -117,8 +118,8 @@ void LowerToMem::collect_tensor_types() {
                         add_tensor_ty(app->arg()->proj(*nis_l, i)->type());
                     }
                 }
-            } else if (auto [axm, curry, trip] = Axm::get(app); axm && curry == 0
-                                                                && axm->plugin() == tensor::Plugin_Id) {
+            } else if (auto [axm, curry, trip] = Axm::get(app);
+                       axm && curry == 0 && axm->plugin() == tensor::Plugin_Id) {
                 // Any other tensor op (a symbolic `shape`, …) has no buffer-world lowering.
                 gate("unbufferizable tensor op", app);
             }
@@ -513,9 +514,8 @@ const Def* LowerToMem::lower_pad(const App* app) {
     // must keep size-1 axes (the result type's `Buf` folds them away and cannot be used here).
     DefVec so(*r_l);
     for (u64 d = 0; d < *r_l; ++d)
-        so[d] = w.call(core::nat::add,
-                       DefVec{w.call(core::nat::add, DefVec{lo->proj(*r_l, d), s_in->proj(*r_l, d)}),
-                              hi->proj(*r_l, d)});
+        so[d] = w.call(core::nat::add, DefVec{w.call(core::nat::add, DefVec{lo->proj(*r_l, d), s_in->proj(*r_l, d)}),
+                                              hi->proj(*r_l, d)});
     auto s_out = w.tuple(so);
 
     auto op       = w.annex<matrix::pad>();

--- a/src/mim/sexpr.cpp
+++ b/src/mim/sexpr.cpp
@@ -722,7 +722,7 @@ std::string Emitter::emit_type(BB& bb, const Def* type, bool in_term /* = false*
     } else if (auto top = type->isa<Top>()) {
         std::print(os, "(top {})", emit_type(bb, top->type(), in_term));
     } else {
-        error("unsupported type '{}'", type);
+        fe::throwf("unsupported type '{}'", type);
         fe::unreachable();
     }
 
@@ -933,7 +933,7 @@ std::string Emitter::emit_bb(BB& bb, const Def* def) {
     } else if (auto hole = def->isa<Hole>()) {
         std::print(os, "\n{}(hole {})", tab, emit_type(bb, hole->type()));
     } else {
-        error("Unhandled Def in SExpr backend: {} : {}", def, def->type());
+        fe::throwf("Unhandled Def in SExpr backend: {} : {}", def, def->type());
         fe::unreachable();
     }
 

--- a/src/mim/util/dl.cpp
+++ b/src/mim/util/dl.cpp
@@ -15,17 +15,17 @@ void* open(const char* file) {
     if (HMODULE handle = LoadLibraryA(file)) {
         return static_cast<void*>(handle);
     } else {
-        error("could not load plugin '{}' due to error '{}'\n"
-              "see https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes\n",
-              file, GetLastError());
+        fe::throwf("could not load plugin '{}' due to error '{}'\n"
+                   "see https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes\n",
+                   file, GetLastError());
     }
 #else
     if (void* handle = dlopen(file, RTLD_NOW))
         return handle;
     else if (auto err = dlerror())
-        error("could not load plugin '{}' due to error '{}'\n", file, err);
+        fe::throwf("could not load plugin '{}' due to error '{}'\n", file, err);
     else
-        error("could not load plugin '{}'\n", file);
+        fe::throwf("could not load plugin '{}'\n", file);
 #endif
 }
 
@@ -34,15 +34,15 @@ void* get(void* handle, const char* symbol) {
     if (auto addr = GetProcAddress(static_cast<HMODULE>(handle), symbol)) {
         return reinterpret_cast<void*>(addr);
     } else {
-        error("could not find symbol '{}' in plugin due to error '{}'\n"
-              "see (https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes)\n",
-              symbol, GetLastError());
+        fe::throwf("could not find symbol '{}' in plugin due to error '{}'\n"
+                   "see (https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes)\n",
+                   symbol, GetLastError());
     }
 #else
     dlerror(); // clear error state
     void* addr = dlsym(handle, symbol);
     if (auto err = dlerror())
-        error("could not find symbol '{}' in plugin due to error '{}' \n", symbol, err);
+        fe::throwf("could not find symbol '{}' in plugin due to error '{}' \n", symbol, err);
     else
         return addr;
 #endif
@@ -50,9 +50,9 @@ void* get(void* handle, const char* symbol) {
 
 void close(void* handle) {
 #ifdef _WIN32
-    if (!FreeLibrary(static_cast<HMODULE>(handle))) error("FreeLibrary() failed\n");
+    if (!FreeLibrary(static_cast<HMODULE>(handle))) fe::throwf("FreeLibrary() failed\n");
 #else
-    if (auto err = dlclose(handle)) error("dlclose() failed with error code '{}'\n", err);
+    if (auto err = dlclose(handle)) fe::throwf("dlclose() failed with error code '{}'\n", err);
 #endif
 }
 

--- a/src/mim/util/sys.cpp
+++ b/src/mim/util/sys.cpp
@@ -89,7 +89,7 @@ std::string exec(std::string cmd) {
             result += buffer.data();
         return result;
     } else
-        error("popen() failed!");
+        fe::throwf("popen() failed!");
 }
 
 std::string find_cmd(std::string cmd) {

--- a/src/mim/util/sys.cpp
+++ b/src/mim/util/sys.cpp
@@ -98,10 +98,20 @@ std::string find_cmd(std::string cmd) {
     return out;
 }
 
+std::string require_cmd(std::string_view name) {
+    auto cmd = find_cmd(std::string(name));
+    if (!fs::exists(cmd)) fe::throwf<CmdNotFound>("Could not find command: {} {}", name, cmd);
+    return cmd;
+}
+
 int system(std::string cmd) {
     std::cout << cmd << std::endl;
     int status = std::system(cmd.c_str());
     return WEXITSTATUS(status);
+}
+
+void require_run(const std::string& cmd) {
+    if (auto rc = sys::system(cmd); rc != 0) fe::throwf("Command exited with error code {}", rc);
 }
 
 int run(std::string cmd, std::string args /* = {}*/) {


### PR DESCRIPTION
- cleanup
- the four big methods moved to `ll.cpp` again: 
  - `emit_bb`
  - `emit_epilogue`
  - `convert`
  -  `finalize`
  -  Bodies move verbatim (renamed to *_impl), so member access and virtual recursion are preserved. Small methods and the tiny free helpers stay inline in the header.
- The Emitter ctor resolves function pointers once via `world().driver().GET_FUN_PTR("ll", mim_ll_X)`.
- convert constants to coding conventions (`CU_LAUNCH_KERNEL` -> `Cu_Launch_Kernel` - all caps is reserved for macros)
- fix `HACK`s
- in addition to `as` and `isa` there is now `expect` which throws with an error msg on failure - even in Release
- remove silent assumptions in llvm backend with proper errors (fixes #9)
- move throwing find_cmd/run_cmd helpers to sys.h