### PR TITLE
[Fix] NVPTX plugin tests use GPU plugin test code directly

### DIFF
--- a/lit/nvptx/array_kernel.mim
+++ b/lit/nvptx/array_kernel.mim
@@ -1,5 +1,5 @@
 // RUN: rm -f %{s:stem}.ll %{s:stem}_dev.ll %t
-// RUN: %mim %s -p ll_nvptx -o -
+// RUN: %mim %S/../gpu/%{s:stem}.mim -p ll_nvptx -o -
 // RUN: %FileCheck %s --input-file=%{s:stem}.ll --check-prefix=HOST
 // RUN: %FileCheck %s --input-file=%{s:stem}_dev.ll --check-prefix=DEVICE
 // RUN: %if system-linux && cuda %{ clang %{s:stem}.ll -o %t -lcuda -Wno-override-module %}
@@ -7,50 +7,6 @@
 // RUN: %if system-linux && cuda %{ %t 1; test $? -eq 43 %}
 // RUN: %if system-linux && cuda %{ %t 1 2; test $? -eq 44 %}
 // RUN: %if system-linux && cuda %{ %t 1 2 3; test $? -eq 45 %}
-
-plugin core;
-plugin gpu;
-
-con kernel (m1: %gpu.GlobalM, m3: %gpu.SharedM, m4: %gpu.ConstM, m5: %gpu.LocalM,
-            group_id item_id: Idx 4, (), data: %gpu.GlobalPtr «4; I32»,
-            return: Cn [%gpu.GlobalM, %gpu.SharedM, %gpu.ConstM, %gpu.LocalM]) =
-    let el = %mem.lea (data, item_id);
-    let val = %core.bitcast I32 item_id;
-    let val = %core.wrap.add 0 (val, 42I32);
-    let m1 = %mem.store (m1, el, val);
-    return (m1, m3, m4, m5);
-
-fun extern main (m0: %mem.M 0, argc: I32, argv: %mem.Ptr («⊤:Nat; %mem.Ptr («⊤:Nat; I8», 0)», 0))
-: [%mem.M 0, I32] =
-    let (m0, arr) = %mem.alloc («4; I32», 0) m0;
-
-    let arr_0 = %mem.lea (arr, 0₄);
-    let m0 = %mem.store (m0, arr_0, argc);
-    let arr_1 = %mem.lea (arr, 1₄);
-    let m0 = %mem.store (m0, arr_1, argc);
-    let arr_2 = %mem.lea (arr, 2₄);
-    let m0 = %mem.store (m0, arr_2, argc);
-    let arr_3 = %mem.lea (arr, 3₄);
-    let m0 = %mem.store (m0, arr_3, argc);
-
-    let (m0, m1, m4) = %gpu.init m0;
-
-    let (m1, d_ptr) = %mem.alloc («4; I32», 1) m1;
-    let (m0, m1) = %gpu.copy_to_device.block (m0, m1, arr, d_ptr);
-
-    ret (m0, m1, m4) = %gpu.launch (4, 4, %gpu.default_stream, ff, ()) kernel d_ptr $ (m0, m1, m4);
-
-    let (m0, m1) = %gpu.copy_to_host.block (m0, m1, d_ptr, arr);
-    let m1 = %mem.free (m1, d_ptr);
-
-    let m0 = %gpu.deinit (m0, m1, m4);
-
-    let idx = %core.bitcast (Idx 4) (%core.wrap.sub 0 (argc, 1I32));
-    let val_arr = %mem.lea (arr, idx);
-    let (m0, val) = %mem.load (m0, val_arr);
-    let m0 = %mem.free (m0, arr);
-
-    return (m0, val);
 
 // HOST: define i32 @main(
 // HOST-DAG: call i8* @malloc(i64 16)

--- a/lit/nvptx/dyn_smem_kernel.mim
+++ b/lit/nvptx/dyn_smem_kernel.mim
@@ -1,45 +1,11 @@
 // RUN: rm -f %{s:stem}.ll %{s:stem}_dev.ll %t
-// RUN: %mim %s -p ll_nvptx -o -
+// RUN: %mim %S/../gpu/%{s:stem}.mim -p ll_nvptx -o -
 // RUN: %FileCheck %s --input-file=%{s:stem}.ll --check-prefix=HOST
 // RUN: %FileCheck %s --input-file=%{s:stem}_dev.ll --check-prefix=DEVICE
 // RUN: %if system-linux && cuda %{ clang %{s:stem}.ll -o %t -lcuda -Wno-override-module %}
 // RUN: %if system-linux && cuda %{ %t; test $? -eq 42 %}
 // RUN: %if system-linux && cuda %{ %t 1 2 3; test $? -eq 42 %}
 // RUN: %if system-linux && cuda %{ %t 1 2 3 4 5; test $? -eq 42 %}
-
-plugin core;
-plugin gpu;
-
-con kernel (m1: %gpu.GlobalM, m3: %gpu.SharedM, m4: %gpu.ConstM, m5: %gpu.LocalM, group_id item_id: Idx 4,
-            smem: %gpu.SharedPtr «4; I32», data: %gpu.GlobalPtr I32,
-            return: Cn [%gpu.GlobalM, %gpu.SharedM, %gpu.ConstM, %gpu.LocalM]) =
-    let el = %mem.lea (smem, item_id);
-    let val = %core.bitcast I32 item_id;
-    let m3 = %mem.store (m3, el, val);
-    let m1 = %mem.store (m1, data, 42I32);
-    return (m1, m3, m4, m5);
-
-fun extern main (m0: %mem.M 0, argc: I32, argv: %mem.Ptr («⊤:Nat; %mem.Ptr («⊤:Nat; I8», 0)», 0))
-: [%mem.M 0, I32] =
-    let (m0, ptr) = %mem.alloc (I32, 0) m0;
-    let m0 = %mem.store (m0, ptr, argc);
-
-    let (m0, m1, m4) = %gpu.init m0;
-
-    let (m1, d_ptr) = %mem.alloc (I32, 1) m1;
-    let (m0, m1) = %gpu.copy_to_device.block (m0, m1, ptr, d_ptr);
-
-    ret (m0, m1, m4) = %gpu.launch (4, 4, %gpu.default_stream, tt, «4; I32») kernel d_ptr $ (m0, m1, m4);
-
-    let (m0, m1) = %gpu.copy_to_host.block (m0, m1, d_ptr, ptr);
-    let m1 = %mem.free (m1, d_ptr);
-
-    let m0 = %gpu.deinit (m0, m1, m4);
-
-    let (m0, val) = %mem.load (m0, ptr);
-    let m0 = %mem.free (m0, ptr);
-
-    return (m0, val);
 
 // HOST: define i32 @main(
 // HOST-DAG: call i8* @malloc(i64 4)

--- a/lit/nvptx/generic_kernel.mim
+++ b/lit/nvptx/generic_kernel.mim
@@ -1,46 +1,11 @@
 // RUN: rm -f %{s:stem}.ll %{s:stem}_dev.ll %t
-// RUN: %mim %s -p ll_nvptx -o -
+// RUN: %mim %S/../gpu/%{s:stem}.mim -p ll_nvptx -o -
 // RUN: %FileCheck %s --input-file=%{s:stem}.ll --check-prefix=HOST
 // RUN: %FileCheck %s --input-file=%{s:stem}_dev.ll --check-prefix=DEVICE
 // RUN: %if system-linux && cuda %{ clang %{s:stem}.ll -o %t -lcuda -Wno-override-module %}
 // RUN: %if system-linux && cuda %{ %t; test $? -eq 42 %}
 // RUN: %if system-linux && cuda %{ %t 1 2 3; test $? -eq 42 %}
 // RUN: %if system-linux && cuda %{ %t 1 2 3 4 5; test $? -eq 42 %}
-
-plugin core;
-plugin gpu;
-
-con generic_kernel (n_groups n_items: Nat)
-                   (m1: %gpu.GlobalM, m3: %gpu.SharedM, m4: %gpu.ConstM, m5: %gpu.LocalM,
-                    group_id: Idx n_groups, item_id: Idx n_items, (), data: %gpu.GlobalPtr I32,
-                    return: Cn [%gpu.GlobalM, %gpu.SharedM, %gpu.ConstM, %gpu.LocalM]) =
-    let m1 = %mem.store (m1, data, 42I32);
-    return (m1, m3, m4, m5);
-
-fun extern main (m0: %mem.M 0, argc: I32, argv: %mem.Ptr («⊤:Nat; %mem.Ptr («⊤:Nat; I8», 0)», 0))
-: [%mem.M 0, I32] =
-    let (m0, ptr) = %mem.alloc (I32, 0) m0;
-    let m0 = %mem.store (m0, ptr, argc);
-
-    let (m0, m1, m4) = %gpu.init m0;
-
-    let (m1, d_ptr) = %mem.alloc (I32, 1) m1;
-    let (m0, m1) = %gpu.copy_to_device.block (m0, m1, ptr, d_ptr);
-
-    let k4 = generic_kernel (4, 4);
-    ret (m0, m1, m4) = %gpu.launch (4, 4, %gpu.default_stream, ff, ()) k4 d_ptr $ (m0, m1, m4);
-    let k16 = generic_kernel (16, 16);
-    ret (m0, m1, m4) = %gpu.launch (16, 16, %gpu.default_stream, ff, ()) k16 d_ptr $ (m0, m1, m4);
-
-    let (m0, m1) = %gpu.copy_to_host.block (m0, m1, d_ptr, ptr);
-    let m1 = %mem.free (m1, d_ptr);
-
-    let m0 = %gpu.deinit (m0, m1, m4);
-
-    let (m0, val) = %mem.load (m0, ptr);
-    let m0 = %mem.free (m0, ptr);
-
-    return (m0, val);
 
 // HOST: define i32 @main(
 // HOST-DAG: call i8* @malloc(i64 4)

--- a/lit/nvptx/manual_streams.mim
+++ b/lit/nvptx/manual_streams.mim
@@ -1,63 +1,11 @@
 // RUN: rm -f %{s:stem}.ll %{s:stem}_dev.ll %t
-// RUN: %mim %s -p ll_nvptx -o -
+// RUN: %mim %S/../gpu/%{s:stem}.mim -p ll_nvptx -o -
 // RUN: %FileCheck %s --input-file=%{s:stem}.ll --check-prefix=HOST
 // RUN: %FileCheck %s --input-file=%{s:stem}_dev.ll --check-prefix=DEVICE
 // RUN: %if system-linux && cuda %{ clang %{s:stem}.ll -o %t -lcuda -Wno-override-module %}
 // RUN: %if system-linux && cuda %{ %t; test $? -eq 84 %}
 // RUN: %if system-linux && cuda %{ %t 1 2 3; test $? -eq 84 %}
 // RUN: %if system-linux && cuda %{ %t 1 2 3 4 5; test $? -eq 84 %}
-
-plugin core;
-plugin gpu;
-
-con kernel (m1: %gpu.GlobalM, m3: %gpu.SharedM, m4: %gpu.ConstM, m5: %gpu.LocalM,
-            group_id item_id: Idx 4, (), data: %gpu.GlobalPtr I32,
-            return: Cn [%gpu.GlobalM, %gpu.SharedM, %gpu.ConstM, %gpu.LocalM]) =
-    let m1 = %mem.store (m1, data, 42I32);
-    return (m1, m3, m4, m5);
-
-fun extern main (m0: %mem.M 0, argc: I32, argv: %mem.Ptr («⊤:Nat; %mem.Ptr («⊤:Nat; I8», 0)», 0))
-: [%mem.M 0, I32] =
-    let (m0, ptr1) = %mem.alloc (I32, 0) m0;
-    let (m0, ptr2) = %mem.alloc (I32, 0) m0;
-    let m0 = %mem.store (m0, ptr1, argc);
-    let m0 = %mem.store (m0, ptr2, argc);
-
-    let (m0, m1, m4) = %gpu.init m0;
-
-    ret (m0, s1_ptr) = %mem.slot (%gpu.Stream, 0) $ m0;
-    ret (m0, s2_ptr) = %mem.slot (%gpu.Stream, 0) $ m0;
-    let (m0, m1) = %gpu.stream_init (m0, m1, s1_ptr);
-    let (m0, m1) = %gpu.stream_init (m0, m1, s2_ptr);
-    let (m0, s1) = %mem.load (m0, s1_ptr);
-    let (m0, s2) = %mem.load (m0, s2_ptr);
-
-    let (m0, m1, d_ptr1) = %gpu.alloc_copy.asyn (m0, m1, ptr1, s1);
-    let (m0, m1, d_ptr2) = %gpu.alloc_copy.asyn (m0, m1, ptr2, s2);
-
-    ret (m0, m1, m4) = %gpu.launch (4, 4, s1, ff, ()) kernel d_ptr1 $ (m0, m1, m4);
-    ret (m0, m1, m4) = %gpu.launch (4, 4, s2, ff, ()) kernel d_ptr2 $ (m0, m1, m4);
-
-    let (m0, m1) = %gpu.copy_to_host.asyn (m0, m1, d_ptr1, ptr1, s1);
-    let (m0, m1) = %gpu.copy_to_host.asyn (m0, m1, d_ptr2, ptr2, s2);
-    let m1 = %gpu.free.asyn (m1, d_ptr1, s1);
-    let m1 = %gpu.free.asyn (m1, d_ptr2, s2);
-
-    let (m0, m1) = %gpu.stream_sync (m0, m1, s1);
-    let (m0, m1) = %gpu.stream_sync (m0, m1, s2);
-
-    let (m0, m1) = %gpu.stream_deinit (m0, m1, s1);
-    let (m0, m1) = %gpu.stream_deinit (m0, m1, s2);
-
-    let m0 = %gpu.deinit (m0, m1, m4);
-
-    let (m0, val1) = %mem.load (m0, ptr1);
-    let (m0, val2) = %mem.load (m0, ptr2);
-    let val = %core.wrap.add 0 (val1, val2);
-    let m0 = %mem.free (m0, ptr1);
-    let m0 = %mem.free (m0, ptr2);
-
-    return (m0, val);
 
 // HOST: define i32 @main(
 // HOST-DAG: call i32 @cuInit(i32 0)

--- a/lit/nvptx/manual_sync_kernel.mim
+++ b/lit/nvptx/manual_sync_kernel.mim
@@ -1,55 +1,11 @@
 // RUN: rm -f %{s:stem}.ll %{s:stem}_dev.ll %t
-// RUN: %mim %s -p ll_nvptx -o -
+// RUN: %mim %S/../gpu/%{s:stem}.mim -p ll_nvptx -o -
 // RUN: %FileCheck %s --input-file=%{s:stem}.ll --check-prefix=HOST
 // RUN: %FileCheck %s --input-file=%{s:stem}_dev.ll --check-prefix=DEVICE
 // RUN: %if system-linux && cuda %{ clang %{s:stem}.ll -o %t -lcuda -Wno-override-module %}
 // RUN: %if system-linux && cuda %{ %t; test $? -eq 2 %}
 // RUN: %if system-linux && cuda %{ %t 1 2 3; test $? -eq 2 %}
 // RUN: %if system-linux && cuda %{ %t 1 2 3 4 5; test $? -eq 2 %}
-
-plugin core;
-plugin gpu;
-
-con kernel (m1: %gpu.GlobalM, m3: %gpu.SharedM, m4: %gpu.ConstM, m5: %gpu.LocalM,
-            group_id item_id: Idx 4, (), data: %gpu.GlobalPtr I32,
-            return: Cn [%gpu.GlobalM, %gpu.SharedM, %gpu.ConstM, %gpu.LocalM]) =
-    ret (m3, shared_ptr) = %mem.slot («4; I32», 3) $ m3;
-    let store_loc = %mem.lea (shared_ptr, item_id);
-    let val = %core.bitcast I32 item_id;
-    let m3 = %mem.store (m3, store_loc, val);
-    let (m1, m3) = %gpu.sync_work_items (m1, m3);
-    let load_idx = %core.wrap.sub 0 (3₄, item_id);
-    let load_loc = %mem.lea (shared_ptr, load_idx);
-    let (m3, load_val) = %mem.load (m3, load_loc);
-    let cond = %core.icmp.e (item_id, 1₄);
-    (return, store)#cond (m1, m3, m4, m5)
-    where
-        lam store (m1: %gpu.GlobalM, m3: %gpu.SharedM, m4: %gpu.ConstM, m5: %gpu.LocalM) =
-            let m1 = %mem.store (m1, data, load_val);
-            return (m1, m3, m4, m5);
-    end;
-
-fun extern main (m0: %mem.M 0, argc: I32, argv: %mem.Ptr («⊤:Nat; %mem.Ptr («⊤:Nat; I8», 0)», 0))
-: [%mem.M 0, I32] =
-    let (m0, ptr) = %mem.alloc (I32, 0) m0;
-    let m0 = %mem.store (m0, ptr, argc);
-
-    let (m0, m1, m4) = %gpu.init m0;
-
-    let (m1, d_ptr) = %mem.alloc (I32, 1) m1;
-    let (m0, m1) = %gpu.copy_to_device.block (m0, m1, ptr, d_ptr);
-
-    ret (m0, m1, m4) = %gpu.launch (4, 4, %gpu.default_stream, ff, ()) kernel d_ptr $ (m0, m1, m4);
-
-    let (m0, m1) = %gpu.copy_to_host.block (m0, m1, d_ptr, ptr);
-    let m1 = %mem.free (m1, d_ptr);
-
-    let m0 = %gpu.deinit (m0, m1, m4);
-
-    let (m0, val) = %mem.load (m0, ptr);
-    let m0 = %mem.free (m0, ptr);
-
-    return (m0, val);
 
 // HOST: define i32 @main(
 // HOST-DAG: call i8* @malloc(i64 4)

--- a/lit/nvptx/scope_streams.mim
+++ b/lit/nvptx/scope_streams.mim
@@ -1,57 +1,11 @@
 // RUN: rm -f %{s:stem}.ll %{s:stem}_dev.ll %t
-// RUN: %mim %s -p ll_nvptx -o -
+// RUN: %mim %S/../gpu/%{s:stem}.mim -p ll_nvptx -o -
 // RUN: %FileCheck %s --input-file=%{s:stem}.ll --check-prefix=HOST
 // RUN: %FileCheck %s --input-file=%{s:stem}_dev.ll --check-prefix=DEVICE
 // RUN: %if system-linux && cuda %{ clang %{s:stem}.ll -o %t -lcuda -Wno-override-module %}
 // RUN: %if system-linux && cuda %{ %t; test $? -eq 84 %}
 // RUN: %if system-linux && cuda %{ %t 1 2 3; test $? -eq 84 %}
 // RUN: %if system-linux && cuda %{ %t 1 2 3 4 5; test $? -eq 84 %}
-
-plugin core;
-plugin gpu;
-
-con kernel (m1: %gpu.GlobalM, m3: %gpu.SharedM, m4: %gpu.ConstM, m5: %gpu.LocalM,
-            group_id item_id: Idx 4, (), data: %gpu.GlobalPtr I32,
-            return: Cn [%gpu.GlobalM, %gpu.SharedM, %gpu.ConstM, %gpu.LocalM]) =
-    let m1 = %mem.store (m1, data, 42I32);
-    return (m1, m3, m4, m5);
-
-fun extern main (m0: %mem.M 0, argc: I32, argv: %mem.Ptr («⊤:Nat; %mem.Ptr («⊤:Nat; I8», 0)», 0))
-: [%mem.M 0, I32] =
-    let (m0, ptr1) = %mem.alloc (I32, 0) m0;
-    let (m0, ptr2) = %mem.alloc (I32, 0) m0;
-    let m0 = %mem.store (m0, ptr1, argc);
-    let m0 = %mem.store (m0, ptr2, argc);
-
-    let (m0, m1, m4) = %gpu.init m0;
-
-    ret (m0, m1) = %gpu.with_streams (2, scope)
-    where
-        fun scope (m0: %mem.M 0, m1: %gpu.GlobalM, (s1 s2: %gpu.Stream)): [%mem.M 0, %gpu.GlobalM] =
-            let (m0, m1, d_ptr1) = %gpu.alloc_copy.asyn (m0, m1, ptr1, s1);
-            let (m0, m1, d_ptr2) = %gpu.alloc_copy.asyn (m0, m1, ptr2, s2);
-
-            ret (m0, m1, m4) = %gpu.launch (4, 4, s1, ff, ()) kernel d_ptr1 $ (m0, m1, m4);
-            ret (m0, m1, m4) = %gpu.launch (4, 4, s2, ff, ()) kernel d_ptr2 $ (m0, m1, m4);
-
-            let (m0, m1) = %gpu.copy_to_host.asyn (m0, m1, d_ptr1, ptr1, s1);
-            let (m0, m1) = %gpu.copy_to_host.asyn (m0, m1, d_ptr2, ptr2, s2);
-            let m1 = %gpu.free.asyn (m1, d_ptr1, s1);
-            let m1 = %gpu.free.asyn (m1, d_ptr2, s2);
-
-            return (m0, m1);
-    end
-    $ (m0, m1);
-
-    let m0 = %gpu.deinit (m0, m1, m4);
-
-    let (m0, val1) = %mem.load (m0, ptr1);
-    let (m0, val2) = %mem.load (m0, ptr2);
-    let val = %core.wrap.add 0 (val1, val2);
-    let m0 = %mem.free (m0, ptr1);
-    let m0 = %mem.free (m0, ptr2);
-
-    return (m0, val);
 
 // HOST: define i32 @main(
 // HOST-DAG: call i32 @cuInit(i32 0)

--- a/lit/nvptx/scope_sync_kernel.mim
+++ b/lit/nvptx/scope_sync_kernel.mim
@@ -1,71 +1,11 @@
 // RUN: rm -f %{s:stem}.ll %{s:stem}_dev.ll %t
-// RUN: %mim %s -p ll_nvptx -o -
+// RUN: %mim %S/../gpu/%{s:stem}.mim -p ll_nvptx -o -
 // RUN: %FileCheck %s --input-file=%{s:stem}.ll --check-prefix=HOST
 // RUN: %FileCheck %s --input-file=%{s:stem}_dev.ll --check-prefix=DEVICE
 // RUN: %if system-linux && cuda %{ clang %{s:stem}.ll -o %t -lcuda -Wno-override-module %}
 // RUN: %if system-linux && cuda %{ %t; test $? -eq 2 %}
 // RUN: %if system-linux && cuda %{ %t 1 2 3; test $? -eq 2 %}
 // RUN: %if system-linux && cuda %{ %t 1 2 3 4 5; test $? -eq 2 %}
-
-plugin core;
-plugin gpu;
-
-con kernel (m1: %gpu.GlobalM, m3: %gpu.SharedM, m4: %gpu.ConstM, m5: %gpu.LocalM,
-            group_id item_id: Idx 4, (), data: %gpu.GlobalPtr I32,
-            return: Cn [%gpu.GlobalM, %gpu.SharedM, %gpu.ConstM, %gpu.LocalM]) =
-    let (m1, m3) = %gpu.sync_work_items (m1, m3);
-    ret (m3, shared_ptr) = %mem.slot («4; I32», 3) $ m3;
-    let (m1, local_data) = %mem.alloc (I32, 1) m1;
-    let (m1, m3) = %gpu.synced_scope (m1, m3, scope)
-    where
-        lam scope (m1: %gpu.GlobalM, m3: %gpu.SharedM) =
-            let store_loc = %mem.lea (shared_ptr, item_id);
-            let val = %core.bitcast I32 item_id;
-            let m3 = %mem.store (m3, store_loc, val);
-            (m1, m3);
-    end;
-    let (m1, m3) = %gpu.synced_scope (m1, m3, scope)
-    where
-        lam scope (m1: %gpu.GlobalM, m3: %gpu.SharedM) =
-            let load_idx = %core.wrap.sub 0 (3₄, item_id);
-            let load_loc = %mem.lea (shared_ptr, load_idx);
-            let (m3, load_val) = %mem.load (m3, load_loc);
-            let cond = %core.icmp.e (item_id, 1₄);
-            let m1 = %mem.store (m1, local_data, load_val);
-            (m1, m3);
-    end;
-    let (m1, val) = %mem.load (m1, local_data);
-    let m1 = %mem.free (m1, local_data);
-    let cond = %core.icmp.e (item_id, 1₄);
-    (return, store)#cond (m1, m3, m4, m5)
-    where
-        lam store (m1: %gpu.GlobalM, m3: %gpu.SharedM, m4: %gpu.ConstM, m5: %gpu.LocalM) =
-            let m1 = %mem.store (m1, data, val);
-            return (m1, m3, m4, m5);
-    end;
-
-
-fun extern main (m0: %mem.M 0, argc: I32, argv: %mem.Ptr («⊤:Nat; %mem.Ptr («⊤:Nat; I8», 0)», 0))
-: [%mem.M 0, I32] =
-    let (m0, ptr) = %mem.alloc (I32, 0) m0;
-    let m0 = %mem.store (m0, ptr, argc);
-
-    let (m0, m1, m4) = %gpu.init m0;
-
-    let (m1, d_ptr) = %mem.alloc (I32, 1) m1;
-    let (m0, m1) = %gpu.copy_to_device.block (m0, m1, ptr, d_ptr);
-
-    ret (m0, m1, m4) = %gpu.launch (4, 4, %gpu.default_stream, ff, ()) kernel d_ptr $ (m0, m1, m4);
-
-    let (m0, m1) = %gpu.copy_to_host.block (m0, m1, d_ptr, ptr);
-    let m1 = %mem.free (m1, d_ptr);
-
-    let m0 = %gpu.deinit (m0, m1, m4);
-
-    let (m0, val) = %mem.load (m0, ptr);
-    let m0 = %mem.free (m0, ptr);
-
-    return (m0, val);
 
 // HOST: define i32 @main(
 // HOST-DAG: call i8* @malloc(i64 4)

--- a/lit/nvptx/simple_kernel.mim
+++ b/lit/nvptx/simple_kernel.mim
@@ -1,42 +1,11 @@
 // RUN: rm -f %{s:stem}.ll %{s:stem}_dev.ll %t
-// RUN: %mim %s -p ll_nvptx -o -
+// RUN: %mim %S/../gpu/%{s:stem}.mim -p ll_nvptx -o -
 // RUN: %FileCheck %s --input-file=%{s:stem}.ll --check-prefix=HOST
 // RUN: %FileCheck %s --input-file=%{s:stem}_dev.ll --check-prefix=DEVICE
 // RUN: %if system-linux && cuda %{ clang %{s:stem}.ll -o %t -lcuda -Wno-override-module %}
 // RUN: %if system-linux && cuda %{ %t; test $? -eq 42 %}
 // RUN: %if system-linux && cuda %{ %t 1 2 3; test $? -eq 42 %}
 // RUN: %if system-linux && cuda %{ %t 1 2 3 4 5; test $? -eq 42 %}
-
-plugin core;
-plugin gpu;
-
-con kernel (m1: %gpu.GlobalM, m3: %gpu.SharedM, m4: %gpu.ConstM, m5: %gpu.LocalM,
-            group_id item_id: Idx 4, (), data: %gpu.GlobalPtr I32,
-            return: Cn [%gpu.GlobalM, %gpu.SharedM, %gpu.ConstM, %gpu.LocalM]) =
-    let m1 = %mem.store (m1, data, 42I32);
-    return (m1, m3, m4, m5);
-
-fun extern main (m0: %mem.M 0, argc: I32, argv: %mem.Ptr («⊤:Nat; %mem.Ptr («⊤:Nat; I8», 0)», 0))
-: [%mem.M 0, I32] =
-    let (m0, ptr) = %mem.alloc (I32, 0) m0;
-    let m0 = %mem.store (m0, ptr, argc);
-
-    let (m0, m1, m4) = %gpu.init m0;
-
-    let (m1, d_ptr) = %mem.alloc (I32, 1) m1;
-    let (m0, m1) = %gpu.copy_to_device.block (m0, m1, ptr, d_ptr);
-
-    ret (m0, m1, m4) = %gpu.launch (4, 4, %gpu.default_stream, ff, ()) kernel d_ptr $ (m0, m1, m4);
-
-    let (m0, m1) = %gpu.copy_to_host.block (m0, m1, d_ptr, ptr);
-    let m1 = %mem.free (m1, d_ptr);
-
-    let m0 = %gpu.deinit (m0, m1, m4);
-
-    let (m0, val) = %mem.load (m0, ptr);
-    let m0 = %mem.free (m0, ptr);
-
-    return (m0, val);
 
 // The CUresult error handling is offloaded to the C runtime wrapper `@mim_cu_check` (rt/mim_cuda_rt.c);
 // in the default `embed` mode its definition is spliced into the host module (issue #486).

--- a/lit/nvptx/two_arg_kernel.mim
+++ b/lit/nvptx/two_arg_kernel.mim
@@ -1,53 +1,11 @@
 // RUN: rm -f %{s:stem}.ll %{s:stem}_dev.ll %t
-// RUN: %mim %s -p ll_nvptx -o -
+// RUN: %mim %S/../gpu/%{s:stem}.mim -p ll_nvptx -o -
 // RUN: %FileCheck %s --input-file=%{s:stem}.ll --check-prefix=HOST
 // RUN: %FileCheck %s --input-file=%{s:stem}_dev.ll --check-prefix=DEVICE
 // RUN: %if system-linux && cuda %{ clang %{s:stem}.ll -o %t -lcuda -Wno-override-module %}
 // RUN: %if system-linux && cuda %{ %t; test $? -eq 242 %}
 // RUN: %if system-linux && cuda %{ %t 1 2 3; test $? -eq 242 %}
 // RUN: %if system-linux && cuda %{ %t 1 2 3 4 5; test $? -eq 242 %}
-
-plugin core;
-plugin gpu;
-
-con kernel (m1: %gpu.GlobalM, m3: %gpu.SharedM, m4: %gpu.ConstM, m5: %gpu.LocalM,
-            group_id item_id: Idx 4, (), (data1: %gpu.GlobalPtr I32, data2: %gpu.GlobalPtr I32),
-            return: Cn [%gpu.GlobalM, %gpu.SharedM, %gpu.ConstM, %gpu.LocalM]) =
-    let m1 = %mem.store (m1, data1, 42I32);
-    let m1 = %mem.store (m1, data2, 200I32);
-    return (m1, m3, m4, m5);
-
-fun extern main (m0: %mem.M 0, argc: I32, argv: %mem.Ptr («⊤:Nat; %mem.Ptr («⊤:Nat; I8», 0)», 0))
-: [%mem.M 0, I32] =
-    let (m0, ptr1) = %mem.alloc (I32, 0) m0;
-    let (m0, ptr2) = %mem.alloc (I32, 0) m0;
-    let m0 = %mem.store (m0, ptr1, argc);
-    let m0 = %mem.store (m0, ptr2, argc);
-
-    let (m0, m1, m4) = %gpu.init m0;
-
-    let (m1, d_ptr1) = %mem.alloc (I32, 1) m1;
-    let (m1, d_ptr2) = %mem.alloc (I32, 1) m1;
-    let (m0, m1) = %gpu.copy_to_device.block (m0, m1, ptr1, d_ptr1);
-    let (m0, m1) = %gpu.copy_to_device.block (m0, m1, ptr2, d_ptr2);
-
-    ret (m0, m1, m4) = %gpu.launch (4, 4, %gpu.default_stream, ff, ())
-        kernel (d_ptr1, d_ptr2) $ (m0, m1, m4);
-
-    let (m0, m1) = %gpu.copy_to_host.block (m0, m1, d_ptr1, ptr1);
-    let (m0, m1) = %gpu.copy_to_host.block (m0, m1, d_ptr2, ptr2);
-    let m1 = %mem.free (m1, d_ptr1);
-    let m1 = %mem.free (m1, d_ptr2);
-
-    let m0 = %gpu.deinit (m0, m1, m4);
-
-    let (m0, val1) = %mem.load (m0, ptr1);
-    let (m0, val2) = %mem.load (m0, ptr2);
-    let m0 = %mem.free (m0, ptr1);
-    let m0 = %mem.free (m0, ptr2);
-
-    let val = %core.wrap.add 0 (val1, val2);
-    return (m0, val);
 
 // HOST: define i32 @main(
 // HOST-DAG: call i32 @cuInit(i32 0)


### PR DESCRIPTION
The source code in the current nvptx tests is just copied 100% from gpu tests.
This PR fixes this code duplication. The nvptx plugin's tests now compile the gpu test and check/run the output. 