### PR TITLE
fix(ll): distinguish vec.zip inputs count and lane count

### DIFF
--- a/src/mim/plug/ll/ll.cpp
+++ b/src/mim/plug/ll/ll.cpp
@@ -984,7 +984,8 @@ std::string Emitter::emit_bb_impl(BB& bb, const Def* def) {
         return bb.assign(name, "tail call {} @{}({} {})", t, f, t, a);
     } else if (auto zip = Axm::isa<vec::zip>(def)) {
         auto ni_n   = zip->decurry()->decurry()->decurry()->arg();
-        auto nat_ni = Lit::expect(ni_n->proj(2, 0), "a %vec.zip lane count");
+        auto nat_ni = Lit::expect(ni_n->proj(2, 0), "a %vec.zip inputs count");
+        auto nat_n = Lit::expect(ni_n->proj(2, 1), "a %vec.zip lane count");
         auto f      = zip->decurry()->arg();
         auto inputs = zip->arg();
         auto t_in   = convert(inputs->proj(nat_ni, 0)->type());
@@ -1002,7 +1003,7 @@ std::string Emitter::emit_bb_impl(BB& bb, const Def* def) {
                     auto v2     = emit(inputs->proj(nat_ni, 1));
                     auto ugt    = bb.assign(name + ".ugt", "icmp ugt {} {}, {}", t_in, v2, v1);
                     auto raw    = bb.assign(name + ".raw", "sub {} {}, {}", t_in, v1, v2);
-                    return prev = bb.assign(name, "select <{} x i1> {}, {} zeroinitializer, {} {}", nat_ni, ugt, t_out,
+                    return prev = bb.assign(name, "select <{} x i1> {}, {} zeroinitializer, {} {}", nat_n, ugt, t_out,
                                             t_out, raw);
                 }
                 case core::nat::mul: op = "mul nuw nsw"; break;


### PR DESCRIPTION
## Description

`select` mask for SIMD operations should match the lane count instead of inputs count.