### PR TITLE
[tensor] Use mutable continutations to get fresh (distinct) memory to prevent buffer aliasing in tensor operations.

### DIFF
--- a/include/mim/plug/mem/phase/add_mem.h
+++ b/include/mim/plug/mem/phase/add_mem.h
@@ -8,7 +8,8 @@ namespace mim::plug::mem::phase {
 /// mem-extends continuations and rewires every memory operand to the *current* memory at that program point.
 /// It's primarily to be used as preparation for other phases that rely on all continuations having a mem.
 /// It also splices the `⊥ : %mem.M 0` memory placeholders of freshly emitted memory operations into the
-/// global memory chain (see mim::plug::tensor::phase::LowerToMem, which runs this phase embedded).
+/// global memory chain and resolves `%mem.fresh (a, k)` requests by jumping to `k` with the current memory
+/// (see mim::plug::tensor::phase::LowerToMem, which emits both and schedules this phase right behind itself).
 ///
 /// The rewrite is a plain RWPhase.
 /// Memory is a linear resource, so at any program point exactly one memory token is live - the *current* memory.

--- a/include/mim/plug/tensor/phase/lower_to_mem.h
+++ b/include/mim/plug/tensor/phase/lower_to_mem.h
@@ -101,9 +101,9 @@ private:
     const Def* fresh_mem();
 
     /// Chains the LowerToMem::pending_ continuations in front of @p new_lam's freshly rewritten body:
-    /// `new_lam ↦ k₁ (⊥: %mem.M 0)`, `k₁ ↦ k₂ (⊥: %mem.M 0)`, …, and the last one carries the body.
-    /// AddMem rewrites each jump's `⊥` argument to the scheduler-placed current memory, and the `tt` filter
-    /// beta-reduces the continuations away again as soon as that substitution happens.
+    /// `new_lam ↦ %mem.fresh (0, k₁)`, `k₁ ↦ %mem.fresh (0, k₂)`, …, and the last one carries the body.
+    /// AddMem resolves each request by jumping to the continuation with the scheduler-placed current memory,
+    /// and the `tt` filter beta-reduces the continuations away again as soon as that happens.
     void wrap_fresh_mem(Lam* new_lam);
 
     /// The fresh-memory continuations minted while the current lam's body is being rewritten.

--- a/include/mim/plug/tensor/phase/lower_to_mem.h
+++ b/include/mim/plug/tensor/phase/lower_to_mem.h
@@ -14,7 +14,8 @@ namespace mim::plug::tensor::phase {
 ///
 /// This phase is *conversion-only*: it rewrites types and operations but does not thread the `%mem.M`
 /// memory monad itself. Emitted buffer operations consume a `⊥: %mem.M 0` placeholder (or a short local
-/// chain), and the SSA value dependencies keep them anchored and ordered. The `%mem.add_mem` phase
+/// chain rooted in a LowerToMem::fresh_mem continuation's var), and the SSA value dependencies keep them
+/// anchored and ordered. The `%mem.add_mem` phase
 /// (mim::plug::mem::phase::AddMem), scheduled right after this one in the pipeline, then mem-extends all
 /// continuations and rewires every memory operand to the scheduler-placed current memory — handling returns,
 /// error continuations, join points, branch arms, and interleaving with a caller's own memory operations
@@ -30,8 +31,13 @@ public:
 
 private:
     void start() override;
+    const Def* rewrite(const Def*) override;
     const Def* rewrite_mut_Lam(Lam*) override;
     const Def* rewrite_imm_App(const App*) override;
+
+    /// The conversion part of LowerToMem::rewrite_mut_Lam (boundary conversion, local continuations, or the
+    /// generic RWPhase rewrite); the override itself only scopes the fresh-memory bookkeeping around it.
+    const Def* conv_mut_Lam(Lam*);
 
     const Def* lower_get(const App*);
     const Def* lower_set(const App*);
@@ -77,7 +83,34 @@ private:
 
     /// A `⊥: %mem.M 0` placeholder consumed by emitted buffer operations; AddMem replaces it with the
     /// scheduler-placed current memory.
+    /// Shared by every op whose result is a pure function of its value operands, so that genuinely equal
+    /// ops still collapse into one (e.g. a weight literal materialized at many sites).
     const Def* bot_mem();
+
+    /// A *fresh* `%mem.M 0` for one emitted buffer/matrix operation: the var of a newly minted continuation
+    /// `con fresh_mem(mem: %mem.M 0)` that receives its memory once LowerToMem::wrap_fresh_mem has chained it
+    /// in front of the enclosing lam's body.
+    /// Required by every op that allocates a buffer it then writes into, for two independent reasons:
+    /// 1. Immutable Def%s are hash-consed, so two `%buffer.alloc`s agreeing on `(r, s, T)` and sharing one
+    ///    placeholder collapse into a single allocation - two distinct tensors would alias one buffer.
+    /// 2. AddMem is a memoizing Rewriter, so two operations sharing one argument tuple
+    ///    `(⊥: %mem.M 0, …)` - which happens whenever they differ only in their curried callee - are threaded
+    ///    from the *same* current memory, and the resulting parallel mem chains collapse in `%cps.conv`.
+    /// Mutables are never hash-consed, so the continuations' vars are distinct by construction - no
+    /// distinguishing tag required.
+    const Def* fresh_mem();
+
+    /// Chains the LowerToMem::pending_ continuations in front of @p new_lam's freshly rewritten body:
+    /// `new_lam ↦ k₁ (⊥: %mem.M 0)`, `k₁ ↦ k₂ (⊥: %mem.M 0)`, …, and the last one carries the body.
+    /// AddMem rewrites each jump's `⊥` argument to the scheduler-placed current memory, and the `tt` filter
+    /// beta-reduces the continuations away again as soon as that substitution happens.
+    void wrap_fresh_mem(Lam* new_lam);
+
+    /// The fresh-memory continuations minted while the current lam's body is being rewritten.
+    Vector<Lam*> pending_;
+
+    /// Per-lam memo for the ops that consume a fresh memory (see LowerToMem::rewrite).
+    DefMap<const Def*> fresh_memo_;
 
     /// A function is bufferized iff it is external, set, and mentions a tensor type in its domain.
     bool is_tensor_fn(Lam*) const;

--- a/lit/buffer/two_same_shape_binary.mim
+++ b/lit/buffer/two_same_shape_binary.mim
@@ -22,8 +22,8 @@ plugin core;
 plugin tensor;
 plugin mem;
 
-lam i32_add (a: I32, b: I32): I32 = %core.wrap.add 0 (a, b);
-lam i32_sub (a: I32, b: I32): I32 = %core.wrap.sub 0 (a, b);
+lam i32_add (a b: I32): I32 = %core.wrap.add 0 (a, b);
+lam i32_sub (a b: I32): I32 = %core.wrap.sub 0 (a, b);
 
 fun extern kernel (x y: «3, 4; I32», i j: [Idx 6, Idx 4]): I32 =
     let a  = %tensor.binary @(I32, I32, I32) i32_add @(2, (3, 4)) (x, y);

--- a/lit/buffer/two_same_shape_binary.mim
+++ b/lit/buffer/two_same_shape_binary.mim
@@ -1,0 +1,46 @@
+// RUN: %mim -p opt %s -o - > %t.out
+// RUN: %FileCheck %s < %t.out
+// RUN: %FileCheck %s --check-prefix=GONE < %t.out
+
+// Regression: two same-shaped elementwise results that are BOTH live must get DISTINCT buffers.
+// This is the *delayed* form of the collapse, and the one that silently corrupted multi-output graphs.
+// Both `%tensor.binary`s lower to `%matrix.map_reduce_aff` and differ only in their *curried callee* (the
+// combiner), so their final argument tuple `(⊥: %mem.M 0, (x, y))` was one shared Def. AddMem is a
+// memoizing Rewriter, so the second op got threaded from the *first's* memory; `%cps.conv` then
+// substituted both accumulator functions' mem vars with the same memory and the two `%mem.alloc`s - by
+// then identical - were hash-consed into one (see LowerToMem::fresh_mem).
+//
+// The `%tensor.concat` is what forces `a` and `b` to be materialized as two separate buffers: read
+// directly, an elementwise result fuses into its consumer and never needs one. This mirrors how the bug
+// actually surfaced - packing several same-shaped results of one graph into a single output.
+// The dynamic index parameters keep both `get`s from being resolved statically.
+// ga = c[i] = a[0][0] = x+y = 10+5 = 15,  gb = c[j] = b[1][2] = x-y = 30-3 = 27  =>  returns 42.
+// Aliased, both halves of `c` come from whichever loop wrote the shared buffer last: with the `add` loop
+// last, gb reads x+y = 33 instead of 27 -> 48 (the other order reads x-y = 5 for ga -> 32).
+// two_same_shape_binary_run.mim compiles this to an executable and asserts the exit code.
+plugin core;
+plugin tensor;
+plugin mem;
+
+lam i32_add (a: I32, b: I32): I32 = %core.wrap.add 0 (a, b);
+lam i32_sub (a: I32, b: I32): I32 = %core.wrap.sub 0 (a, b);
+
+fun extern kernel (x y: «3, 4; I32», i j: [Idx 6, Idx 4]): I32 =
+    let a  = %tensor.binary @(I32, I32, I32) i32_add @(2, (3, 4)) (x, y);
+    let b  = %tensor.binary @(I32, I32, I32) i32_sub @(2, (3, 4)) (x, y);
+    let c  = %tensor.concat @(I32, 2, 2) 0₂ @((3, 4), (3, 4)) (a, b);
+    let ga = %tensor.get @(I32, 2, (6, 4)) (c, i);
+    let gb = %tensor.get @(I32, 2, (6, 4)) (c, j);
+    return (%core.wrap.add 0 (ga, gb));
+
+con extern main (mem: %mem.M 0, argc: I32, argv: %mem.Ptr (%mem.Ptr (I8, 0), 0), return: Cn [%mem.M 0, I32]) =
+    let x = ((10I32, 1I32, 2I32, 3I32), (4I32, 5I32, 30I32, 7I32), (8I32, 9I32, 10I32, 11I32));
+    let y = (( 5I32, 1I32, 1I32, 1I32), (1I32, 1I32,  3I32, 1I32), (1I32, 1I32,  1I32,  1I32));
+    con done (v: I32) = return (mem, v);
+    kernel ((x, y, (0₆, 0₄), (4₆, 2₄)), done);
+
+// CHECK-DAG: %mem.load
+// CHECK-DAG: %mem.store
+// GONE-NOT: %tensor.
+// GONE-NOT: %buffer.
+// GONE-NOT: %matrix.

--- a/lit/buffer/two_same_shape_binary_run.mim
+++ b/lit/buffer/two_same_shape_binary_run.mim
@@ -1,0 +1,4 @@
+// RUN: rm -f two_same_shape_binary.ll
+// RUN: FILE=%s;%mim -p opt -p clos -o - ${FILE%_run.mim}.mim -p ll
+// RUN: clang two_same_shape_binary.ll -o %t -Wno-override-module
+// RUN: %t ; test $? -eq 42

--- a/lit/buffer/two_same_shape_set.mim
+++ b/lit/buffer/two_same_shape_set.mim
@@ -1,0 +1,37 @@
+// RUN: %mim -p opt %s -o - > %t.out
+// RUN: %FileCheck %s < %t.out
+// RUN: %FileCheck %s --check-prefix=GONE < %t.out
+
+// Regression: two `%tensor.set`s that agree on shape AND element type must get DISTINCT buffers.
+// `%buffer.alloc`'s identity is `(r, s, T, mem)` and it has no normalizer, so when both allocations shared
+// one `⊥: %mem.M 0` placeholder they were hash-consed into a single allocation: `a` and `b` aliased one
+// buffer, and `b`'s copy-then-write clobbered what `a` had written (see LowerToMem::fresh_mem).
+//
+// Each result is read at the index the *other* one wrote, for two reasons: a `get` at the very index a
+// `set` just wrote folds to the stored value (so the tensor would never reach a buffer at all), and the
+// cross-read is what makes the aliasing observable. The dynamic index parameters keep `i`/`j` opaque, so
+// neither `get` can be resolved statically.
+// ga = a[j] = t[j] = 30, gb = b[i] = t[i] = 12  =>  kernel returns 42.
+// Aliased, `b`'s copy of `t` overwrites `a`'s write, so ga reads b's 40 instead -> 52.
+// two_same_shape_set_run.mim compiles this to an executable and asserts the exit code.
+plugin core;
+plugin tensor;
+plugin mem;
+
+fun extern kernel (t: «3, 4; I32», i j: [Idx 3, Idx 4]): I32 =
+    let a  = %tensor.set @(I32, 2, (3, 4)) (t, i, 2I32);
+    let b  = %tensor.set @(I32, 2, (3, 4)) (t, j, 40I32);
+    let ga = %tensor.get @(I32, 2, (3, 4)) (a, j);
+    let gb = %tensor.get @(I32, 2, (3, 4)) (b, i);
+    return (%core.wrap.add 0 (ga, gb));
+
+con extern main (mem: %mem.M 0, argc: I32, argv: %mem.Ptr (%mem.Ptr (I8, 0), 0), return: Cn [%mem.M 0, I32]) =
+    let t = ((12I32, 2I32, 3I32, 4I32), (5I32, 6I32, 30I32, 8I32), (9I32, 10I32, 11I32, 12I32));
+    con done (v: I32) = return (mem, v);
+    kernel ((t, (0₃, 0₄), (1₃, 2₄)), done);
+
+// CHECK-DAG: %mem.load
+// CHECK-DAG: %mem.store
+// GONE-NOT: %tensor.
+// GONE-NOT: %buffer.
+// GONE-NOT: %matrix.

--- a/lit/buffer/two_same_shape_set_run.mim
+++ b/lit/buffer/two_same_shape_set_run.mim
@@ -1,0 +1,4 @@
+// RUN: rm -f two_same_shape_set.ll
+// RUN: FILE=%s;%mim -p opt -p clos -o - ${FILE%_run.mim}.mim -p ll
+// RUN: clang two_same_shape_set.ll -o %t -Wno-override-module
+// RUN: %t ; test $? -eq 42

--- a/src/mim/plug/mem/mem.mim
+++ b/src/mim/plug/mem/mem.mim
@@ -43,6 +43,15 @@ axm %mem.store: {T: *, a: Nat} as Ta → [%mem.M a, %mem.Ptr Ta, T] → %mem.M a
 /// Creates a new dummy `%%mem.M a`-typed value in order to acknowledge the fact that some unspecified side-effect happened.
 axm %mem.remem: {a: Nat} → %mem.M a → %mem.M a, normalize_remem;
 ///
+/// ### %%mem.fresh
+///
+/// Passes a *fresh* `%%mem.M a` for address space `a` to its return continuation: `ret mem = %%mem.fresh $ 0`.
+/// Conversion-only phases (e.g. `%%tensor.lower_to_mem`) emit memory operations before memory has been threaded.
+/// Each call site's return continuation is a distinct mutable, so the received memories are distinct by construction -
+/// hash-consing cannot collapse two otherwise identical memory operations into one.
+/// `%%mem.add_mem` resolves each call by jumping to the continuation with the memory that is current at that point.
+axm %mem.fresh: Fn [a: Nat] → %mem.M a;
+///
 /// ### %%mem.alloc
 ///
 /// Allocates memory of type `T` in address space `a`.

--- a/src/mim/plug/mem/phase/add_mem.cpp
+++ b/src/mim/plug/mem/phase/add_mem.cpp
@@ -19,7 +19,9 @@ void AddMem::start() {
     while (!queue.empty()) {
         auto def = queue.pop();
 
-        if (auto app = def->isa<App>(); app && app->axm())
+        // `%mem.fresh`'s return continuation is *not* pinned: it receives the current memory (see
+        // rewrite_imm_App below), so its body must be mem-threaded like any other continuation.
+        if (auto app = def->isa<App>(); app && app->axm() && !Axm::isa<mem::fresh>(app))
             for (auto arg : app->arg()->projs())
                 if (auto lam = arg->isa_mut<Lam>()) pinned.push(lam);
 
@@ -116,6 +118,13 @@ const Def* AddMem::rewrite_imm_App(const App* app) {
     if (is_bootstrapping() || preserving_ || !curr_mem_) return Rewriter::rewrite_imm_App(app);
 
     auto& w = new_world();
+
+    // `%mem.fresh (a, k)`: the request for a fresh memory resolves to the memory that is current right
+    // here - jump to `k` with it. (Like the rest of this phase, only address space 0 is threaded.)
+    if (Axm::isa<mem::fresh>(app)) {
+        auto [_, k] = app->args<2>();
+        return w.app(rewrite(k), curr_mem_);
+    }
     // Rewrite the argument before the callee (as the base Rewriter does). This threads the current memory
     // through the argument's memory effects first; and because operands are rewritten before their users, a
     // shared memory operation is anchored in the scope that consumes its result mem (its own scope) rather

--- a/src/mim/plug/tensor/phase/lower_to_mem.cpp
+++ b/src/mim/plug/tensor/phase/lower_to_mem.cpp
@@ -34,11 +34,14 @@ const Def* splat_scalar(const Def* d) {
     return (d->is_closed() && !d->type()->isa<Arr>()) ? d : nullptr;
 }
 
-/// Is `app` one of the tensor ops this phase bufferizes?
-bool is_tensor_op(const App* app) {
-    return Axm::isa<tensor::get>(app) || Axm::isa<tensor::set>(app) || Axm::isa<tensor::broadcast>(app)
-        || Axm::isa<tensor::map_reduce>(app) || Axm::isa<tensor::pad>(app) || Axm::isa<tensor::concat>(app);
+/// Is `app` a tensor op whose lowering consumes a LowerToMem::fresh_mem?
+bool wants_fresh_mem(const App* app) {
+    return Axm::isa<tensor::set>(app) || Axm::isa<tensor::broadcast>(app) || Axm::isa<tensor::map_reduce>(app)
+        || Axm::isa<tensor::pad>(app) || Axm::isa<tensor::concat>(app);
 }
+
+/// Is `app` one of the tensor ops this phase bufferizes?
+bool is_tensor_op(const App* app) { return Axm::isa<tensor::get>(app) || wants_fresh_mem(app); }
 
 } // namespace
 
@@ -188,6 +191,8 @@ void LowerToMem::start() {
     // Nothing tensor-related in the program: skip the whole-world rebuild entirely.
     if (tensor_fns_.empty() && !ops_seen_) return;
     RWPhase::start();
+    // Every fresh-memory continuation must have found an enclosing lam to be chained into.
+    assert(pending_.empty());
 }
 
 const Def* LowerToMem::buf_of(const Def* arr_ty) {
@@ -213,6 +218,41 @@ const Def* LowerToMem::fold_index(const Def* shape, const Def* idx) {
 const Def* LowerToMem::bot_mem() {
     auto& w = new_world();
     return w.bot(w.call<mem::M>(0));
+}
+
+const Def* LowerToMem::fresh_mem() {
+    auto k = mem::mut_con(new_world())->set("fresh_mem");
+    pending_.push_back(k);
+    return k->var();
+}
+
+void LowerToMem::wrap_fresh_mem(Lam* new_lam) {
+    auto& w     = new_world();
+    auto filter = new_lam->filter();
+    auto body   = new_lam->body();
+    new_lam->unset();
+    // The last-minted continuation carries the original body; the lam ends up jumping to the first one.
+    for (auto k : pending_ | std::views::reverse) {
+        auto jump = w.app(k, bot_mem()); // k is still unset here, so the jump cannot beta-reduce yet
+        k->set(true, body);              // filter `tt`: k vanishes as soon as AddMem substitutes the real memory
+        body = jump;
+    }
+    new_lam->set(filter, body);
+}
+
+const Def* LowerToMem::rewrite(const Def* old_def) {
+    // An op lowering that consumes a fresh memory references its receiving continuation's var (see
+    // fresh_mem). The global memo would share such a lowering with every other function that mentions the
+    // same (closed) old op - where that var would dangle - so these ops are memoized per enclosing lam.
+    if (!is_bootstrapping()) {
+        if (auto app = old_def->isa<App>(); app && wants_fresh_mem(app)) {
+            if (auto i = fresh_memo_.find(app); i != fresh_memo_.end()) return i->second;
+            auto new_def = rewrite_imm_App(app);
+            fresh_memo_.emplace(app, new_def);
+            return new_def;
+        }
+    }
+    return RWPhase::rewrite(old_def);
 }
 
 bool LowerToMem::mentions_tensor(const Def* t) const {
@@ -245,6 +285,19 @@ const Def* LowerToMem::conv_boundary(const Def* t) {
 const Def* LowerToMem::rewrite_mut_Lam(Lam* lam) {
     if (is_bootstrapping()) return RWPhase::rewrite_mut_Lam(lam);
 
+    // Scope the fresh-memory bookkeeping: ops lowered while this body is rewritten mint their receiving
+    // continuations into pending_, which are chained in front of the finished body. Nested lams anchor
+    // their own requests (and their own per-lam op memo).
+    auto pending = std::exchange(pending_, {});
+    auto memo    = std::exchange(fresh_memo_, {});
+    auto new_def = conv_mut_Lam(lam);
+    if (!pending_.empty()) wrap_fresh_mem(new_def->as_mut<Lam>());
+    pending_    = std::move(pending);
+    fresh_memo_ = std::move(memo);
+    return new_def;
+}
+
+const Def* LowerToMem::conv_mut_Lam(Lam* lam) {
     // A bufferized function: convert tensor-typed parameters to `%buffer.Buf`, including inside grouped
     // sigma parameters and continuation domains. No memory is introduced here — AddMem does that.
     if (is_tensor_fn(lam)) {
@@ -391,13 +444,13 @@ const Def* LowerToMem::lower_set(const App* app) {
     auto fidx         = fold_index(s, index);
 
     if (reuse_in_place(app)) {
-        auto [m, buf2] = buffer::op_write(br, bs, bT, bot_mem(), arr, fidx, x)->projs<2>();
+        auto [m, buf2] = buffer::op_write(br, bs, bT, fresh_mem(), arr, fidx, x)->projs<2>();
         return buf2;
     }
 
     // AlwaysAllocate policy: allocate a fresh buffer, copy the source in, then write the element.
-    // This local chain is properly threaded; AddMem splices its `⊥` root into the global chain.
-    auto [m1, q]   = buffer::op_alloc(br, bs, bT, bot_mem())->projs<2>();
+    // This local chain is properly threaded; AddMem splices its placeholder root into the global chain.
+    auto [m1, q]   = buffer::op_alloc(br, bs, bT, fresh_mem())->projs<2>();
     auto m2        = buffer::op_copy(br, bs, bT, m1, q, arr);
     auto [m3, out] = buffer::op_write(br, bs, bT, m2, q, fidx, x)->projs<2>();
     return out;
@@ -433,7 +486,7 @@ const Def* LowerToMem::lower_broadcast(const App* app) {
     auto op       = w.annex<matrix::broadcast>();
     op            = w.app(op, w.tuple({T, bri, bsi, bro, bso, r}));
     op            = w.app(op, w.tuple({s_in, s_out}));
-    auto [m, out] = w.app(op, w.tuple({bot_mem(), input}))->projs<2>();
+    auto [m, out] = w.app(op, w.tuple({fresh_mem(), input}))->projs<2>();
     return out;
 }
 
@@ -485,7 +538,7 @@ const Def* LowerToMem::lower_map_reduce(const App* app) {
     op            = w.app(op, w.tuple({memcomb, init}));
     op            = w.app(op, acc_out);
     op            = w.app(op, accs);
-    auto [m, out] = w.app(op, w.tuple({bot_mem(), inputs}))->projs<2>();
+    auto [m, out] = w.app(op, w.tuple({fresh_mem(), inputs}))->projs<2>();
     return out;
 }
 
@@ -521,7 +574,7 @@ const Def* LowerToMem::lower_pad(const App* app) {
     auto op       = w.annex<matrix::pad>();
     op            = w.app(op, w.tuple({T, r}));
     op            = w.app(op, w.tuple({s_in, s_out, mode, lo, hi}));
-    auto [m, out] = w.app(op, w.tuple({bot_mem(), input, value}))->projs<2>();
+    auto [m, out] = w.app(op, w.tuple({fresh_mem(), input, value}))->projs<2>();
     return out;
 }
 
@@ -573,7 +626,7 @@ const Def* LowerToMem::lower_concat(const App* app) {
     op            = w.app(op, ax);
     op            = w.app(op, Sis);
     op            = w.app(op, s_out);
-    auto [m, out] = w.app(op, w.tuple({bot_mem(), inputs}))->projs<2>();
+    auto [m, out] = w.app(op, w.tuple({fresh_mem(), inputs}))->projs<2>();
     return out;
 }
 

--- a/src/mim/plug/tensor/phase/lower_to_mem.cpp
+++ b/src/mim/plug/tensor/phase/lower_to_mem.cpp
@@ -1,5 +1,7 @@
 #include "mim/plug/tensor/phase/lower_to_mem.h"
 
+#include <mim/util/util.h>
+
 #include "mim/axm.h"
 #include "mim/def.h"
 #include "mim/lam.h"
@@ -231,11 +233,10 @@ void LowerToMem::wrap_fresh_mem(Lam* new_lam) {
     auto filter = new_lam->filter();
     auto body   = new_lam->body();
     new_lam->unset();
-    // The last-minted continuation carries the original body; the lam ends up jumping to the first one.
+    // The last-minted continuation carries the original body; the lam ends up requesting the first memory.
     for (auto k : pending_ | std::views::reverse) {
-        auto jump = w.app(k, bot_mem()); // k is still unset here, so the jump cannot beta-reduce yet
-        k->set(true, body);              // filter `tt`: k vanishes as soon as AddMem substitutes the real memory
-        body = jump;
+        k->set(true, body); // filter `tt`: k vanishes as soon as AddMem substitutes the real memory
+        body = w.app(w.annex<mem::fresh>(), w.tuple({w.lit_nat_0(), k}));
     }
     new_lam->set(filter, body);
 }
@@ -288,12 +289,10 @@ const Def* LowerToMem::rewrite_mut_Lam(Lam* lam) {
     // Scope the fresh-memory bookkeeping: ops lowered while this body is rewritten mint their receiving
     // continuations into pending_, which are chained in front of the finished body. Nested lams anchor
     // their own requests (and their own per-lam op memo).
-    auto pending = std::exchange(pending_, {});
-    auto memo    = std::exchange(fresh_memo_, {});
+    auto p       = Restore(pending_, {});
+    auto m       = Restore(fresh_memo_, {});
     auto new_def = conv_mut_Lam(lam);
     if (!pending_.empty()) wrap_fresh_mem(new_def->as_mut<Lam>());
-    pending_    = std::move(pending);
-    fresh_memo_ = std::move(memo);
     return new_def;
 }
 


### PR DESCRIPTION
Just using `bot:%mem.M 0` actually means that certain operations would be hash-consed instead of generating a fresh new allocation of a buffer. There are still a few places where allowing hash-consing might actually be okay (splat_buffer, e.g.).
